### PR TITLE
feat: add chat-based arena creation

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -6,10 +6,12 @@ import fr.heneria.nexus.arena.repository.JdbcArenaRepository;
 import fr.heneria.nexus.command.NexusAdminCommand;
 import fr.heneria.nexus.db.HikariDataSourceProvider;
 import fr.heneria.nexus.listener.PlayerConnectionListener;
+import fr.heneria.nexus.listener.AdminConversationListener;
 import fr.heneria.nexus.player.manager.PlayerManager;
 import fr.heneria.nexus.player.repository.JdbcPlayerRepository;
 import fr.heneria.nexus.player.repository.PlayerRepository;
 import fr.heneria.nexus.economy.manager.EconomyManager;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
@@ -49,12 +51,14 @@ public final class Nexus extends JavaPlugin {
             this.playerManager = new PlayerManager(playerRepository);
             this.economyManager = new EconomyManager(this.playerManager, this.dataSourceProvider.getDataSource());
 
+            AdminConversationManager.init(this.arenaManager, this);
             this.arenaManager.loadArenas();
             getLogger().info(this.arenaManager.getAllArenas().size() + " arène(s) chargée(s).");
 
             getCommand("nx").setExecutor(new NexusAdminCommand(this.arenaManager));
             // CORRECTION: L'instance du plugin (this) est maintenant passée au listener
             getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this.arenaManager, this), this);
+            getServer().getPluginManager().registerEvents(new AdminConversationListener(AdminConversationManager.getInstance(), this), this);
 
             getLogger().info("✅ Le plugin Nexus a été activé avec succès !");
 

--- a/src/main/java/fr/heneria/nexus/admin/conversation/AdminConversationManager.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/AdminConversationManager.java
@@ -1,0 +1,121 @@
+package fr.heneria.nexus.admin.conversation;
+
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.gui.admin.ArenaListGui;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Gère les conversations de création d'arène pour les administrateurs.
+ */
+public class AdminConversationManager {
+
+    private static AdminConversationManager instance;
+
+    public static void init(ArenaManager arenaManager, JavaPlugin plugin) {
+        instance = new AdminConversationManager(arenaManager, plugin);
+    }
+
+    public static AdminConversationManager getInstance() {
+        return instance;
+    }
+
+    private final ArenaManager arenaManager;
+    private final JavaPlugin plugin;
+    private final Map<UUID, ArenaCreationConversation> conversations = new ConcurrentHashMap<>();
+
+    private AdminConversationManager(ArenaManager arenaManager, JavaPlugin plugin) {
+        this.arenaManager = arenaManager;
+        this.plugin = plugin;
+    }
+
+    /**
+     * Démarre une nouvelle conversation de création d'arène pour l'admin donné.
+     */
+    public void startConversation(Player admin) {
+        UUID id = admin.getUniqueId();
+        if (conversations.containsKey(id)) {
+            admin.sendMessage("Une conversation est déjà en cours.");
+            return;
+        }
+
+        ArenaCreationConversation conversation = new ArenaCreationConversation(id);
+        conversations.put(id, conversation);
+        admin.sendMessage("Entrez le nom de la nouvelle arène (ou 'annuler').");
+
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (conversations.containsKey(id)) {
+                admin.sendMessage("Création d'arène annulée (timeout).");
+                cancelConversation(admin);
+                new ArenaListGui(arenaManager, this).open(admin);
+            }
+        }, 5 * 60 * 20L); // 5 minutes
+    }
+
+    /**
+     * Traite une réponse envoyée par l'administrateur.
+     */
+    public void handleResponse(Player admin, String message) {
+        UUID id = admin.getUniqueId();
+        ArenaCreationConversation conversation = conversations.get(id);
+        if (conversation == null) {
+            return;
+        }
+
+        if ("annuler".equalsIgnoreCase(message)) {
+            admin.sendMessage("Création d'arène annulée.");
+            cancelConversation(admin);
+            new ArenaListGui(arenaManager, this).open(admin);
+            return;
+        }
+
+        switch (conversation.getCurrentStep()) {
+            case AWAITING_ARENA_NAME:
+                if (arenaManager.getArena(message) != null) {
+                    admin.sendMessage("Ce nom d'arène est déjà utilisé. Essayez encore.");
+                    return;
+                }
+                conversation.setArenaName(message);
+                conversation.setCurrentStep(ConversationStep.AWAITING_MAX_PLAYERS);
+                admin.sendMessage("Entrez le nombre maximum de joueurs.");
+                break;
+            case AWAITING_MAX_PLAYERS:
+                int maxPlayers;
+                try {
+                    maxPlayers = Integer.parseInt(message);
+                    if (maxPlayers <= 0) {
+                        admin.sendMessage("Le nombre doit être un entier positif. Réessayez.");
+                        return;
+                    }
+                } catch (NumberFormatException e) {
+                    admin.sendMessage("Le nombre doit être un entier positif. Réessayez.");
+                    return;
+                }
+                conversation.setMaxPlayers(maxPlayers);
+                arenaManager.createArena(conversation.getArenaName(), conversation.getMaxPlayers());
+                admin.sendMessage("Arène créée avec succès.");
+                cancelConversation(admin);
+                new ArenaListGui(arenaManager, this).open(admin);
+                break;
+        }
+    }
+
+    /**
+     * Annule la conversation pour l'administrateur donné.
+     */
+    public void cancelConversation(Player admin) {
+        conversations.remove(admin.getUniqueId());
+    }
+
+    /**
+     * Vérifie si un joueur est actuellement dans une conversation.
+     */
+    public boolean isInConversation(Player admin) {
+        return conversations.containsKey(admin.getUniqueId());
+    }
+}

