### PR TITLE
[BUILD] Corriger l'avertissement de compilation Maven (system modules path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## v1.0.0-SNAPSHOT
 - Ajout de l'architecture de base du plugin, des classes de données et des squelettes de managers.
 - Implémentation du système de création, configuration et sauvegarde des arènes via les commandes `/hb admin`.
+- [BUILD] Correction de l'avertissement de compilation en configurant la balise `<release>` pour le maven-compiler-plugin.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,20 @@
     <artifactId>Henebrain</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <repositories>
         <repository>
             <id>spigot-repo</id>


### PR DESCRIPTION
## Summary
- configure maven-compiler-plugin with `<release>17</release>` to remove system modules path warning
- document build fix in changelog

## Testing
- `mvn -q package` *(fails: Network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a32498d890832485e040f18a7679fd