### PR TITLE
feat(core): implement game lifecycle and join command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 - Ajout de l'architecture de base du plugin, des classes de données et des squelettes de managers.
 - Implémentation du système de création, configuration et sauvegarde des arènes via les commandes `/hb admin`.
 - [BUILD] Correction de l'avertissement de compilation en configurant la balise `<release>` pour le maven-compiler-plugin.
+- Implémentation du moteur de jeu principal permettant de rejoindre, démarrer et terminer une partie. Ajout de la commande `/hb join`.
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ Toutes les commandes suivantes nécessitent la permission `henebrain.admin` et s
 | `/hb admin setpoint <nom_arène>` | Définit la position actuelle du joueur comme point à marquer. |
 | `/hb admin addmode <nom_arène> <mode>` | Ajoute un mode de jeu supporté à l'arène. |
 | `/hb admin removemode <nom_arène> <mode>` | Retire un mode de jeu supporté de l'arène. |
+
+## Commandes Joueur
+
+| Commande | Description | Permission |
+| --- | --- | --- |
+| `/hb join <nom_arène>` | Rejoint la file d'attente de l'arène indiquée. | `henebrain.join` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,4 +5,5 @@
 | Architecture de base | Terminé |
 | Gestion des Arènes (Logique & Persistance) | Terminé |
 | Commandes d'Administration | Terminé |
+| Cycle de Vie des Parties (Rejoindre, Démarrer, Terminer) | Terminé |
 

--- a/src/main/java/com/gordoxgit/henebrain/Henebrain.java
+++ b/src/main/java/com/gordoxgit/henebrain/Henebrain.java
@@ -3,6 +3,8 @@ package com.gordoxgit.henebrain;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import com.gordoxgit.henebrain.commands.AdminCommand;
+import com.gordoxgit.henebrain.commands.JoinCommand;
+import com.gordoxgit.henebrain.listeners.PlayerConnectionListener;
 import com.gordoxgit.henebrain.managers.ArenaManager;
 import com.gordoxgit.henebrain.managers.ConfigManager;
 import com.gordoxgit.henebrain.managers.GameManager;
@@ -32,8 +34,11 @@ public class Henebrain extends JavaPlugin {
         this.arenaManager.loadArenas();
 
         AdminCommand adminCommand = new AdminCommand(this);
-        getCommand("hb").setExecutor(adminCommand);
-        getCommand("hb").setTabCompleter(adminCommand);
+        JoinCommand joinCommand = new JoinCommand(this, adminCommand);
+        getCommand("hb").setExecutor(joinCommand);
+        getCommand("hb").setTabCompleter(joinCommand);
+
+        getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this), this);
     }
 
     @Override

