### PR TITLE
feat: add visual spawn placement mode

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -7,11 +7,13 @@ import fr.heneria.nexus.command.NexusAdminCommand;
 import fr.heneria.nexus.db.HikariDataSourceProvider;
 import fr.heneria.nexus.listener.PlayerConnectionListener;
 import fr.heneria.nexus.listener.AdminConversationListener;
+import fr.heneria.nexus.listener.AdminPlacementListener;
 import fr.heneria.nexus.player.manager.PlayerManager;
 import fr.heneria.nexus.player.repository.JdbcPlayerRepository;
 import fr.heneria.nexus.player.repository.PlayerRepository;
 import fr.heneria.nexus.economy.manager.EconomyManager;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
@@ -52,13 +54,15 @@ public final class Nexus extends JavaPlugin {
             this.economyManager = new EconomyManager(this.playerManager, this.dataSourceProvider.getDataSource());
 
             AdminConversationManager.init(this.arenaManager, this);
+            AdminPlacementManager.init();
             this.arenaManager.loadArenas();
             getLogger().info(this.arenaManager.getAllArenas().size() + " arène(s) chargée(s).");
 
             getCommand("nx").setExecutor(new NexusAdminCommand(this.arenaManager));
             // CORRECTION: L'instance du plugin (this) est maintenant passée au listener
-            getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this.arenaManager, this), this);
+            getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this.arenaManager, AdminPlacementManager.getInstance(), this), this);
             getServer().getPluginManager().registerEvents(new AdminConversationListener(AdminConversationManager.getInstance(), this), this);
+            getServer().getPluginManager().registerEvents(new AdminPlacementListener(AdminPlacementManager.getInstance(), this.arenaManager, this), this);
 
             getLogger().info("✅ Le plugin Nexus a été activé avec succès !");
 

--- a/src/main/java/fr/heneria/nexus/admin/conversation/AdminConversationManager.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/AdminConversationManager.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.admin.conversation;
 
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.gui.admin.ArenaListGui;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -52,7 +53,7 @@ public class AdminConversationManager {
             if (conversations.containsKey(id)) {
                 admin.sendMessage("Création d'arène annulée (timeout).");
                 cancelConversation(admin);
-                new ArenaListGui(arenaManager, this).open(admin);
+                new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
             }
         }, 5 * 60 * 20L); // 5 minutes
     }
@@ -70,7 +71,7 @@ public class AdminConversationManager {
         if ("annuler".equalsIgnoreCase(message)) {
             admin.sendMessage("Création d'arène annulée.");
             cancelConversation(admin);
-            new ArenaListGui(arenaManager, this).open(admin);
+            new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
             return;
         }
 
@@ -100,7 +101,7 @@ public class AdminConversationManager {
                 arenaManager.createArena(conversation.getArenaName(), conversation.getMaxPlayers());
                 admin.sendMessage("Arène créée avec succès.");
                 cancelConversation(admin);
-                new ArenaListGui(arenaManager, this).open(admin);
+                new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
                 break;
         }
     }

