### PR TITLE
feat: implement arena management and admin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## v1.0.0-SNAPSHOT
 - Ajout de l'architecture de base du plugin, des classes de données et des squelettes de managers.
+- Implémentation du système de création, configuration et sauvegarde des arènes via les commandes `/hb admin`.
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ Henebrain est un plugin Spigot pour Minecraft 1.21. Il fournit l'architecture de
 3. Exécutez `mvn package` à la racine du projet.
 4. Le fichier `Henebrain-1.0.0-SNAPSHOT.jar` sera généré dans le dossier `target/` et pourra être placé dans le dossier `plugins` de votre serveur Spigot.
 
+## Commandes d'Administration
+
+Toutes les commandes suivantes nécessitent la permission `henebrain.admin` et se basent sur la commande principale `/hb` :
+
+| Commande | Description |
+| --- | --- |
+| `/hb admin create <nom>` | Crée une nouvelle arène avec le nom donné. |
+| `/hb admin delete <nom>` | Supprime l'arène spécifiée. |
+| `/hb admin setlobby <nom_arène>` | Définit la position actuelle du joueur comme lobby de l'arène. |
+| `/hb admin setspawn <nom_arène> <nom_équipe>` | Définit le spawn de l'équipe donnée à la position du joueur. |
+| `/hb admin setpoint <nom_arène>` | Définit la position actuelle du joueur comme point à marquer. |
+| `/hb admin addmode <nom_arène> <mode>` | Ajoute un mode de jeu supporté à l'arène. |
+| `/hb admin removemode <nom_arène> <mode>` | Retire un mode de jeu supporté de l'arène. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,4 +3,6 @@
 | Fonctionnalité | Statut |
 | -------------- | ------ |
 | Architecture de base | Terminé |
+| Gestion des Arènes (Logique & Persistance) | Terminé |
+| Commandes d'Administration | Terminé |
 

--- a/src/main/java/com/gordoxgit/henebrain/Henebrain.java
+++ b/src/main/java/com/gordoxgit/henebrain/Henebrain.java
@@ -2,6 +2,7 @@ package com.gordoxgit.henebrain;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import com.gordoxgit.henebrain.commands.AdminCommand;
 import com.gordoxgit.henebrain.managers.ArenaManager;
 import com.gordoxgit.henebrain.managers.ConfigManager;
 import com.gordoxgit.henebrain.managers.GameManager;