--- a/src/main/java/com/gordoxgit/henebrain/commands/JoinCommand.java
+++ b/src/main/java/com/gordoxgit/henebrain/commands/JoinCommand.java
@@ -1,0 +1,116 @@
+package com.gordoxgit.henebrain.commands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.data.Arena;
+import com.gordoxgit.henebrain.game.Game;
+import com.gordoxgit.henebrain.game.GameState;
+import com.gordoxgit.henebrain.managers.ArenaManager;
+import com.gordoxgit.henebrain.managers.GameManager;
+
+/**
+ * Main player command handling join logic and delegating admin subcommands.
+ */
+public class JoinCommand implements CommandExecutor, TabCompleter {
+    private final Henebrain plugin;
+    private final ArenaManager arenaManager;
+    private final GameManager gameManager;
+    private final AdminCommand adminCommand;
+
+    public JoinCommand(Henebrain plugin, AdminCommand adminCommand) {
+        this.plugin = plugin;
+        this.arenaManager = plugin.getArenaManager();
+        this.gameManager = plugin.getGameManager();
+        this.adminCommand = adminCommand;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /" + label + " <subcommand>");
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("join")) {
+            handleJoin(sender, args, label);
+            return true;
+        }
+
+        // Delegate admin commands to the existing AdminCommand
+        if (args[0].equalsIgnoreCase("admin")) {
+            return adminCommand.onCommand(sender, command, label, args);
+        }
+
+        sender.sendMessage("Commande inconnue.");
+        return true;
+    }
+
+    private void handleJoin(CommandSender sender, String[] args, String label) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+            return;
+        }
+
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /" + label + " join <nom_arène>");
+            return;
+        }
+
+        Player player = (Player) sender;
+        if (!player.hasPermission("henebrain.join")) {
+            player.sendMessage("Vous n'avez pas la permission d'utiliser cette commande.");
+            return;
+        }
+        String arenaName = args[1];
+        Arena arena = arenaManager.getArena(arenaName);
+        if (arena == null) {
+            player.sendMessage("Cette arène n'existe pas.");
+            return;
+        }
+
+        Game game = gameManager.getGame(arenaName);
+        if (game != null && game.getState() != GameState.WAITING) {
+            player.sendMessage("Une partie est déjà en cours dans cette arène.");
+            return;
+        }
+
+        gameManager.addPlayerToGame(player, arenaName);
+        player.sendMessage("Vous avez rejoint l'arène " + arenaName + ".");
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+
+        if (args.length == 1) {
+            List<String> subs = Arrays.asList("join", "admin");
+            StringUtil.copyPartialMatches(args[0], subs, completions);
+            return completions;
+        }
+
+        if (args[0].equalsIgnoreCase("join")) {
+            if (args.length == 2) {
+                List<String> arenaNames = arenaManager.getAllArenas().stream().map(Arena::getName).collect(Collectors.toList());
+                StringUtil.copyPartialMatches(args[1], arenaNames, completions);
+            }
+            return completions;
+        }
+
+        if (args[0].equalsIgnoreCase("admin")) {
+            return adminCommand.onTabComplete(sender, command, alias, args);
+        }
+
+        return completions;
+    }
+}

--- a/src/main/java/com/gordoxgit/henebrain/game/Game.java
+++ b/src/main/java/com/gordoxgit/henebrain/game/Game.java
@@ -1,19 +1,29 @@
 package com.gordoxgit.henebrain.game;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.block.BlockState;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.data.Arena;
 import com.gordoxgit.henebrain.data.Team;
