### PR TITLE
fix: unfreeze players after manual stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.1 - Critical Hotfix
+- **Fix:** Players are no longer permanently frozen after a game is manually stopped with `/hb stop`. The game state is now correctly reset.
+
 ## 1.5.0 - Lobby Adventure & Zone Manager
 - **Feat:** Joueurs en GameMode.ADVENTURE au lobby pour une protection totale.
 - **Feat:** Commande `/hb protect list` avec GUI pour gérer les zones protégées.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Java 21](https://img.shields.io/badge/Java-21-red?logo=openjdk)](https://openjdk.org/)
 [![Spigot/Paper 1.21](https://img.shields.io/badge/Spigot/Paper-1.21-yellow?logo=spigotmc)](https://www.spigotmc.org/)
 [![Gradle](https://img.shields.io/badge/Gradle-build-blue?logo=gradle)](https://gradle.org/)
-[![Version](https://img.shields.io/badge/Version-1.5.0-informational)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-1.5.1-informational)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
 Site : [heneria.com](https://heneria.com)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.5.0"
+version = "1.5.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/example/hikabrain/GameManager.java
+++ b/src/main/java/com/example/hikabrain/GameManager.java
@@ -298,6 +298,7 @@ public class GameManager {
     }
 
     private void endCleanup() {
+        setFrozen(false); // ensure players can move after game ends
         flushPlacedBlocks();
         if (arena != null) {
             for (Team t : Team.values()) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.5.0
+version: 1.5.1
 api-version: "1.21"
 description: Hikabrain minigame for Spigot/Paper 1.21
 


### PR DESCRIPTION
## Summary
- prevent players from staying frozen by clearing frozen state during game cleanup
- bump version to 1.5.1 and document hotfix

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_689dd6f92c0883249f368230c826f2d1