@@ -27,6 +28,17 @@ public class Henebrain extends JavaPlugin {
         this.teamManager = new TeamManager(this);
         this.loadoutManager = new LoadoutManager(this);
         this.gameManager = new GameManager(this);
+
+        this.arenaManager.loadArenas();
+
+        AdminCommand adminCommand = new AdminCommand(this);
+        getCommand("hb").setExecutor(adminCommand);
+        getCommand("hb").setTabCompleter(adminCommand);
+    }
+
+    @Override
+    public void onDisable() {
+        this.arenaManager.saveArenas();
     }
 
     public static Henebrain getInstance() {

--- a/src/main/java/com/gordoxgit/henebrain/commands/AdminCommand.java
+++ b/src/main/java/com/gordoxgit/henebrain/commands/AdminCommand.java
@@ -1,0 +1,232 @@
+package com.gordoxgit.henebrain.commands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.data.Arena;
+import com.gordoxgit.henebrain.game.GameModeType;
+import com.gordoxgit.henebrain.managers.ArenaManager;
+
+public class AdminCommand implements CommandExecutor, TabCompleter {
+
+    private final Henebrain plugin;
+    private final ArenaManager arenaManager;
+
+    public AdminCommand(Henebrain plugin) {
+        this.plugin = plugin;
+        this.arenaManager = plugin.getArenaManager();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /" + label + " admin <subcommand>");
+            return true;
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "admin":
+                if (!sender.hasPermission("henebrain.admin")) {
+                    sender.sendMessage("Vous n'avez pas la permission d'exécuter cette commande.");
+                    return true;
+                }
+                handleAdminCommand(sender, label, Arrays.copyOfRange(args, 1, args.length));
+                return true;
+            default:
+                sender.sendMessage("Commande inconnue.");
+                return true;
+        }
+    }
+
+    private void handleAdminCommand(CommandSender sender, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /" + label + " admin <subcommand>");
+            return;
+        }
+
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "create":
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /" + label + " admin create <nom>");
+                    return;
+                }
+                String createName = args[1];
+                if (arenaManager.getArena(createName) != null) {
+                    sender.sendMessage("Cette arène existe déjà.");
+                    return;
+                }
+                arenaManager.createArena(createName);
+                sender.sendMessage("Arène " + createName + " créée.");
+                break;
+            case "delete":
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /" + label + " admin delete <nom>");
+                    return;
+                }
+                String deleteName = args[1];
+                if (arenaManager.getArena(deleteName) == null) {
+                    sender.sendMessage("Cette arène n'existe pas.");
+                    return;
+                }
+                arenaManager.deleteArena(deleteName);
+                sender.sendMessage("Arène " + deleteName + " supprimée.");
+                break;
+            case "setlobby":
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+                    return;
+                }
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /" + label + " admin setlobby <nom_arène>");
+                    return;
+                }
+                Player lobbyPlayer = (Player) sender;
+                Arena lobbyArena = arenaManager.getArena(args[1]);
+                if (lobbyArena == null) {
+                    sender.sendMessage("Cette arène n'existe pas.");
+                    return;
+                }
+                lobbyArena.setLobby(lobbyPlayer.getLocation());
+                sender.sendMessage("Lobby défini pour l'arène " + lobbyArena.getName() + ".");
+                break;
+            case "setspawn":
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+                    return;
+                }
+                if (args.length < 3) {
+                    sender.sendMessage("Usage: /" + label + " admin setspawn <nom_arène> <nom_équipe>");
+                    return;
+                }
+                Player spawnPlayer = (Player) sender;
+                Arena spawnArena = arenaManager.getArena(args[1]);
+                if (spawnArena == null) {
+                    sender.sendMessage("Cette arène n'existe pas.");
+                    return;
+                }
+                Map<String, Location> spawns = spawnArena.getTeamSpawns();
+                spawns.put(args[2], spawnPlayer.getLocation());
+                spawnArena.setTeamSpawns(spawns);
+                sender.sendMessage("Spawn défini pour l'équipe " + args[2] + " dans l'arène " + spawnArena.getName() + ".");
+                break;
+            case "setpoint":
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+                    return;
+                }
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /" + label + " admin setpoint <nom_arène>");
+                    return;
+                }
+                Player pointPlayer = (Player) sender;
+                Arena pointArena = arenaManager.getArena(args[1]);
+                if (pointArena == null) {
+                    sender.sendMessage("Cette arène n'existe pas.");
+                    return;
+                }
+                pointArena.setPoint(pointPlayer.getLocation());
+                sender.sendMessage("Point défini pour l'arène " + pointArena.getName() + ".");
+                break;
+            case "addmode":
+                if (args.length < 3) {
+                    sender.sendMessage("Usage: /" + label + " admin addmode <nom_arène> <mode>");
+                    return;
+                }
+                Arena addArena = arenaManager.getArena(args[1]);
+                if (addArena == null) {
+                    sender.sendMessage("Cette arène n'existe pas.");
+                    return;
+                }
+                try {
+                    GameModeType mode = GameModeType.valueOf(args[2].toUpperCase());
+                    if (!addArena.getSupportedModes().contains(mode)) {
+                        addArena.getSupportedModes().add(mode);
+                        sender.sendMessage("Mode " + mode.name() + " ajouté à l'arène " + addArena.getName() + ".");
+                    } else {
+                        sender.sendMessage("Ce mode est déjà supporté par l'arène.");
+                    }
+                } catch (IllegalArgumentException ex) {
+                    sender.sendMessage("Mode inconnu.");
+                }
+                break;
+            case "removemode":
+                if (args.length < 3) {
+                    sender.sendMessage("Usage: /" + label + " admin removemode <nom_arène> <mode>");
+                    return;
+                }
+                Arena removeArena = arenaManager.getArena(args[1]);
+                if (removeArena == null) {
+                    sender.sendMessage("Cette arène n'existe pas.");
+                    return;
+                }
+                try {
+                    GameModeType mode = GameModeType.valueOf(args[2].toUpperCase());
+                    if (removeArena.getSupportedModes().remove(mode)) {
+                        sender.sendMessage("Mode " + mode.name() + " retiré de l'arène " + removeArena.getName() + ".");
+                    } else {
+                        sender.sendMessage("Ce mode n'est pas supporté par l'arène.");
+                    }
+                } catch (IllegalArgumentException ex) {
+                    sender.sendMessage("Mode inconnu.");
+                }
+                break;
+            default:
+                sender.sendMessage("Sous-commande inconnue.");
+                break;
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], Collections.singletonList("admin"), completions);
+            return completions;
+        }
+
+        if (!args[0].equalsIgnoreCase("admin")) {
+            return completions;
+        }
+
+        if (args.length == 2) {
+            List<String> subs = Arrays.asList("create", "delete", "setlobby", "setspawn", "setpoint", "addmode", "removemode");
+            StringUtil.copyPartialMatches(args[1], subs, completions);
+            return completions;
+        }
+
+        if (args.length == 3) {
+            String sub = args[1].toLowerCase();
+            if (Arrays.asList("delete", "setlobby", "setspawn", "setpoint", "addmode", "removemode").contains(sub)) {
+                List<String> arenaNames = arenaManager.getAllArenas().stream().map(Arena::getName).collect(Collectors.toList());
+                StringUtil.copyPartialMatches(args[2], arenaNames, completions);
+            }
+            return completions;
+        }
+
+        if (args.length == 4) {
+            String sub = args[1].toLowerCase();
+            if (sub.equals("addmode") || sub.equals("removemode")) {
+                List<String> modes = Arrays.stream(GameModeType.values()).map(Enum::name).collect(Collectors.toList());
+                StringUtil.copyPartialMatches(args[3], modes, completions);
+            }
+            return completions;
+        }
+
+        return completions;
+    }
+}