+import com.gordoxgit.henebrain.managers.LoadoutManager;
+import com.gordoxgit.henebrain.managers.TeamManager;
 
 public class Game {
     private String arenaName;
     private GameState state;
     private GameModeType mode;
-    private List<Team> teams;
-    private Map<UUID, Object> players;
+    private List<Team> teams = new ArrayList<>();
+    private Map<UUID, Player> players = new HashMap<>();
     private Map<Team, Integer> scores;
     private List<BlockState> placedBlocks;
 
@@ -55,11 +65,11 @@ public class Game {
         this.teams = teams;
     }
 
-    public Map<UUID, Object> getPlayers() {
+    public Map<UUID, Player> getPlayers() {
         return players;
     }
 
-    public void setPlayers(Map<UUID, Object> players) {
+    public void setPlayers(Map<UUID, Player> players) {
         this.players = players;
     }
 
@@ -77,6 +87,98 @@ public class Game {
 
     public void setPlacedBlocks(List<BlockState> placedBlocks) {
         this.placedBlocks = placedBlocks;
+    }
+
+    /**
+     * Starts a 10 second countdown before the game actually begins.
+     */
+    public void startCountdown() {
+        if (state != GameState.WAITING) {
+            return;
+        }
+        setState(GameState.STARTING);
+        new BukkitRunnable() {
+            int counter = 10;
+
+            @Override
+            public void run() {
+                if (counter <= 0) {
+                    cancel();
+                    start();
+                    return;
+                }
+
+                for (Player p : players.values()) {
+                    p.sendMessage("La partie commence dans " + counter + " secondes !");
+                }
+                counter--;
+            }
+        }.runTaskTimer(Henebrain.getInstance(), 0L, 20L);
+    }
+
+    /**
+     * Starts the game after the countdown.
+     */
+    public void start() {
+        TeamManager teamManager = Henebrain.getInstance().getTeamManager();
+        LoadoutManager loadoutManager = Henebrain.getInstance().getLoadoutManager();
+        Arena arena = Henebrain.getInstance().getArenaManager().getArena(arenaName);
+
+        teamManager.balanceTeams(this);
+        setState(GameState.PLAYING);
+
+        for (Team team : teams) {
+            Location spawn = arena.getTeamSpawns().get(team.getTeamName());
+            for (UUID uuid : team.getMembers()) {
+                Player p = Bukkit.getPlayer(uuid);
+                if (p != null) {
+                    if (spawn != null) {
+                        p.teleport(spawn);
+                    }
+                    loadoutManager.applyLoadout(p);
+                }
+            }
+        }
+    }
+
+    /**
+     * Ends the game and cleans up after 10 seconds.
+     *
+     * @param winner the winning team
+     */
+    public void end(Team winner) {
+        if (state == GameState.ENDING) {
+            return;
+        }
+        setState(GameState.ENDING);
+        for (Player p : players.values()) {
+            if (winner != null) {
+                p.sendMessage("L'équipe " + winner.getTeamName() + " a gagné !");
+            } else {
+                p.sendMessage("La partie est terminée.");
+            }
+        }
+
+        new BukkitRunnable() {
+            int counter = 10;
+
+            @Override
+            public void run() {
+                if (counter <= 0) {
+                    cancel();
+                    Arena arena = Henebrain.getInstance().getArenaManager().getArena(arenaName);
+                    Location lobby = arena != null ? arena.getLobby() : null;
+                    for (Player p : players.values()) {
+                        if (lobby != null) {
+                            p.teleport(lobby);
+                        }
+                    }
+                    Henebrain.getInstance().getGameManager().cleanupGame(Game.this);
+                    return;
+                }
+                counter--;
+            }
+        }.runTaskTimer(Henebrain.getInstance(), 0L, 20L);
     }
 }
 

--- a/src/main/java/com/gordoxgit/henebrain/game/GameState.java
+++ b/src/main/java/com/gordoxgit/henebrain/game/GameState.java
@@ -2,7 +2,8 @@ package com.gordoxgit.henebrain.game;
 
 public enum GameState {
     WAITING,
-    RUNNING,
-    ENDED
+    STARTING,
+    PLAYING,
+    ENDING
 }
 

--- a/src/main/java/com/gordoxgit/henebrain/listeners/PlayerConnectionListener.java
+++ b/src/main/java/com/gordoxgit/henebrain/listeners/PlayerConnectionListener.java
@@ -1,0 +1,24 @@
+package com.gordoxgit.henebrain.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.managers.GameManager;
+
+/**
+ * Handles player connection events.
+ */
+public class PlayerConnectionListener implements Listener {
+    private final GameManager gameManager;
+
+    public PlayerConnectionListener(Henebrain plugin) {
+        this.gameManager = plugin.getGameManager();
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        gameManager.removePlayerFromGame(event.getPlayer());
+    }
+}

--- a/src/main/java/com/gordoxgit/henebrain/managers/GameManager.java
+++ b/src/main/java/com/gordoxgit/henebrain/managers/GameManager.java
@@ -1,12 +1,87 @@
 package com.gordoxgit.henebrain.managers;
 
-import com.gordoxgit.henebrain.Henebrain;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
+import org.bukkit.entity.Player;
+
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.data.Arena;
+import com.gordoxgit.henebrain.game.Game;
+import com.gordoxgit.henebrain.game.GameModeType;
+
+/**
+ * Manages all running games.
+ */
 public class GameManager {
     private final Henebrain plugin;
+    private final Map<String, Game> games = new HashMap<>();
+    private final Map<UUID, Game> playerGames = new HashMap<>();
 
     public GameManager(Henebrain plugin) {
         this.plugin = plugin;
+    }
+
+    public Game getGame(String arenaName) {
+        return games.get(arenaName);
+    }
+
+    public Game getGame(Player player) {
+        return playerGames.get(player.getUniqueId());
+    }
+
+    /**
+     * Adds a player to the specified arena game. Creates the game if necessary
+     * and starts the countdown when enough players have joined.
+     */
+    public void addPlayerToGame(Player player, String arenaName) {
+        Arena arena = plugin.getArenaManager().getArena(arenaName);
+        if (arena == null) {
+            return;
+        }
+
+        Game game = games.get(arenaName);
+        if (game == null) {
+            game = new Game(arenaName, GameModeType.CLASSIC);
+            games.put(arenaName, game);
+        }
+
+        game.getPlayers().put(player.getUniqueId(), player);
+        playerGames.put(player.getUniqueId(), game);
+
+        if (arena.getLobby() != null) {
+            player.teleport(arena.getLobby());
+        }
+
+        int minPlayers = 2; // default minimum players
+        if (game.getPlayers().size() >= minPlayers) {
+            game.startCountdown();
+        }
+    }
+
+    /**
+     * Removes a player from its game.
+     */
+    public void removePlayerFromGame(Player player) {
+        Game game = playerGames.remove(player.getUniqueId());
+        if (game != null) {
+            game.getPlayers().remove(player.getUniqueId());
+            if (game.getPlayers().isEmpty()) {
+                cleanupGame(game);
+            }
+        }
+    }
+
+    /**
+     * Cleans up a finished game.
+     */
+    public void cleanupGame(Game game) {
+        games.remove(game.getArenaName());
+        for (UUID uuid : new ArrayList<>(game.getPlayers().keySet())) {
+            playerGames.remove(uuid);
+        }
     }
 }
 

--- a/src/main/java/com/gordoxgit/henebrain/managers/LoadoutManager.java
+++ b/src/main/java/com/gordoxgit/henebrain/managers/LoadoutManager.java
@@ -1,12 +1,25 @@
 package com.gordoxgit.henebrain.managers;
 
+import org.bukkit.entity.Player;
+
 import com.gordoxgit.henebrain.Henebrain;
 
+/**
+ * Handles application of player loadouts.
+ */
 public class LoadoutManager {
     private final Henebrain plugin;
 
     public LoadoutManager(Henebrain plugin) {
         this.plugin = plugin;
+    }
+
+    /**
+     * Applies the default loadout to the player.
+     * This is a placeholder for future implementation.
+     */
+    public void applyLoadout(Player player) {
+        // TODO: Give the player their starting items
     }
 }
 

--- a/src/main/java/com/gordoxgit/henebrain/managers/TeamManager.java
+++ b/src/main/java/com/gordoxgit/henebrain/managers/TeamManager.java
@@ -1,12 +1,49 @@
 package com.gordoxgit.henebrain.managers;
 
-import com.gordoxgit.henebrain.Henebrain;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import com.gordoxgit.henebrain.Henebrain;
+import com.gordoxgit.henebrain.data.Arena;
+import com.gordoxgit.henebrain.data.Team;
+import com.gordoxgit.henebrain.game.Game;
+
+/**
+ * Handles team creation and balancing for games.
+ */
 public class TeamManager {
     private final Henebrain plugin;
 
     public TeamManager(Henebrain plugin) {
         this.plugin = plugin;
+    }
+
+    /**
+     * Balances players across teams in a round-robin fashion.
+     */
+    public void balanceTeams(Game game) {
+        Arena arena = plugin.getArenaManager().getArena(game.getArenaName());
+        if (arena == null) {
+            return;
+        }
+
+        List<Team> teams = new ArrayList<>();
+        ChatColor[] colors = ChatColor.values();
+        int colorIndex = 0;
+        for (String name : arena.getTeamSpawns().keySet()) {
+            teams.add(new Team(name, colors[colorIndex++ % colors.length], new ArrayList<>()));
+        }
+
+        List<Player> players = new ArrayList<>(game.getPlayers().values());
+        for (int i = 0; i < players.size(); i++) {
+            Team team = teams.get(i % teams.size());
+            team.getMembers().add(players.get(i).getUniqueId());
+        }
+
+        game.setTeams(teams);
     }
 }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,3 +7,10 @@ commands:
   hb:
     description: Commande principale Henebrain
     usage: /hb
+permissions:
+  henebrain.admin:
+    description: Accès aux commandes d'administration de Henebrain
+    default: op
+  henebrain.join:
+    description: Autorise un joueur à rejoindre une arène
+    default: true


### PR DESCRIPTION
## Summary
- implement Game state machine with countdown, start and end flow
- manage player queues via GameManager and round-robin team balancing
- add `/hb join` command and connection listener for player departures

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3278abd7c832490d927f158b54084