### PR TITLE
fix: shade dependencies and improve CI checks

### DIFF
--- a/.github/workflows/heneria-ci.yml
+++ b/.github/workflows/heneria-ci.yml
@@ -222,8 +222,9 @@ jobs:
           "plugin.yml"
           "fr/heneria/nexus/Nexus.class"
           "org/mariadb/jdbc/Driver.class"
-          "com/zaxxer/hikari/HikariDataSource.class"
-          "org/flywaydb/core/Flyway.class"
+          "fr/heneria/nexus/libs/hikari/HikariDataSource.class"
+          "fr/heneria/nexus/libs/flywaydb/core/Flyway.class"
+          "fr/heneria/nexus/libs/gui/BaseGui.class"
         )
 
         for file in "${critical_files[@]}"; do
@@ -237,11 +238,11 @@ jobs:
         done
 
         echo ""
-        echo "📈 Analyse des dépendances incluses:"
+        echo "📈 Analyse des dépendances relocalisées:"
         echo "  MariaDB classes: $(jar tf "$JAR_FILE" | grep -c "org/mariadb/")"
-        echo "  HikariCP classes: $(jar tf "$JAR_FILE" | grep -c "com/zaxxer/hikari/")"
-        echo "  Flyway classes: $(jar tf "$JAR_FILE" | grep -c "org/flywaydb/")"
-
+        echo "  HikariCP classes (relocalisées): $(jar tf "$JAR_FILE" | grep -c "fr/heneria/nexus/libs/hikari/")"
+        echo "  Flyway classes (relocalisées): $(jar tf "$JAR_FILE" | grep -c "fr/heneria/nexus/libs/flywaydb/")"
+        echo "  Triumph GUI classes (relocalisées): $(jar tf "$JAR_FILE" | grep -c "fr/heneria/nexus/libs/gui/")"
         echo ""
         echo "🔧 Classes relocalisées:"
         jar tf "$JAR_FILE" | grep -E "fr/heneria/nexus/libs/" | head -5 | sed 's/^/  /' || echo "  ℹ️ Aucune relocalisation détectée"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+### Fixed
+- Ensure Maven Shade packages HikariCP, Flyway and Triumph GUI dependencies and update CI verification.

--- a/pom.xml
+++ b/pom.xml
@@ -145,18 +145,60 @@
                                 </relocation>
                             </relocations>
                             <filters>
+                                <!-- Filtre global pour exclure les métadonnées inutiles -->
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                        <exclude>META-INF/LICENSE*</exclude>
+                                        <exclude>META-INF/NOTICE*</exclude>
+                                        <exclude>**/*.kotlin_metadata</exclude>
+                                        <exclude>**/*.kotlin_module</exclude>
+                                        <exclude>**/*.kotlin_builtins</exclude>
                                     </excludes>
                                 </filter>
+
+                        <!-- MariaDB - inclusion explicite -->
                                 <filter>
                                     <artifact>org.mariadb.jdbc:mariadb-java-client</artifact>
                                     <includes>
                                         <include>org/mariadb/**</include>
+                                    </includes>
+                                </filter>
+
+                        <!-- HikariCP -->
+                                <filter>
+                                    <artifact>com.zaxxer:HikariCP</artifact>
+                                    <includes>
+                                        <include>com/zaxxer/hikari/**</include>
+                                    </includes>
+                                </filter>
+
+                        <!-- Flyway Core -->
+                                <filter>
+                                    <artifact>org.flywaydb:flyway-core</artifact>
+                                    <includes>
+                                        <include>org/flywaydb/**</include>
+                                    </includes>
+                                </filter>
+
+                        <!-- Flyway MySQL -->
+                                <filter>
+                                    <artifact>org.flywaydb:flyway-mysql</artifact>
+                                    <includes>
+                                        <include>org/flywaydb/**</include>
+                                    </includes>
+                                </filter>
+
+                        <!-- Triumph GUI -->
+                                <filter>
+                                    <artifact>dev.triumphteam:triumph-gui</artifact>
+                                    <includes>
+                                        <include>dev/triumphteam/**</include>
                                     </includes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
## Summary
- include HikariCP, Flyway, and Triumph GUI in shaded JAR
- verify relocated dependencies in CI jar analysis
- document change in changelog

## Testing
- `mvn clean compile -q` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d4e90ff88324bd90a5787db37090