--- a/src/main/java/com/gordoxgit/henebrain/managers/ArenaManager.java
+++ b/src/main/java/com/gordoxgit/henebrain/managers/ArenaManager.java
@@ -1,12 +1,134 @@
 package com.gordoxgit.henebrain.managers;
 
-import com.gordoxgit.henebrain.Henebrain;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.data.Arena;
+import com.gordoxgit.henebrain.game.GameModeType;
+
+/**
+ * Manages all arena persistence and CRUD operations.
+ */
 public class ArenaManager {
     private final Henebrain plugin;
+    private final Map<String, Arena> arenas = new HashMap<>();
+    private File configFile;
 
     public ArenaManager(Henebrain plugin) {
         this.plugin = plugin;
     }
+
+    /**
+     * Loads all arenas from the arenas.yml file.
+     */
+    public void loadArenas() {
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdirs();
+        }
+
+        configFile = new File(plugin.getDataFolder(), "arenas.yml");
+        if (!configFile.exists()) {
+            return; // Nothing to load yet
+        }
+
+        FileConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+        for (String key : config.getKeys(false)) {
+            String path = key + ".";
+
+            Location lobby = config.getLocation(path + "lobby");
+
+            Map<String, Location> spawns = new HashMap<>();
+            ConfigurationSection spawnSection = config.getConfigurationSection(path + "spawns");
+            if (spawnSection != null) {
+                for (String team : spawnSection.getKeys(false)) {
+                    spawns.put(team, spawnSection.getLocation(team));
+                }
+            }
+
+            Location point = config.getLocation(path + "point");
+
+            List<GameModeType> modes = new ArrayList<>();
+            for (String modeName : config.getStringList(path + "modes")) {
+                try {
+                    modes.add(GameModeType.valueOf(modeName));
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+
+            List<Location> barriers = new ArrayList<>();
+            List<?> barrierList = config.getList(path + "barrier");
+            if (barrierList != null) {
+                for (Object obj : barrierList) {
+                    if (obj instanceof Location) {
+                        barriers.add((Location) obj);
+                    }
+                }
+            }
+
+            Arena arena = new Arena(key, lobby, spawns, point, modes, barriers);
+            arenas.put(key, arena);
+        }
+    }
+
+    /**
+     * Saves all arenas to the arenas.yml file.
+     */
+    public void saveArenas() {
+        if (configFile == null) {
+            configFile = new File(plugin.getDataFolder(), "arenas.yml");
+        }
+
+        FileConfiguration config = new YamlConfiguration();
+
+        for (Arena arena : arenas.values()) {
+            String path = arena.getName() + ".";
+            config.set(path + "lobby", arena.getLobby());
+            for (Map.Entry<String, Location> entry : arena.getTeamSpawns().entrySet()) {
+                config.set(path + "spawns." + entry.getKey(), entry.getValue());
+            }
+            config.set(path + "point", arena.getPoint());
+
+            List<String> modeNames = new ArrayList<>();
+            for (GameModeType mode : arena.getSupportedModes()) {
+                modeNames.add(mode.name());
+            }
+            config.set(path + "modes", modeNames);
+            config.set(path + "barrier", arena.getBarrierLocations());
+        }
+
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void createArena(String name) {
+        arenas.put(name, new Arena(name, null, new HashMap<>(), null, new ArrayList<>(), new ArrayList<>()));
+    }
+
+    public void deleteArena(String name) {
+        arenas.remove(name);
+    }
+
+    public Arena getArena(String name) {
+        return arenas.get(name);
+    }
+
+    public Collection<Arena> getAllArenas() {
+        return arenas.values();
+    }
 }
+
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,7 @@ main: com.gordoxgit.henebrain.Henebrain
 version: ${project.version}
 api-version: '1.21'
 author: GordoxGit
+commands:
+  hb:
+    description: Commande principale Henebrain
+    usage: /hb


### PR DESCRIPTION
## Summary
- persist arenas using `ArenaManager` with load/save and CRUD helpers
- introduce `/hb admin` command for arena creation and configuration
- document new arena management and administration features

## Testing
- `mvn -q package` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a31d4e73d88324a5b71a4e22bb8844