--- a/src/main/java/fr/heneria/nexus/admin/placement/AdminPlacementManager.java
+++ b/src/main/java/fr/heneria/nexus/admin/placement/AdminPlacementManager.java
@@ -1,0 +1,63 @@
+package fr.heneria.nexus.admin.placement;
+
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Gère les sessions de placement de spawns pour les administrateurs.
+ */
+public class AdminPlacementManager {
+
+    private static AdminPlacementManager instance;
+
+    public static void init() {
+        instance = new AdminPlacementManager();
+    }
+
+    public static AdminPlacementManager getInstance() {
+        return instance;
+    }
+
+    private final Map<UUID, SpawnPlacementContext> placementSessions = new ConcurrentHashMap<>();
+
+    private AdminPlacementManager() {
+    }
+
+    /**
+     * Démarre le mode de placement pour un administrateur.
+     */
+    public void startPlacementMode(Player admin, SpawnPlacementContext context) {
+        placementSessions.put(admin.getUniqueId(), context);
+        admin.sendMessage("§eMode placement activé. Cliquez-gauche sur un bloc pour définir le spawn de l'Équipe "
+                + context.teamId() + ", Spawn " + context.spawnNumber() + ". Clic-droit pour annuler.");
+    }
+
+    /**
+     * Termine le mode de placement pour un administrateur.
+     */
+    public void endPlacementMode(Player admin) {
+        endPlacementMode(admin.getUniqueId());
+    }
+
+    public void endPlacementMode(UUID adminId) {
+        placementSessions.remove(adminId);
+    }
+
+    /**
+     * Récupère le contexte de placement d'un administrateur.
+     */
+    public SpawnPlacementContext getPlacementContext(Player admin) {
+        return placementSessions.get(admin.getUniqueId());
+    }
+
+    /**
+     * Vérifie si un administrateur est en mode de placement.
+     */
+    public boolean isInPlacementMode(Player admin) {
+        return placementSessions.containsKey(admin.getUniqueId());
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/admin/placement/SpawnPlacementContext.java
+++ b/src/main/java/fr/heneria/nexus/admin/placement/SpawnPlacementContext.java
@@ -1,0 +1,10 @@
+package fr.heneria.nexus.admin.placement;
+
+import fr.heneria.nexus.arena.model.Arena;
+
+/**
+ * Contexte de placement pour un point de spawn.
+ */
+public record SpawnPlacementContext(Arena arena, int teamId, int spawnNumber) {
+}
+

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -1,9 +1,9 @@
 package fr.heneria.nexus.command;
 
 import fr.heneria.nexus.arena.manager.ArenaManager;
-import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.gui.admin.AdminMenuGui;
-import org.bukkit.Location;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.arena.model.Arena;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -38,48 +38,18 @@ public class NexusAdminCommand implements CommandExecutor {
                 sender.sendMessage("Vous n'avez pas la permission nécessaire.");
                 return true;
             }
-            new AdminMenuGui(arenaManager).open((Player) sender);
-            return true;
-        }
-
-        if ("setspawn".equalsIgnoreCase(args[0])) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage("Cette commande doit être exécutée par un joueur.");
-                return true;
-            }
-            if (args.length < 3) {
-                sender.sendMessage("Usage: /" + label + " setspawn <équipe> <numéroSpawn>");
-                return true;
-            }
-            int teamId;
-            int spawnNumber;
-            try {
-                teamId = Integer.parseInt(args[1]);
-                spawnNumber = Integer.parseInt(args[2]);
-            } catch (NumberFormatException e) {
-                sender.sendMessage("Équipe et numéro de spawn doivent être des nombres.");
-                return true;
-            }
-            Player player = (Player) sender;
-            Arena arena = arenaManager.getEditingArena(player.getUniqueId());
-            if (arena == null) {
-                sender.sendMessage("Aucune arène en cours d'édition.");
-                return true;
-            }
-            Location loc = player.getLocation();
-            arena.setSpawn(teamId, spawnNumber, loc);
-            sender.sendMessage("Spawn défini pour l'arène " + arena.getName() + ".");
+            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance()).open((Player) sender);
             return true;
         }
 
         // Anciennes sous-commandes pour la gestion des arènes
         if (!"arena".equalsIgnoreCase(args[0])) {
-            sender.sendMessage("Usage: /" + label + " arena <list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
+            sender.sendMessage("Usage: /" + label + " arena <list|save>");
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage("Usage: /" + label + " arena <list|save> | /" + label + " setspawn <équipe> <numéroSpawn>");
+            sender.sendMessage("Usage: /" + label + " arena <list|save>");
             return true;
         }
 

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 
 /**
  * Menu principal du centre de contrôle Nexus.
@@ -16,9 +17,11 @@ import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 public class AdminMenuGui {
 
     private final ArenaManager arenaManager;
+    private final AdminPlacementManager adminPlacementManager;
 
-    public AdminMenuGui(ArenaManager arenaManager) {
+    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager) {
         this.arenaManager = arenaManager;
+        this.adminPlacementManager = adminPlacementManager;
     }
 
     /**
@@ -40,7 +43,7 @@ public class AdminMenuGui {
                 .lore(Component.text("Configurer et gérer les arènes"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
+                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance(), adminPlacementManager).open((Player) event.getWhoClicked());
                 });
 
         // Place l'item au centre

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
@@ -6,6 +6,7 @@ import dev.triumphteam.gui.guis.GuiItem;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import org.bukkit.Location;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -21,10 +22,12 @@ public class ArenaEditorGui {
 
     private final ArenaManager arenaManager;
     private final Arena arena;
+    private final AdminPlacementManager adminPlacementManager;
 
-    public ArenaEditorGui(ArenaManager arenaManager, Arena arena) {
+    public ArenaEditorGui(ArenaManager arenaManager, Arena arena, AdminPlacementManager adminPlacementManager) {
         this.arenaManager = arenaManager;
         this.arena = arena;
+        this.adminPlacementManager = adminPlacementManager;
     }
 
     /**
@@ -59,7 +62,7 @@ public class ArenaEditorGui {
                     event.setCancelled(true);
                     Player p = (Player) event.getWhoClicked();
                     gui.setCloseGuiAction(closeEvent -> {});
-                    new ArenaSpawnManagerGui(arenaManager, arena).open(p);
+                    new ArenaSpawnManagerGui(arenaManager, arena, adminPlacementManager).open(p);
                 });
 
         GuiItem save = ItemBuilder.from(Material.ANVIL)
@@ -97,14 +100,14 @@ public class ArenaEditorGui {
                     event.setCancelled(true);
                     Player p = (Player) event.getWhoClicked();
                     gui.setCloseGuiAction(closeEvent -> {});
-                    new ConfirmDeleteGui(arenaManager, arena).open(p);
+                    new ConfirmDeleteGui(arenaManager, arena, adminPlacementManager).open(p);
                 });
 
         GuiItem back = ItemBuilder.from(Material.BARRIER)
                 .name(Component.text("Retour", NamedTextColor.RED))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
+                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance(), adminPlacementManager).open((Player) event.getWhoClicked());
                 });
 
         gui.setItem(13, info);

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
@@ -6,6 +6,7 @@ import dev.triumphteam.gui.guis.GuiItem;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -20,10 +21,12 @@ public class ArenaListGui {
 
     private final ArenaManager arenaManager;
     private final AdminConversationManager adminConversationManager;
+    private final AdminPlacementManager adminPlacementManager;
 
-    public ArenaListGui(ArenaManager arenaManager, AdminConversationManager adminConversationManager) {
+    public ArenaListGui(ArenaManager arenaManager, AdminConversationManager adminConversationManager, AdminPlacementManager adminPlacementManager) {
         this.arenaManager = arenaManager;
         this.adminConversationManager = adminConversationManager;
+        this.adminPlacementManager = adminPlacementManager;
     }
 
     /**
@@ -51,7 +54,7 @@ public class ArenaListGui {
                     )
                     .asGuiItem(event -> {
                         event.setCancelled(true);
-                        new ArenaEditorGui(arenaManager, arena).open((Player) event.getWhoClicked());
+                        new ArenaEditorGui(arenaManager, arena, adminPlacementManager).open((Player) event.getWhoClicked());
                     });
             gui.addItem(item);
         }

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaSpawnManagerGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaSpawnManagerGui.java
@@ -5,6 +5,9 @@ import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.gui.admin.ArenaEditorGui;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.admin.placement.SpawnPlacementContext;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -21,10 +24,12 @@ public class ArenaSpawnManagerGui {
 
     private final ArenaManager arenaManager;
     private final Arena arena;
+    private final AdminPlacementManager adminPlacementManager;
 
-    public ArenaSpawnManagerGui(ArenaManager arenaManager, Arena arena) {
+    public ArenaSpawnManagerGui(ArenaManager arenaManager, Arena arena, AdminPlacementManager adminPlacementManager) {
         this.arenaManager = arenaManager;
         this.arena = arena;
+        this.adminPlacementManager = adminPlacementManager;
     }
 
     public void open(Player player) {
@@ -67,9 +72,8 @@ public class ArenaSpawnManagerGui {
                     event.setCancelled(true);
                     Player p = (Player) event.getWhoClicked();
                     p.closeInventory();
-                    p.sendMessage("§6[Nexus] §fConfiguration du spawn §e" + finalSpawn + "§f de l'équipe §e" + finalTeamId + "§f pour l'arène '§e" + arena.getName() + "§f'.");
-                    p.sendMessage("§71. Placez-vous à l'emplacement souhaité.");
-                    p.sendMessage("§72. Tapez la commande: §c/nx setspawn " + finalTeamId + " " + finalSpawn);
+                    SpawnPlacementContext context = new SpawnPlacementContext(arena, finalTeamId, finalSpawn);
+                    adminPlacementManager.startPlacementMode(p, context);
                 });
 
                 gui.addItem(item);
@@ -80,7 +84,7 @@ public class ArenaSpawnManagerGui {
                 .name(Component.text("Retour", NamedTextColor.RED))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    new ArenaEditorGui(arenaManager, arena).open((Player) event.getWhoClicked());
+                    new ArenaEditorGui(arenaManager, arena, adminPlacementManager).open((Player) event.getWhoClicked());
                 });
 
         gui.setItem(rows * 9 - 1, back);

--- a/src/main/java/fr/heneria/nexus/gui/admin/ConfirmDeleteGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ConfirmDeleteGui.java
@@ -6,6 +6,7 @@ import dev.triumphteam.gui.guis.GuiItem;
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -18,10 +19,12 @@ public class ConfirmDeleteGui {
 
     private final ArenaManager arenaManager;
     private final Arena arena;
+    private final AdminPlacementManager adminPlacementManager;
 
-    public ConfirmDeleteGui(ArenaManager arenaManager, Arena arena) {
+    public ConfirmDeleteGui(ArenaManager arenaManager, Arena arena, AdminPlacementManager adminPlacementManager) {
         this.arenaManager = arenaManager;
         this.arena = arena;
+        this.adminPlacementManager = adminPlacementManager;
     }
 
     public void open(Player player) {
@@ -44,14 +47,14 @@ public class ConfirmDeleteGui {
                     Player p = (Player) event.getWhoClicked();
                     arenaManager.deleteArena(arena);
                     arenaManager.stopEditing(p.getUniqueId());
-                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance()).open(p);
+                    new ArenaListGui(arenaManager, AdminConversationManager.getInstance(), adminPlacementManager).open(p);
                 });
 
         GuiItem no = ItemBuilder.from(Material.RED_CONCRETE)
                 .name(Component.text("NON, ANNULER", NamedTextColor.RED))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
-                    new ArenaEditorGui(arenaManager, arena).open((Player) event.getWhoClicked());
+                    new ArenaEditorGui(arenaManager, arena, adminPlacementManager).open((Player) event.getWhoClicked());
                 });
 
         gui.setItem(12, yes);

--- a/src/main/java/fr/heneria/nexus/listener/AdminPlacementListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/AdminPlacementListener.java
@@ -1,0 +1,60 @@
+package fr.heneria.nexus.listener;
+
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.admin.placement.SpawnPlacementContext;
+import fr.heneria.nexus.gui.admin.ArenaSpawnManagerGui;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Intercepte les clics des administrateurs en mode de placement.
+ */
+public class AdminPlacementListener implements Listener {
+
+    private final AdminPlacementManager placementManager;
+    private final ArenaManager arenaManager;
+    private final JavaPlugin plugin;
+
+    public AdminPlacementListener(AdminPlacementManager placementManager, ArenaManager arenaManager, JavaPlugin plugin) {
+        this.placementManager = placementManager;
+        this.arenaManager = arenaManager;
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (!placementManager.isInPlacementMode(player)) {
+            return;
+        }
+        event.setCancelled(true);
+        SpawnPlacementContext context = placementManager.getPlacementContext(player);
+        Action action = event.getAction();
+        if (action == Action.LEFT_CLICK_BLOCK && event.getClickedBlock() != null) {
+            Block block = event.getClickedBlock();
+            Location loc = block.getLocation().add(0.5, 1, 0.5);
+            Location playerLoc = player.getLocation();
+            loc.setYaw(playerLoc.getYaw());
+            loc.setPitch(playerLoc.getPitch());
+            context.arena().setSpawn(context.teamId(), context.spawnNumber(), loc);
+            player.sendMessage("§aSpawn défini pour l'équipe §e" + context.teamId() + " §a, spawn §e" + context.spawnNumber() + "§a.");
+            placementManager.endPlacementMode(player);
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    new ArenaSpawnManagerGui(arenaManager, context.arena(), placementManager).open(player));
+        } else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+            player.sendMessage("§cPlacement du spawn annulé.");
+            placementManager.endPlacementMode(player);
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    new ArenaSpawnManagerGui(arenaManager, context.arena(), placementManager).open(player));
+        }
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/listener/PlayerConnectionListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/PlayerConnectionListener.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.listener;
 
 import fr.heneria.nexus.player.manager.PlayerManager;
 import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
