### PR TITLE
feat: add database connection and player data structure

### DIFF
--- a/src/main/java/io/github/gordoxgit/henebrain/Henebrain.java
+++ b/src/main/java/io/github/gordoxgit/henebrain/Henebrain.java
@@ -1,18 +1,31 @@
 package io.github.gordoxgit.henebrain;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import io.github.gordoxgit.henebrain.database.DatabaseManager;
 
 public final class Henebrain extends JavaPlugin {
 
+    private DatabaseManager databaseManager;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        // Save default configuration if not present
+        saveDefaultConfig();
+
+        // Initialize and connect to the database
+        databaseManager = new DatabaseManager(this);
+        databaseManager.connect();
+
         getLogger().info("Henebrain a démarré avec succès !");
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        // Disconnect from database if connected
+        if (databaseManager != null) {
+            databaseManager.disconnect();
+        }
+
         getLogger().info("Henebrain s'est arrêté.");
     }
 }

--- a/src/main/java/io/github/gordoxgit/henebrain/database/DatabaseManager.java
+++ b/src/main/java/io/github/gordoxgit/henebrain/database/DatabaseManager.java
@@ -1,0 +1,62 @@
+package io.github.gordoxgit.henebrain.database;
+
+import io.github.gordoxgit.henebrain.Henebrain;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Handles the connection to the MySQL database.
+ */
+public class DatabaseManager {
+
+    private final Henebrain plugin;
+    private Connection connection;
+
+    public DatabaseManager(Henebrain plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Connects to the database using the credentials provided in the config.yml.
+     */
+    public void connect() {
+        String host = plugin.getConfig().getString("database.host");
+        int port = plugin.getConfig().getInt("database.port");
+        String database = plugin.getConfig().getString("database.database");
+        String username = plugin.getConfig().getString("database.username");
+        String password = plugin.getConfig().getString("database.password");
+
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + database;
+
+        try {
+            connection = DriverManager.getConnection(url, username, password);
+            plugin.getLogger().info("Connexion à la base de données réussie.");
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Échec de la connexion à la base de données : " + e.getMessage());
+        }
+    }
+
+    /**
+     * Closes the database connection.
+     */
+    public void disconnect() {
+        if (connection != null) {
+            try {
+                connection.close();
+                plugin.getLogger().info("Connexion à la base de données fermée.");
+            } catch (SQLException e) {
+                plugin.getLogger().severe("Erreur lors de la fermeture de la connexion : " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Returns the current SQL connection.
+     *
+     * @return Connection or null if not connected
+     */
+    public Connection getConnection() {
+        return connection;
+    }
+}

--- a/src/main/java/io/github/gordoxgit/henebrain/player/PlayerData.java
+++ b/src/main/java/io/github/gordoxgit/henebrain/player/PlayerData.java
@@ -1,0 +1,49 @@
+package io.github.gordoxgit.henebrain.player;
+
+import java.util.UUID;
+
+/**
+ * Simple data container for player statistics.
+ */
+public class PlayerData {
+
+    private final UUID uuid;
+    private int elo;
+    private int wins;
+    private int losses;
+
+    public PlayerData(UUID uuid, int elo, int wins, int losses) {
+        this.uuid = uuid;
+        this.elo = elo;
+        this.wins = wins;
+        this.losses = losses;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public int getElo() {
+        return elo;
+    }
+
+    public void setElo(int elo) {
+        this.elo = elo;
+    }
+
+    public int getWins() {
+        return wins;
+    }
+
+    public void setWins(int wins) {
+        this.wins = wins;
+    }
+
+    public int getLosses() {
+        return losses;
+    }
+
+    public void setLosses(int losses) {
+        this.losses = losses;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+database:
+  host: '51.75.125.229'
+  port: 3306
+  database: 'henebrain'
+  username: 'root'
+  password: 'your_password'


### PR DESCRIPTION
## Summary
- load default configuration and connect to MySQL on startup
- add `DatabaseManager` for handling MySQL connections
- introduce `PlayerData` POJO for player statistics

## Testing
- `mvn -q clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a393422ea083248ac96f02d8af24df