### PR TITLE
feat: add arena editor GUI with spawn definition

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -54,7 +54,7 @@ public final class Nexus extends JavaPlugin {
 
             getCommand("nx").setExecutor(new NexusAdminCommand(this.arenaManager));
             // CORRECTION: L'instance du plugin (this) est maintenant passée au listener
-            getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this), this);
+            getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this.arenaManager, this), this);
 
             getLogger().info("✅ Le plugin Nexus a été activé avec succès !");
 

--- a/src/main/java/fr/heneria/nexus/arena/manager/ArenaManager.java
+++ b/src/main/java/fr/heneria/nexus/arena/manager/ArenaManager.java
@@ -5,11 +5,13 @@ import fr.heneria.nexus.arena.repository.ArenaRepository;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ArenaManager {
     private final ArenaRepository arenaRepository;
     private final Map<String, Arena> arenasByName = new ConcurrentHashMap<>();
+    private final Map<UUID, Arena> adminEditingMap = new ConcurrentHashMap<>();
 
     public ArenaManager(ArenaRepository arenaRepository) {
         this.arenaRepository = arenaRepository;
@@ -38,5 +40,17 @@ public class ArenaManager {
 
     public Collection<Arena> getAllArenas() {
         return arenasByName.values();
+    }
+
+    public void setEditingArena(UUID adminId, Arena arena) {
+        adminEditingMap.put(adminId, arena);
+    }
+
+    public void stopEditing(UUID adminId) {
+        adminEditingMap.remove(adminId);
+    }
+
+    public Arena getEditingArena(UUID adminId) {
+        return adminEditingMap.get(adminId);
     }
 }

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -42,14 +42,44 @@ public class NexusAdminCommand implements CommandExecutor {
             return true;
         }
 
+        if ("setspawn".equalsIgnoreCase(args[0])) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+                return true;
+            }
+            if (args.length < 3) {
+                sender.sendMessage("Usage: /" + label + " setspawn <équipe> <numéroSpawn>");
+                return true;
+            }
+            int teamId;
+            int spawnNumber;
+            try {
+                teamId = Integer.parseInt(args[1]);
+                spawnNumber = Integer.parseInt(args[2]);
+            } catch (NumberFormatException e) {
+                sender.sendMessage("Équipe et numéro de spawn doivent être des nombres.");
+                return true;
+            }
+            Player player = (Player) sender;
+            Arena arena = arenaManager.getEditingArena(player.getUniqueId());
+            if (arena == null) {
+                sender.sendMessage("Aucune arène en cours d'édition.");
+                return true;
+            }
+            Location loc = player.getLocation();
+            arena.setSpawn(teamId, spawnNumber, loc);
+            sender.sendMessage("Spawn défini pour l'arène " + arena.getName() + ".");
+            return true;
+        }
+
         // Anciennes sous-commandes pour la gestion des arènes
         if (!"arena".equalsIgnoreCase(args[0])) {
-            sender.sendMessage("Usage: /" + label + " arena <create|list|setspawn|save>");
+            sender.sendMessage("Usage: /" + label + " arena <create|list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage("Usage: /" + label + " arena <create|list|setspawn|save>");
+            sender.sendMessage("Usage: /" + label + " arena <create|list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
             return true;
         }
 
@@ -76,33 +106,6 @@ public class NexusAdminCommand implements CommandExecutor {
                         .map(Arena::getName)
                         .collect(Collectors.joining(", "));
                 sender.sendMessage("Arènes: " + arenas);
-                return true;
-            case "setspawn":
-                if (!(sender instanceof Player)) {
-                    sender.sendMessage("Cette commande doit être exécutée par un joueur.");
-                    return true;
-                }
-                if (args.length < 5) {
-                    sender.sendMessage("Usage: /" + label + " arena setspawn <nomArène> <équipe> <numéroSpawn>");
-                    return true;
-                }
-                Arena arena = arenaManager.getArena(args[2]);
-                if (arena == null) {
-                    sender.sendMessage("Arène introuvable.");
-                    return true;
-                }
-                int teamId;
-                int spawnNumber;
-                try {
-                    teamId = Integer.parseInt(args[3]);
-                    spawnNumber = Integer.parseInt(args[4]);
-                } catch (NumberFormatException e) {
-                    sender.sendMessage("Équipe et numéro de spawn doivent être des nombres.");
-                    return true;
-                }
-                Location loc = ((Player) sender).getLocation();
-                arena.setSpawn(teamId, spawnNumber, loc);
-                sender.sendMessage("Spawn défini pour l'arène " + arena.getName() + ".");
                 return true;
             case "save":
                 if (args.length < 3) {

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
@@ -1,0 +1,87 @@
+package fr.heneria.nexus.gui.admin;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * Interface d'édition d'une arène spécifique.
+ */
+public class ArenaEditorGui {
+
+    private final ArenaManager arenaManager;
+    private final Arena arena;
+
+    public ArenaEditorGui(ArenaManager arenaManager, Arena arena) {
+        this.arenaManager = arenaManager;
+        this.arena = arena;
+    }
+
+    /**
+     * Ouvre le GUI d'édition pour le joueur donné.
+     *
+     * @param player joueur à qui ouvrir l'interface
+     */
+    public void open(Player player) {
+        Component title = Component.text("Édition: ", NamedTextColor.DARK_GRAY)
+                .append(Component.text(arena.getName(), NamedTextColor.RED));
+
+        Gui gui = Gui.gui()
+                .title(title)
+                .rows(3)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+        gui.setCloseGuiAction(event -> arenaManager.stopEditing(player.getUniqueId()));
+
+        GuiItem info = ItemBuilder.from(Material.PAPER)
+                .name(Component.text("Informations", NamedTextColor.YELLOW))
+                .lore(
+                        Component.text("Nom: " + arena.getName()),
+                        Component.text("Joueurs max: " + arena.getMaxPlayers())
+                )
+                .asGuiItem();
+
+        GuiItem setSpawns = ItemBuilder.from(Material.ARMOR_STAND)
+                .name(Component.text("Définir les spawns", NamedTextColor.YELLOW))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    event.getGui().setCloseGuiAction(closeEvent -> {});
+                    p.closeInventory();
+                    p.sendMessage("§6[Nexus] §fMode édition des spawns pour l'arène '§e" + arena.getName() + "§f'.");
+                    p.sendMessage("§71. Placez-vous à l'emplacement souhaité.");
+                    p.sendMessage("§72. Tapez la commande: §c/nx setspawn <teamId> <spawnNum>");
+                    p.sendMessage("§7Exemple: §c/nx setspawn 1 1 §7pour le premier spawn de l'équipe 1.");
+                });
+
+        GuiItem save = ItemBuilder.from(Material.ANVIL)
+                .name(Component.text("Sauvegarder l'arène", NamedTextColor.DARK_GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    arenaManager.saveArena(arena);
+                    ((Player) event.getWhoClicked()).sendMessage("Arène sauvegardée.");
+                });
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ArenaListGui(arenaManager).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(13, info);
+        gui.setItem(11, setSpawns);
+        gui.setItem(15, save);
+        gui.setItem(26, back);
+
+        arenaManager.setEditingArena(player.getUniqueId(), arena);
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
@@ -48,7 +48,7 @@ public class ArenaListGui {
                     )
                     .asGuiItem(event -> {
                         event.setCancelled(true);
-                        ((Player) event.getWhoClicked()).sendMessage("Fonctionnalité à venir");
+                        new ArenaEditorGui(arenaManager, arena).open((Player) event.getWhoClicked());
                     });
             gui.addItem(item);
         }

--- a/src/main/java/fr/heneria/nexus/listener/PlayerConnectionListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/PlayerConnectionListener.java
@@ -1,6 +1,7 @@
 package fr.heneria.nexus.listener;
 
 import fr.heneria.nexus.player.manager.PlayerManager;
+import fr.heneria.nexus.arena.manager.ArenaManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
@@ -10,11 +11,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class PlayerConnectionListener implements Listener {
 
     private final PlayerManager playerManager;
+    private final ArenaManager arenaManager;
     private final JavaPlugin plugin; // CORRECTION: Ajout du champ pour le plugin
 
     // CORRECTION: Le constructeur accepte maintenant le plugin
-    public PlayerConnectionListener(PlayerManager playerManager, JavaPlugin plugin) {
+    public PlayerConnectionListener(PlayerManager playerManager, ArenaManager arenaManager, JavaPlugin plugin) {
         this.playerManager = playerManager;
+        this.arenaManager = arenaManager;
         this.plugin = plugin;
     }
 
@@ -28,5 +31,6 @@ public class PlayerConnectionListener implements Listener {
     public void onQuit(PlayerQuitEvent event) {
         plugin.getLogger().info("Sauvegarde du profil pour " + event.getPlayer().getName() + "...");
         playerManager.unloadPlayerProfile(event.getPlayer().getUniqueId());
+        arenaManager.stopEditing(event.getPlayer().getUniqueId());
     }
 }


### PR DESCRIPTION
## Summary
- make arena list items open a dedicated editor GUI
- add arena editor GUI with info, spawn setup instructions, save and back actions
- enable /nx setspawn to target the arena currently being edited

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c02edc37d8832481ad5c3ceb15c54f