### PR TITLE
feat: add asynchronous player profile system

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -5,6 +5,10 @@ import fr.heneria.nexus.arena.repository.ArenaRepository;
 import fr.heneria.nexus.arena.repository.JdbcArenaRepository;
 import fr.heneria.nexus.command.ArenaCommand;
 import fr.heneria.nexus.db.HikariDataSourceProvider;
+import fr.heneria.nexus.listener.PlayerConnectionListener;
+import fr.heneria.nexus.player.manager.PlayerManager;
+import fr.heneria.nexus.player.repository.JdbcPlayerRepository;
+import fr.heneria.nexus.player.repository.PlayerRepository;
 
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -20,6 +24,7 @@ public final class Nexus extends JavaPlugin {
 
     private HikariDataSourceProvider dataSourceProvider;
     private ArenaManager arenaManager;
+    private PlayerManager playerManager;
 
     @Override
     public void onEnable() {
@@ -40,11 +45,13 @@ public final class Nexus extends JavaPlugin {
                 getLogger().info("✅ Migrations de la base de données gérées par Liquibase.");
             }
 
-            // 3. Initialiser le repository
+            // 3. Initialiser les repositories
             ArenaRepository arenaRepository = new JdbcArenaRepository(this.dataSourceProvider.getDataSource());
+            PlayerRepository playerRepository = new JdbcPlayerRepository(this.dataSourceProvider.getDataSource());
 
-            // 4. Initialiser le manager
+            // 4. Initialiser les managers
             this.arenaManager = new ArenaManager(arenaRepository);
+            this.playerManager = new PlayerManager(playerRepository);
 
             // 5. Charger les arènes
             this.arenaManager.loadArenas();
@@ -52,6 +59,9 @@ public final class Nexus extends JavaPlugin {
 
             // 6. Enregistrer les commandes
             getCommand("nx").setExecutor(new ArenaCommand(this.arenaManager));
+
+            // 7. Enregistrer les listeners
+            getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this), this);
 
             getLogger().info("✅ Le plugin Nexus a été activé avec succès !");
 

--- a/src/main/java/fr/heneria/nexus/listener/PlayerConnectionListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/PlayerConnectionListener.java
@@ -1,0 +1,40 @@
+package fr.heneria.nexus.listener;
+
+import fr.heneria.nexus.player.manager.PlayerManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+public class PlayerConnectionListener implements Listener {
+
+    private final PlayerManager playerManager;
+    private final JavaPlugin plugin;
+
+    public PlayerConnectionListener(PlayerManager playerManager, JavaPlugin plugin) {
+        this.playerManager = playerManager;
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPreLogin(AsyncPlayerPreLoginEvent event) {
+        UUID uuid = event.getUniqueId();
+        String name = event.getName();
+        try {
+            playerManager.loadProfile(uuid, name).get();
+        } catch (InterruptedException | ExecutionException e) {
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, "§cErreur lors du chargement de votre profil.");
+            plugin.getLogger().severe("Failed to load profile for " + name + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        playerManager.unloadProfile(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/fr/heneria/nexus/player/manager/PlayerManager.java
+++ b/src/main/java/fr/heneria/nexus/player/manager/PlayerManager.java
@@ -1,0 +1,52 @@
+package fr.heneria.nexus.player.manager;
+
+import fr.heneria.nexus.player.model.PlayerProfile;
+import fr.heneria.nexus.player.repository.PlayerRepository;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PlayerManager {
+
+    private final PlayerRepository repository;
+    private final Map<UUID, PlayerProfile> cache = new ConcurrentHashMap<>();
+
+    public PlayerManager(PlayerRepository repository) {
+        this.repository = repository;
+    }
+
+    public CompletableFuture<PlayerProfile> loadProfile(UUID uuid, String playerName) {
+        return repository.findProfileByUUID(uuid).thenApply(optional -> {
+            PlayerProfile profile = optional.orElseGet(() -> new PlayerProfile(uuid, playerName));
+            profile.setPlayerName(playerName);
+            profile.setLastLogin(Instant.now());
+            cache.put(uuid, profile);
+            return profile;
+        });
+    }
+
+    public Optional<PlayerProfile> getProfile(UUID uuid) {
+        return Optional.ofNullable(cache.get(uuid));
+    }
+
+    public CompletableFuture<Void> saveProfile(UUID uuid) {
+        PlayerProfile profile = cache.get(uuid);
+        if (profile == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return repository.saveProfile(profile);
+    }
+
+    public CompletableFuture<Void> unloadProfile(UUID uuid) {
+        PlayerProfile profile = cache.remove(uuid);
+        if (profile == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        profile.setLastLogin(Instant.now());
+        return repository.saveProfile(profile);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/player/model/PlayerProfile.java
+++ b/src/main/java/fr/heneria/nexus/player/model/PlayerProfile.java
@@ -1,0 +1,84 @@
+package fr.heneria.nexus.player.model;
+
+import fr.heneria.nexus.player.rank.PlayerRank;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class PlayerProfile {
+    private final UUID playerId;
+    private String playerName;
+    private int eloRating;
+    private PlayerRank rank;
+    private long points;
+    private final Instant firstLogin;
+    private Instant lastLogin;
+
+    public PlayerProfile(UUID playerId, String playerName) {
+        this.playerId = playerId;
+        this.playerName = playerName;
+        this.eloRating = 1000;
+        this.rank = PlayerRank.UNRANKED;
+        this.points = 0;
+        this.firstLogin = Instant.now();
+        this.lastLogin = this.firstLogin;
+    }
+
+    public PlayerProfile(UUID playerId, String playerName, int eloRating, PlayerRank rank, long points, Instant firstLogin, Instant lastLogin) {
+        this.playerId = playerId;
+        this.playerName = playerName;
+        this.eloRating = eloRating;
+        this.rank = rank;
+        this.points = points;
+        this.firstLogin = firstLogin;
+        this.lastLogin = lastLogin;
+    }
+
+    public UUID getPlayerId() {
+        return playerId;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+
+    public int getEloRating() {
+        return eloRating;
+    }
+
+    public void setEloRating(int eloRating) {
+        this.eloRating = eloRating;
+    }
+
+    public PlayerRank getRank() {
+        return rank;
+    }
+
+    public void setRank(PlayerRank rank) {
+        this.rank = rank;
+    }
+
+    public long getPoints() {
+        return points;
+    }
+
+    public void setPoints(long points) {
+        this.points = points;
+    }
+
+    public Instant getFirstLogin() {
+        return firstLogin;
+    }
+
+    public Instant getLastLogin() {
+        return lastLogin;
+    }
+
+    public void setLastLogin(Instant lastLogin) {
+        this.lastLogin = lastLogin;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/player/rank/PlayerRank.java
+++ b/src/main/java/fr/heneria/nexus/player/rank/PlayerRank.java
@@ -1,0 +1,5 @@
+package fr.heneria.nexus.player.rank;
+
+public enum PlayerRank {
+    UNRANKED, BRONZE, SILVER, GOLD, PLATINUM, DIAMOND, MASTER, GRANDMASTER, CHAMPION
+}

--- a/src/main/java/fr/heneria/nexus/player/repository/JdbcPlayerRepository.java
+++ b/src/main/java/fr/heneria/nexus/player/repository/JdbcPlayerRepository.java
@@ -1,0 +1,68 @@
+package fr.heneria.nexus.player.repository;
+
+import fr.heneria.nexus.player.model.PlayerProfile;
+import fr.heneria.nexus.player.rank.PlayerRank;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class JdbcPlayerRepository implements PlayerRepository {
+
+    private final DataSource dataSource;
+
+    public JdbcPlayerRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public CompletableFuture<Optional<PlayerProfile>> findProfileByUUID(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT player_uuid, player_name, elo_rating, current_rank, total_points, first_login, last_login FROM player_profiles WHERE player_uuid = ?";
+            try (Connection connection = dataSource.getConnection();
+                 PreparedStatement stmt = connection.prepareStatement(sql)) {
+                stmt.setString(1, uuid.toString());
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) {
+                        String playerName = rs.getString("player_name");
+                        int elo = rs.getInt("elo_rating");
+                        PlayerRank rank = PlayerRank.valueOf(rs.getString("current_rank"));
+                        long points = rs.getLong("total_points");
+                        Timestamp firstLoginTs = rs.getTimestamp("first_login");
+                        Timestamp lastLoginTs = rs.getTimestamp("last_login");
+                        Instant firstLogin = firstLoginTs != null ? firstLoginTs.toInstant() : Instant.now();
+                        Instant lastLogin = lastLoginTs != null ? lastLoginTs.toInstant() : Instant.now();
+                        PlayerProfile profile = new PlayerProfile(uuid, playerName, elo, rank, points, firstLogin, lastLogin);
+                        return Optional.of(profile);
+                    }
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+            return Optional.empty();
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> saveProfile(PlayerProfile profile) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO player_profiles (player_uuid, player_name, elo_rating, current_rank, total_points, first_login, last_login) VALUES (?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE player_name = VALUES(player_name), elo_rating = VALUES(elo_rating), current_rank = VALUES(current_rank), total_points = VALUES(total_points), last_login = VALUES(last_login)";
+            try (Connection connection = dataSource.getConnection();
+                 PreparedStatement stmt = connection.prepareStatement(sql)) {
+                stmt.setString(1, profile.getPlayerId().toString());
+                stmt.setString(2, profile.getPlayerName());
+                stmt.setInt(3, profile.getEloRating());
+                stmt.setString(4, profile.getRank().name());
+                stmt.setLong(5, profile.getPoints());
+                stmt.setTimestamp(6, Timestamp.from(profile.getFirstLogin()));
+                stmt.setTimestamp(7, Timestamp.from(profile.getLastLogin()));
+                stmt.executeUpdate();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/src/main/java/fr/heneria/nexus/player/repository/PlayerRepository.java
+++ b/src/main/java/fr/heneria/nexus/player/repository/PlayerRepository.java
@@ -1,0 +1,12 @@
+package fr.heneria.nexus.player.repository;
+
+import fr.heneria.nexus.player.model.PlayerProfile;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public interface PlayerRepository {
+    CompletableFuture<Optional<PlayerProfile>> findProfileByUUID(UUID uuid);
+    CompletableFuture<Void> saveProfile(PlayerProfile profile);
+}


### PR DESCRIPTION
## Summary
- implement player rank and profile models
- add JDBC repository and manager for asynchronous profile caching
- listen to player connections and integrate into main plugin

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdec15651483248b42a0da9ec2988a