### PR TITLE
NEX-015: externalize config and improve DB connection

### DIFF
--- a/src/main/java/fr/heneria/nexus/db/HikariDataSourceProvider.java
+++ b/src/main/java/fr/heneria/nexus/db/HikariDataSourceProvider.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.db;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.sql.DataSource;
@@ -22,7 +23,7 @@ public class HikariDataSourceProvider {
     }
 
     /**
-     * Initialise le pool de connexions avec des valeurs codées en dur pour le moment.
+     * Initialise le pool de connexions à partir du config.yml du plugin.
      *
      * @param plugin instance du plugin
      */
@@ -31,13 +32,56 @@ public class HikariDataSourceProvider {
             return;
         }
 
-        HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:mariadb://localhost:3306/nexus");
-        config.setUsername("root");
-        config.setPassword("password");
-        config.setMaximumPoolSize(10);
-        config.setPoolName("NexusHikariPool");
-        this.dataSource = new HikariDataSource(config);
+        // Créer le config.yml par défaut si inexistant
+        plugin.saveDefaultConfig();
+        FileConfiguration config = plugin.getConfig();
+
+        HikariConfig hikariConfig = new HikariConfig();
+        
+        // Configuration de base de données depuis config.yml
+        String host = config.getString("database.host", "localhost");
+        int port = config.getInt("database.port", 3306);
+        String database = config.getString("database.database", "nexus");
+        String username = config.getString("database.username", "nexus_user");
+        String password = config.getString("database.password", "your_password_here");
+
+        // Construction de l'URL JDBC
+        String jdbcUrl = String.format("jdbc:mariadb://%s:%d/%s", host, port, database);
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setUsername(username);
+        hikariConfig.setPassword(password);
+
+        // IMPORTANT : Spécifier explicitement le driver relocalisé
+        hikariConfig.setDriverClassName("fr.heneria.nexus.libs.mariadb.jdbc.Driver");
+
+        // Configuration du pool HikariCP
+        hikariConfig.setMaximumPoolSize(config.getInt("database.hikari.maximum-pool-size", 10));
+        hikariConfig.setMinimumIdle(config.getInt("database.hikari.minimum-idle", 5));
+        hikariConfig.setConnectionTimeout(config.getLong("database.hikari.connection-timeout", 20000));
+        hikariConfig.setIdleTimeout(config.getLong("database.hikari.idle-timeout", 600000));
+        hikariConfig.setMaxLifetime(config.getLong("database.hikari.max-lifetime", 1800000));
+        hikariConfig.setLeakDetectionThreshold(config.getLong("database.hikari.leak-detection-threshold", 60000));
+
+        // Propriétés spécifiques MariaDB
+        hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        hikariConfig.addDataSourceProperty("useUnicode", "true");
+        hikariConfig.addDataSourceProperty("characterEncoding", "utf8mb4");
+        hikariConfig.addDataSourceProperty("serverTimezone", "UTC");
+        hikariConfig.addDataSourceProperty("rewriteBatchedStatements", "true");
+
+        hikariConfig.setPoolName("NexusHikariPool");
+
+        try {
+            this.dataSource = new HikariDataSource(hikariConfig);
+            plugin.getLogger().info("✅ Connexion à la base de données établie avec succès !");
+        } catch (Exception e) {
+            plugin.getLogger().severe("❌ Impossible de se connecter à la base de données !");
+            plugin.getLogger().severe("Vérifiez votre configuration dans config.yml");
+            plugin.getLogger().severe("Erreur: " + e.getMessage());
+            throw new RuntimeException("Database connection failed", e);
+        }
     }
 
     public static HikariDataSourceProvider getInstance() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,51 @@
+# ===================================
+# 🚀 Configuration Nexus Plugin
+# ===================================
+
+# Configuration de base de données
+database:
+  # Informations de connexion
+  host: "localhost"
+  port: 3306
+  database: "nexus"
+  username: "nexus_user"
+  password: "your_password_here"
+  
+  # Paramètres de connexion HikariCP
+  hikari:
+    maximum-pool-size: 10      # Nombre maximum de connexions
+    minimum-idle: 5            # Connexions toujours disponibles
+    connection-timeout: 20000    # Timeout de connexion (ms)
+    idle-timeout: 600000         # Timeout d'inactivité (ms) - 10min
+    max-lifetime: 1800000        # Durée de vie max d'une connexion (ms) - 30min
+    leak-detection-threshold: 60000  # Détection de fuite de connexion (ms) - 1min
+
+# Configuration du gameplay
+game:
+  # Configuration des arènes
+  arena:
+    max-players-per-arena: 24
+    capture-time-seconds: 30
+    respawn-time-seconds: 5
+    
+  # Système économique
+  economy:
+    kill-reward: 100
+    assist-reward: 50
+    victory-bonus: 200
+    defeat-bonus: [100, 150]  # 1ère et 2ème défaite consécutive
+
+# Système de classement
+ranking:
+  elo:
+    starting-rating: 1000
+    k-factor: 32
+    seasons:
+      duration-months: 3
+      soft-reset-percentage: 0.8
+
+# Debug et développement
+debug:
+  enabled: false
+  log-sql-queries: false
+  performance-monitoring: true


### PR DESCRIPTION
## Summary
- add default `config.yml` with database, gameplay, ranking and debug settings
- update `HikariDataSourceProvider` to load settings from config and improve connection handling

## Testing
- `mvn -q test` *(fails: maven-resources-plugin could not be resolved)*
- `mvn -q -o test` *(fails: maven-resources-plugin has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68b969c83e788324893050ab61b8b762