### PR TITLE
Fix: Implémenter la persistance des transactions dans EconomyManager

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -47,7 +47,7 @@ public final class Nexus extends JavaPlugin {
 
             this.arenaManager = new ArenaManager(new JdbcArenaRepository(this.dataSourceProvider.getDataSource()));
             this.playerManager = new PlayerManager(playerRepository);
-            this.economyManager = new EconomyManager(this.playerManager);
+            this.economyManager = new EconomyManager(this.playerManager, this.dataSourceProvider.getDataSource());
 
             this.arenaManager.loadArenas();
             getLogger().info(this.arenaManager.getAllArenas().size() + " arène(s) chargée(s).");


### PR DESCRIPTION
## Summary
- persist economy transactions by logging each balance change in `economy_transactions`
- inject `DataSource` into `EconomyManager` and wire it from `Nexus`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2132d68c83249e8eb1b5e9a0557c