@@ -13,11 +14,13 @@ public class PlayerConnectionListener implements Listener {
     private final PlayerManager playerManager;
     private final ArenaManager arenaManager;
     private final JavaPlugin plugin; // CORRECTION: Ajout du champ pour le plugin
+    private final AdminPlacementManager adminPlacementManager;
 
     // CORRECTION: Le constructeur accepte maintenant le plugin
-    public PlayerConnectionListener(PlayerManager playerManager, ArenaManager arenaManager, JavaPlugin plugin) {
+    public PlayerConnectionListener(PlayerManager playerManager, ArenaManager arenaManager, AdminPlacementManager adminPlacementManager, JavaPlugin plugin) {
         this.playerManager = playerManager;
         this.arenaManager = arenaManager;
+        this.adminPlacementManager = adminPlacementManager;
         this.plugin = plugin;
     }
 
@@ -32,5 +35,6 @@ public class PlayerConnectionListener implements Listener {
         plugin.getLogger().info("Sauvegarde du profil pour " + event.getPlayer().getName() + "...");
         playerManager.unloadPlayerProfile(event.getPlayer().getUniqueId());
         arenaManager.stopEditing(event.getPlayer().getUniqueId());
+        adminPlacementManager.endPlacementMode(event.getPlayer());
     }
 }


### PR DESCRIPTION
## Summary
- enable visual spawn placement mode managed via AdminPlacementManager
- add listener for block clicks to confirm or cancel spawn placement
- remove legacy `/nx setspawn` command and reconnect GUI flow

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0398eb6848324a3652756dc4c2d9b