### PR TITLE
feat(admin-gui): arena deletion, teleportation and spawn GUI

### DIFF
--- a/src/main/java/fr/heneria/nexus/arena/manager/ArenaManager.java
+++ b/src/main/java/fr/heneria/nexus/arena/manager/ArenaManager.java
@@ -34,6 +34,11 @@ public class ArenaManager {
         arenaRepository.saveSpawns(arena);
     }
 
+    public void deleteArena(Arena arena) {
+        arenasByName.remove(arena.getName());
+        arenaRepository.deleteArena(arena);
+    }
+
     public Arena getArena(String name) {
         return arenasByName.get(name);
     }

--- a/src/main/java/fr/heneria/nexus/arena/repository/ArenaRepository.java
+++ b/src/main/java/fr/heneria/nexus/arena/repository/ArenaRepository.java
@@ -14,4 +14,6 @@ public interface ArenaRepository {
     Map<Integer, Arena> loadAllArenas();
     // Trouve une arène par son nom.
     Optional<Arena> findArenaByName(String name);
+    // Supprime une arène existante.
+    void deleteArena(Arena arena);
 }

--- a/src/main/java/fr/heneria/nexus/arena/repository/JdbcArenaRepository.java
+++ b/src/main/java/fr/heneria/nexus/arena/repository/JdbcArenaRepository.java
@@ -162,4 +162,16 @@ public class JdbcArenaRepository implements ArenaRepository {
         }
         return Optional.empty();
     }
+
+    @Override
+    public void deleteArena(Arena arena) {
+        String sql = "DELETE FROM arenas WHERE id = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setInt(1, arena.getId());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaSpawnManagerGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaSpawnManagerGui.java
@@ -1,0 +1,91 @@
+package fr.heneria.nexus.gui.admin;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * GUI permettant de visualiser et de gérer les spawns d'une arène.
+ */
+public class ArenaSpawnManagerGui {
+
+    private final ArenaManager arenaManager;
+    private final Arena arena;
+
+    public ArenaSpawnManagerGui(ArenaManager arenaManager, Arena arena) {
+        this.arenaManager = arenaManager;
+        this.arena = arena;
+    }
+
+    public void open(Player player) {
+        Component title = Component.text("Gestion des Spawns: ", NamedTextColor.GOLD)
+                .append(Component.text(arena.getName(), NamedTextColor.YELLOW));
+
+        int playersPerTeam = Math.max(1, arena.getMaxPlayers() / 2);
+        int totalSpawns = playersPerTeam * 2;
+        int rows = Math.min(5, Math.max(4, (int) Math.ceil((totalSpawns + 1) / 9.0)));
+
+        Gui gui = Gui.gui()
+                .title(title)
+                .rows(rows)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+        gui.setCloseGuiAction(event -> {});
+
+        for (int teamId = 1; teamId <= 2; teamId++) {
+            for (int spawn = 1; spawn <= playersPerTeam; spawn++) {
+                Map<Integer, Location> teamSpawns = arena.getSpawns().getOrDefault(teamId, Collections.emptyMap());
+                Location loc = teamSpawns.get(spawn);
+
+                ItemBuilder builder = ItemBuilder.from(loc == null ? Material.RED_STAINED_GLASS_PANE : Material.LIME_STAINED_GLASS_PANE)
+                        .name(Component.text("Équipe " + teamId + " - Spawn " + spawn, NamedTextColor.YELLOW));
+
+                if (loc == null) {
+                    builder.lore(Component.text("Statut: Non défini", NamedTextColor.RED));
+                } else {
+                    builder.lore(
+                            Component.text("Statut: Défini", NamedTextColor.GREEN),
+                            Component.text("Monde: " + loc.getWorld().getName(), NamedTextColor.GRAY),
+                            Component.text(String.format("X: %.2f, Y: %.2f, Z: %.2f", loc.getX(), loc.getY(), loc.getZ()), NamedTextColor.GRAY)
+                    );
+                }
+
+                int finalTeamId = teamId;
+                int finalSpawn = spawn;
+                GuiItem item = builder.asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    p.closeInventory();
+                    p.sendMessage("§6[Nexus] §fConfiguration du spawn §e" + finalSpawn + "§f de l'équipe §e" + finalTeamId + "§f pour l'arène '§e" + arena.getName() + "§f'.");
+                    p.sendMessage("§71. Placez-vous à l'emplacement souhaité.");
+                    p.sendMessage("§72. Tapez la commande: §c/nx setspawn " + finalTeamId + " " + finalSpawn);
+                });
+
+                gui.addItem(item);
+            }
+        }
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ArenaEditorGui(arenaManager, arena).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(rows * 9 - 1, back);
+
+        gui.open(player);
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/gui/admin/ConfirmDeleteGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ConfirmDeleteGui.java
@@ -1,0 +1,63 @@
+package fr.heneria.nexus.gui.admin;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * GUI de confirmation de suppression d'une arène.
+ */
+public class ConfirmDeleteGui {
+
+    private final ArenaManager arenaManager;
+    private final Arena arena;
+
+    public ConfirmDeleteGui(ArenaManager arenaManager, Arena arena) {
+        this.arenaManager = arenaManager;
+        this.arena = arena;
+    }
+
+    public void open(Player player) {
+        Component title = Component.text("Confirmer la suppression de ", NamedTextColor.DARK_RED)
+                .append(Component.text(arena.getName(), NamedTextColor.RED))
+                .append(Component.text(" ?", NamedTextColor.DARK_RED));
+
+        Gui gui = Gui.gui()
+                .title(title)
+                .rows(3)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+        gui.setCloseGuiAction(event -> {});
+
+        GuiItem yes = ItemBuilder.from(Material.LIME_CONCRETE)
+                .name(Component.text("OUI, SUPPRIMER", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    arenaManager.deleteArena(arena);
+                    arenaManager.stopEditing(p.getUniqueId());
+                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance()).open(p);
+                });
+
+        GuiItem no = ItemBuilder.from(Material.RED_CONCRETE)
+                .name(Component.text("NON, ANNULER", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ArenaEditorGui(arenaManager, arena).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(12, yes);
+        gui.setItem(14, no);
+
+        gui.open(player);
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow deleting arenas with confirmation GUI
- teleport admins to arena spawn from editor
- manage spawns visually with dedicated GUI

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c037f18aac8324bd9ecf787e00afcc