### PR TITLE
fix: use Flyway MariaDB dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-mysql</artifactId>
+            <artifactId>flyway-mariadb</artifactId>
             <version>10.15.0</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
## Summary
- replace Flyway MySQL dependency with Flyway MariaDB to support MariaDB 10.11

## Testing
- `mvn -q clean package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b976abc5ac83249a1a43355cde78fe