### PR TITLE
NEX-005: shade MariaDB and Hikari dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,18 @@
                             <pattern>dev.triumphteam.gui</pattern>
                             <shadedPattern>fr.heneria.nexus.libs.gui</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>org.mariadb.jdbc</pattern>
+                            <shadedPattern>fr.heneria.nexus.libs.mariadb</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.zaxxer.hikari</pattern>
+                            <shadedPattern>fr.heneria.nexus.libs.hikari</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.flywaydb</pattern>
+                            <shadedPattern>fr.heneria.nexus.libs.flywaydb</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- shade MariaDB, HikariCP, and Flyway dependencies to embed JDBC drivers

## Testing
- `mvn clean package` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b87506ca548324ad6b4abc032d5ddd