### PR TITLE
feat: add protection zone management gui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.3 - Protection GUI on /hb list
+- **Feat:** Implemented Protection Zone Management GUI on `/hb list`.
+
 ## 1.5.2 - Protection List Menu
 - **Feat:** Implémentation de `/hb protect list` avec menu de gestion des zones.
 - **Fix:** Résolution du conflit entre `/hb list` et `/hb protect list`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Java 21](https://img.shields.io/badge/Java-21-red?logo=openjdk)](https://openjdk.org/)
 [![Spigot/Paper 1.21](https://img.shields.io/badge/Spigot/Paper-1.21-yellow?logo=spigotmc)](https://www.spigotmc.org/)
 [![Gradle](https://img.shields.io/badge/Gradle-build-blue?logo=gradle)](https://gradle.org/)
-[![Version](https://img.shields.io/badge/Version-1.5.2-informational)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-1.5.3-informational)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
 Site : [heneria.com](https://heneria.com)
@@ -103,7 +103,7 @@ broke:
 /hb setbroke
 /hb setlobby
 /hb protect
-/hb protect list
+/hb list
 /hb confirm <nom>
 /hb start
 /hb stop
@@ -112,7 +112,7 @@ broke:
 /hb admin [on|off|toggle]
 ```
 
-La commande `/hb protect list` ouvre une interface graphique pour gérer les zones protégées.
+La commande `/hb list` ouvre une interface graphique pour gérer les zones protégées.
 
 Permissions :
 - `hikabrain.admin` — commandes d’admin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.5.2"
+version = "1.5.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/example/hikabrain/GameListener.java
+++ b/src/main/java/com/example/hikabrain/GameListener.java
@@ -430,7 +430,7 @@ public class GameListener implements Listener {
                     tool.setItemMeta(meta);
                 }
                 p.getInventory().addItem(tool);
-                p.sendMessage(ChatColor.GREEN + "Sélectionnez la nouvelle zone puis /hb confirm " + name);
+                p.sendMessage(ChatColor.GREEN + "Mode protection pour la zone '" + name + "'. Sélectionnez la nouvelle zone puis /hb confirm " + name);
                 p.closeInventory();
             }
             case "delete" -> {

--- a/src/main/java/com/example/hikabrain/commands/HBCommand.java
+++ b/src/main/java/com/example/hikabrain/commands/HBCommand.java
@@ -44,6 +44,7 @@ public class HBCommand implements CommandExecutor {
         line(s, "/hb setspawn <red|blue>", "Définir le point d'apparition d'une équipe.", "hikabrain.admin");
         line(s, "/hb setlobby", "Définir le point de spawn du lobby.", "hikabrain.admin");
         line(s, "/hb protect", "Mode sélection de zones protégées.", "hikabrain.admin");
+        line(s, "/hb list", "Gérer les zones protégées.", "hikabrain.admin");
         line(s, "/hb confirm <nom>", "Enregistrer une zone protégée.", "hikabrain.admin");
         line(s, "/hb start / stop", "Démarrer ou arrêter la partie.", "hikabrain.admin");
         line(s, "/hb ui reload", "Recharger la configuration de l'interface.", "hikabrain.admin");
@@ -119,9 +120,9 @@ public class HBCommand implements CommandExecutor {
                 return true;
             }
             case "list": {
-                List<String> list = game.listArenas();
-                if (list.isEmpty()) sender.sendMessage(ChatColor.GRAY + "Aucune arène sauvegardée.");
-                else sender.sendMessage(ChatColor.YELLOW + "Arènes: " + String.join(", ", list));
+                if (needAdmin(sender)) return true;
+                if (!(sender instanceof Player)) { sender.sendMessage("In-game only"); return true; }
+                HikaBrainPlugin.get().protection().openListMenu((Player) sender);
                 return true;
             }
             case "setbed": {

--- a/src/main/java/com/example/hikabrain/protection/ProtectionService.java
+++ b/src/main/java/com/example/hikabrain/protection/ProtectionService.java
@@ -99,30 +99,41 @@ public class ProtectionService {
 
     /** Open GUI listing protected regions for management. */
     public void openListMenu(Player player) {
-        Inventory inv = Bukkit.createInventory(holder, 54, ChatColor.AQUA + "Zones protégées");
+        loadRegions();
+        Inventory inv = Bukkit.createInventory(holder, 54, ChatColor.DARK_GRAY + "Gestion des Zones Protégées");
+
+        ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta fm = filler.getItemMeta();
+        if (fm != null) {
+            fm.setDisplayName(" ");
+            filler.setItemMeta(fm);
+        }
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, filler);
+        }
+
         int slot = 10;
         for (Map.Entry<String, Cuboid> en : regions.entrySet()) {
             if (slot >= 54) break;
             String name = en.getKey();
             Cuboid c = en.getValue();
 
-            ItemStack zone = new ItemStack(Material.BEACON);
-            ItemMeta zm = zone.getItemMeta();
-            if (zm != null) {
-                zm.setDisplayName(ChatColor.AQUA + name);
-                zm.setLore(Arrays.asList(
+            ItemStack info = new ItemStack(Material.BEACON);
+            ItemMeta im = info.getItemMeta();
+            if (im != null) {
+                im.setDisplayName(ChatColor.AQUA + name);
+                im.setLore(Arrays.asList(
                         ChatColor.GRAY + "(" + c.x1() + "," + c.y1() + "," + c.z1() + ")",
                         ChatColor.GRAY + "(" + c.x2() + "," + c.y2() + "," + c.z2() + ")"
                 ));
-                zm.getPersistentDataContainer().set(actionKey, PersistentDataType.STRING, "noop");
-                zm.getPersistentDataContainer().set(nameKey, PersistentDataType.STRING, name);
-                zone.setItemMeta(zm);
+                info.setItemMeta(im);
             }
 
             ItemStack edit = new ItemStack(Material.ANVIL);
             ItemMeta em = edit.getItemMeta();
             if (em != null) {
                 em.setDisplayName(ChatColor.YELLOW + "Modifier");
+                em.setLore(Arrays.asList(ChatColor.GRAY + "Redéfinir cette zone."));
                 em.getPersistentDataContainer().set(actionKey, PersistentDataType.STRING, "edit");
                 em.getPersistentDataContainer().set(nameKey, PersistentDataType.STRING, name);
                 edit.setItemMeta(em);
@@ -132,12 +143,13 @@ public class ProtectionService {
             ItemMeta dm = del.getItemMeta();
             if (dm != null) {
                 dm.setDisplayName(ChatColor.RED + "Supprimer");
+                dm.setLore(Arrays.asList(ChatColor.GRAY + "Supprimer cette zone."));
                 dm.getPersistentDataContainer().set(actionKey, PersistentDataType.STRING, "delete");
                 dm.getPersistentDataContainer().set(nameKey, PersistentDataType.STRING, name);
                 del.setItemMeta(dm);
             }
 
-            inv.setItem(slot, zone);
+            inv.setItem(slot, info);
             inv.setItem(slot + 1, edit);
             inv.setItem(slot + 2, del);
             slot += 9;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.5.1
+version: 1.5.3
 api-version: "1.21"
 description: Hikabrain minigame for Spigot/Paper 1.21
 


### PR DESCRIPTION
## Summary
- replace `/hb list` text output with protection zone management GUI
- implement complete management menu with edit/delete actions for protected regions
- bump version to 1.5.3 and update docs

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689de4d442b08324b73b6689963dd575