### PR TITLE
feat: add admin control center GUI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@
 ```
 Presentation Layer/
 ├── commands/           # Commandes admin et joueur
-│   ├── ArenaCommand.java
+│   ├── NexusAdminCommand.java
 │   ├── GameCommand.java
 │   └── PlayerCommand.java
 ├── listeners/          # Event handlers Bukkit

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ src/main/java/fr/heneria/nexus/
 ├── db/                         # Couche base de données
 │   └── HikariDataSourceProvider.java
 └── command/                    # Commandes administratives
-    └── ArenaCommand.java
+    └── NexusAdminCommand.java
 ```
 
 ### 📈 Pipeline CI/CD

--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -3,7 +3,7 @@ package fr.heneria.nexus;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.repository.ArenaRepository;
 import fr.heneria.nexus.arena.repository.JdbcArenaRepository;
-import fr.heneria.nexus.command.ArenaCommand;
+import fr.heneria.nexus.command.NexusAdminCommand;
 import fr.heneria.nexus.db.HikariDataSourceProvider;
 import fr.heneria.nexus.listener.PlayerConnectionListener;
 import fr.heneria.nexus.player.manager.PlayerManager;
@@ -52,7 +52,7 @@ public final class Nexus extends JavaPlugin {
             this.arenaManager.loadArenas();
             getLogger().info(this.arenaManager.getAllArenas().size() + " arène(s) chargée(s).");
 
-            getCommand("nx").setExecutor(new ArenaCommand(this.arenaManager));
+            getCommand("nx").setExecutor(new NexusAdminCommand(this.arenaManager));
             // CORRECTION: L'instance du plugin (this) est maintenant passée au listener
             getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this), this);
 

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.command;
 
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.gui.admin.AdminMenuGui;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -10,17 +11,39 @@ import org.bukkit.entity.Player;
 
 import java.util.stream.Collectors;
 
-public class ArenaCommand implements CommandExecutor {
+/**
+ * Commande principale d'administration de Nexus.
+ * <p>
+ * /nx ou /nx admin ouvre le centre de contrôle si le joueur a la permission
+ * "nexus.admin". Les anciennes sous-commandes /nx arena sont conservées pour
+ * le moment.
+ */
+public class NexusAdminCommand implements CommandExecutor {
 
     private final ArenaManager arenaManager;
 
-    public ArenaCommand(ArenaManager arenaManager) {
+    public NexusAdminCommand(ArenaManager arenaManager) {
         this.arenaManager = arenaManager;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (args.length == 0 || !"arena".equalsIgnoreCase(args[0])) {
+        // Ouvre le GUI principal pour /nx ou /nx admin
+        if (args.length == 0 || "admin".equalsIgnoreCase(args[0])) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+                return true;
+            }
+            if (!sender.hasPermission("nexus.admin")) {
+                sender.sendMessage("Vous n'avez pas la permission nécessaire.");
+                return true;
+            }
+            new AdminMenuGui(arenaManager).open((Player) sender);
+            return true;
+        }
+
+        // Anciennes sous-commandes pour la gestion des arènes
+        if (!"arena".equalsIgnoreCase(args[0])) {
             sender.sendMessage("Usage: /" + label + " arena <create|list|setspawn|save>");
             return true;
         }

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -1,0 +1,49 @@
+package fr.heneria.nexus.gui.admin;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Menu principal du centre de contrôle Nexus.
+ */
+public class AdminMenuGui {
+
+    private final ArenaManager arenaManager;
+
+    public AdminMenuGui(ArenaManager arenaManager) {
+        this.arenaManager = arenaManager;
+    }
+
+    /**
+     * Ouvre le GUI du menu principal pour le joueur donné.
+     *
+     * @param player joueur à qui ouvrir l'interface
+     */
+    public void open(Player player) {
+        Gui gui = Gui.gui()
+                .title(Component.text("Centre de Contrôle Nexus"))
+                .rows(3)
+                .create();
+
+        // Empêche la récupération des items
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        GuiItem arenaManagement = ItemBuilder.from(Material.GRASS_BLOCK)
+                .name(Component.text("Gestion des Arènes", NamedTextColor.GREEN))
+                .lore(Component.text("Configurer et gérer les arènes"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ArenaListGui(arenaManager).open((Player) event.getWhoClicked());
+                });
+
+        // Place l'item au centre
+        gui.setItem(13, arenaManagement);
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
@@ -1,0 +1,67 @@
+package fr.heneria.nexus.gui.admin;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+/**
+ * Interface listant toutes les arènes chargées.
+ */
+public class ArenaListGui {
+
+    private final ArenaManager arenaManager;
+
+    public ArenaListGui(ArenaManager arenaManager) {
+        this.arenaManager = arenaManager;
+    }
+
+    /**
+     * Ouvre l'interface listant les arènes.
+     *
+     * @param player joueur à qui ouvrir l'interface
+     */
+    public void open(Player player) {
+        int arenaCount = arenaManager.getAllArenas().size();
+        int rows = Math.min(6, Math.max(1, (int) Math.ceil((arenaCount + 1) / 9.0)));
+
+        Gui gui = Gui.gui()
+                .title(Component.text("Gestion des Arènes"))
+                .rows(rows)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        for (Arena arena : arenaManager.getAllArenas()) {
+            int spawnCount = arena.getSpawns().values().stream().mapToInt(Map::size).sum();
+            GuiItem item = ItemBuilder.from(Material.PAPER)
+                    .name(Component.text(arena.getName()))
+                    .lore(
+                            Component.text("Joueurs max: " + arena.getMaxPlayers()),
+                            Component.text("Spawns définis: " + spawnCount)
+                    )
+                    .asGuiItem(event -> {
+                        event.setCancelled(true);
+                        ((Player) event.getWhoClicked()).sendMessage("Fonctionnalité à venir");
+                    });
+            gui.addItem(item);
+        }
+
+        GuiItem create = ItemBuilder.from(Material.NETHER_STAR)
+                .name(Component.text("Créer une nouvelle arène", NamedTextColor.AQUA))
+                .lore(Component.text("Fonctionnalité à venir"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    ((Player) event.getWhoClicked()).sendMessage("Utilisez /nx arena create <nom> <joueurs>");
+                });
+        gui.addItem(create);
+
+        gui.open(player);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,5 +7,10 @@ description: Plugin principal pour le mode de jeu Nexus sur le serveur Heneria.
 softdepend: [PlaceholderAPI]
 commands:
   nx:
-    description: Commandes administratives de Nexus
-    usage: /nx arena <subcommand>
+    description: Centre de contrôle de Nexus
+    usage: /nx
+    permission: nexus.admin
+permissions:
+  nexus.admin:
+    description: Accès à l'administration de Nexus
+    default: op


### PR DESCRIPTION
## Summary
- replace text-based arena commands with GUI-driven admin command
- add main admin menu and arena list interfaces
- document command rename

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c02883d48c83248e55420b3149a277