--- a/src/main/java/fr/heneria/nexus/admin/conversation/ArenaCreationConversation.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/ArenaCreationConversation.java
@@ -1,0 +1,47 @@
+package fr.heneria.nexus.admin.conversation;
+
+import java.util.UUID;
+
+/**
+ * Représente l'état d'une conversation de création d'arène.
+ */
+public class ArenaCreationConversation {
+
+    private final UUID adminId;
+    private ConversationStep currentStep;
+    private String arenaName;
+    private int maxPlayers;
+
+    public ArenaCreationConversation(UUID adminId) {
+        this.adminId = adminId;
+        this.currentStep = ConversationStep.AWAITING_ARENA_NAME;
+    }
+
+    public UUID getAdminId() {
+        return adminId;
+    }
+
+    public ConversationStep getCurrentStep() {
+        return currentStep;
+    }
+
+    public void setCurrentStep(ConversationStep currentStep) {
+        this.currentStep = currentStep;
+    }
+
+    public String getArenaName() {
+        return arenaName;
+    }
+
+    public void setArenaName(String arenaName) {
+        this.arenaName = arenaName;
+    }
+
+    public int getMaxPlayers() {
+        return maxPlayers;
+    }
+
+    public void setMaxPlayers(int maxPlayers) {
+        this.maxPlayers = maxPlayers;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/admin/conversation/ConversationStep.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/ConversationStep.java
@@ -1,0 +1,9 @@
+package fr.heneria.nexus.admin.conversation;
+
+/**
+ * Étapes possibles pour la création d'une arène via conversation.
+ */
+public enum ConversationStep {
+    AWAITING_ARENA_NAME,
+    AWAITING_MAX_PLAYERS
+}

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -74,33 +74,17 @@ public class NexusAdminCommand implements CommandExecutor {
 
         // Anciennes sous-commandes pour la gestion des arènes
         if (!"arena".equalsIgnoreCase(args[0])) {
-            sender.sendMessage("Usage: /" + label + " arena <create|list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
+            sender.sendMessage("Usage: /" + label + " arena <list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage("Usage: /" + label + " arena <create|list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
+            sender.sendMessage("Usage: /" + label + " arena <list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
             return true;
         }
 
         String sub = args[1].toLowerCase();
         switch (sub) {
-            case "create":
-                if (args.length < 4) {
-                    sender.sendMessage("Usage: /" + label + " arena create <nom> <maxJoueurs>");
-                    return true;
-                }
-                String name = args[2];
-                int maxPlayers;
-                try {
-                    maxPlayers = Integer.parseInt(args[3]);
-                } catch (NumberFormatException e) {
-                    sender.sendMessage("maxJoueurs doit être un nombre");
-                    return true;
-                }
-                arenaManager.createArena(name, maxPlayers);
-                sender.sendMessage("Arène " + name + " créée en mémoire. N'oubliez pas de la sauvegarder.");
-                return true;
             case "list":
                 String arenas = arenaManager.getAllArenas().stream()
                         .map(Arena::getName)

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -8,6 +8,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 
 /**
  * Menu principal du centre de contrôle Nexus.
@@ -39,7 +40,7 @@ public class AdminMenuGui {
                 .lore(Component.text("Configurer et gérer les arènes"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    new ArenaListGui(arenaManager).open((Player) event.getWhoClicked());
+                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
                 });
 
         // Place l'item au centre

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
@@ -5,6 +5,7 @@ import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -73,7 +74,7 @@ public class ArenaEditorGui {
                 .name(Component.text("Retour", NamedTextColor.RED))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    new ArenaListGui(arenaManager).open((Player) event.getWhoClicked());
+                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
                 });
 
         gui.setItem(13, info);

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
@@ -5,6 +5,7 @@ import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -18,9 +19,11 @@ import java.util.Map;
 public class ArenaListGui {
 
     private final ArenaManager arenaManager;
+    private final AdminConversationManager adminConversationManager;
 
-    public ArenaListGui(ArenaManager arenaManager) {
+    public ArenaListGui(ArenaManager arenaManager, AdminConversationManager adminConversationManager) {
         this.arenaManager = arenaManager;
+        this.adminConversationManager = adminConversationManager;
     }
 
     /**
@@ -55,10 +58,12 @@ public class ArenaListGui {
 
         GuiItem create = ItemBuilder.from(Material.NETHER_STAR)
                 .name(Component.text("Créer une nouvelle arène", NamedTextColor.AQUA))
-                .lore(Component.text("Fonctionnalité à venir"))
+                .lore(Component.text("Démarre une conversation"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    ((Player) event.getWhoClicked()).sendMessage("Utilisez /nx arena create <nom> <joueurs>");
+                    Player p = (Player) event.getWhoClicked();
+                    p.closeInventory();
+                    adminConversationManager.startConversation(p);
                 });
         gui.addItem(create);
 

--- a/src/main/java/fr/heneria/nexus/listener/AdminConversationListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/AdminConversationListener.java
@@ -1,0 +1,35 @@
+package fr.heneria.nexus.listener;
+
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Intercepte les messages de chat des administrateurs en conversation.
+ */
+public class AdminConversationListener implements Listener {
+
+    private final AdminConversationManager conversationManager;
+    private final JavaPlugin plugin;
+
+    public AdminConversationListener(AdminConversationManager conversationManager, JavaPlugin plugin) {
+        this.conversationManager = conversationManager;
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onChat(AsyncPlayerChatEvent event) {
+        Player player = event.getPlayer();
+        if (!conversationManager.isInConversation(player)) {
+            return;
+        }
+
+        event.setCancelled(true);
+        String message = event.getMessage();
+        Bukkit.getScheduler().runTask(plugin, () -> conversationManager.handleResponse(player, message));
+    }
+}


### PR DESCRIPTION
## Summary
- add conversation framework for arena creation via chat
- start arena creation flow from admin GUI instead of command
- remove `/nx arena create` subcommand and register chat listener

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c03181f2a48324a5e91276abd226d3