### PR TITLE
fix: replace non-existent flyway-mariadb with flyway-mysql dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-mariadb</artifactId>
+            <artifactId>flyway-mysql</artifactId>
             <version>10.15.0</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
## Summary
- replace deprecated `flyway-mariadb` dependency with `flyway-mysql`

## Testing
- `mvn clean compile` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0 could not be resolved: Network is unreachable)*
- `mvn clean package` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0 could not be resolved: Network is unreachable)*
- `jar tf target/Nexus-0.0.0-SNAPSHOT.jar | grep flyway` *(fails: target/Nexus-0.0.0-SNAPSHOT.jar not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cfd490fc8324af666ccfa6bb05fa