### PR TITLE
fix: add jitpack repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- add jitpack repository to resolve triumph-gui dependency

## Testing
- `mvn -q clean package` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 (absent): Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b32e3225e08324bb5c070e138890ae