### PR TITLE
feat(shop): add admin shop management

### DIFF
--- a/src/main/java/fr/heneria/nexus/admin/conversation/AdminConversationManager.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/AdminConversationManager.java
@@ -2,7 +2,11 @@ package fr.heneria.nexus.admin.conversation;
 
 import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.gui.admin.ArenaListGui;
+import fr.heneria.nexus.gui.admin.shop.ShopCategoryGui;
 import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.shop.repository.ShopRepository;
+import fr.heneria.nexus.shop.model.ShopItem;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -18,8 +22,8 @@ public class AdminConversationManager {
 
     private static AdminConversationManager instance;
 
-    public static void init(ArenaManager arenaManager, JavaPlugin plugin) {
-        instance = new AdminConversationManager(arenaManager, plugin);
+    public static void init(ArenaManager arenaManager, ShopManager shopManager, ShopRepository shopRepository, JavaPlugin plugin) {
+        instance = new AdminConversationManager(arenaManager, shopManager, shopRepository, plugin);
     }
 
     public static AdminConversationManager getInstance() {
@@ -27,11 +31,16 @@ public class AdminConversationManager {
     }
 
     private final ArenaManager arenaManager;
+    private final ShopManager shopManager;
+    private final ShopRepository shopRepository;
     private final JavaPlugin plugin;
     private final Map<UUID, ArenaCreationConversation> conversations = new ConcurrentHashMap<>();
+    private final Map<UUID, PriceUpdateConversation> priceConversations = new ConcurrentHashMap<>();
 
-    private AdminConversationManager(ArenaManager arenaManager, JavaPlugin plugin) {
+    private AdminConversationManager(ArenaManager arenaManager, ShopManager shopManager, ShopRepository shopRepository, JavaPlugin plugin) {
         this.arenaManager = arenaManager;
+        this.shopManager = shopManager;
+        this.shopRepository = shopRepository;
         this.plugin = plugin;
     }
 
@@ -40,7 +49,7 @@ public class AdminConversationManager {
      */
     public void startConversation(Player admin) {
         UUID id = admin.getUniqueId();
-        if (conversations.containsKey(id)) {
+        if (conversations.containsKey(id) || priceConversations.containsKey(id)) {
             admin.sendMessage("Une conversation est déjà en cours.");
             return;
         }
@@ -59,64 +68,118 @@ public class AdminConversationManager {
     }
 
     /**
+     * Démarre une conversation de modification de prix pour un item.
+     */
+    public void startPriceConversation(Player admin, ShopItem item) {
+        UUID id = admin.getUniqueId();
+        if (priceConversations.containsKey(id) || conversations.containsKey(id)) {
+            admin.sendMessage("Une conversation est déjà en cours.");
+            return;
+        }
+        PriceUpdateConversation conv = new PriceUpdateConversation(id, item);
+        priceConversations.put(id, conv);
+        admin.sendMessage("Entrez le nouveau prix pour cet item (ou 'annuler').");
+
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (priceConversations.containsKey(id)) {
+                admin.sendMessage("Modification de prix annulée (timeout).");
+                cancelConversation(admin);
+                new ShopCategoryGui(shopManager, item.getCategory()).open(admin);
+            }
+        }, 5 * 60 * 20L);
+    }
+
+    /**
      * Traite une réponse envoyée par l'administrateur.
      */
     public void handleResponse(Player admin, String message) {
         UUID id = admin.getUniqueId();
-        ArenaCreationConversation conversation = conversations.get(id);
-        if (conversation == null) {
+        if (conversations.containsKey(id)) {
+            ArenaCreationConversation conversation = conversations.get(id);
+            if ("annuler".equalsIgnoreCase(message)) {
+                admin.sendMessage("Création d'arène annulée.");
+                cancelConversation(admin);
+                new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
+                return;
+            }
+
+            switch (conversation.getCurrentStep()) {
+                case AWAITING_ARENA_NAME:
+                    if (arenaManager.getArena(message) != null) {
+                        admin.sendMessage("Ce nom d'arène est déjà utilisé. Essayez encore.");
+                        return;
+                    }
+                    conversation.setArenaName(message);
+                    conversation.setCurrentStep(ConversationStep.AWAITING_MAX_PLAYERS);
+                    admin.sendMessage("Entrez le nombre maximum de joueurs.");
+                    break;
+                case AWAITING_MAX_PLAYERS:
+                    int maxPlayers;
+                    try {
+                        maxPlayers = Integer.parseInt(message);
+                        if (maxPlayers <= 0) {
+                            admin.sendMessage("Le nombre doit être un entier positif. Réessayez.");
+                            return;
+                        }
+                    } catch (NumberFormatException e) {
+                        admin.sendMessage("Le nombre doit être un entier positif. Réessayez.");
+                        return;
+                    }
+                    conversation.setMaxPlayers(maxPlayers);
+                    arenaManager.createArena(conversation.getArenaName(), conversation.getMaxPlayers());
+                    admin.sendMessage("Arène créée avec succès.");
+                    cancelConversation(admin);
+                    new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
+                    break;
+            }
+            return;
+        }
+
+        PriceUpdateConversation priceConv = priceConversations.get(id);
+        if (priceConv == null) {
             return;
         }
 
         if ("annuler".equalsIgnoreCase(message)) {
-            admin.sendMessage("Création d'arène annulée.");
+            admin.sendMessage("Modification de prix annulée.");
             cancelConversation(admin);
-            new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
+            new ShopCategoryGui(shopManager, priceConv.getItem().getCategory()).open(admin);
             return;
         }
 
-        switch (conversation.getCurrentStep()) {
-            case AWAITING_ARENA_NAME:
-                if (arenaManager.getArena(message) != null) {
-                    admin.sendMessage("Ce nom d'arène est déjà utilisé. Essayez encore.");
-                    return;
-                }
-                conversation.setArenaName(message);
-                conversation.setCurrentStep(ConversationStep.AWAITING_MAX_PLAYERS);
-                admin.sendMessage("Entrez le nombre maximum de joueurs.");
-                break;
-            case AWAITING_MAX_PLAYERS:
-                int maxPlayers;
-                try {
-                    maxPlayers = Integer.parseInt(message);
-                    if (maxPlayers <= 0) {
-                        admin.sendMessage("Le nombre doit être un entier positif. Réessayez.");
-                        return;
-                    }
-                } catch (NumberFormatException e) {
-                    admin.sendMessage("Le nombre doit être un entier positif. Réessayez.");
-                    return;
-                }
-                conversation.setMaxPlayers(maxPlayers);
-                arenaManager.createArena(conversation.getArenaName(), conversation.getMaxPlayers());
-                admin.sendMessage("Arène créée avec succès.");
-                cancelConversation(admin);
-                new ArenaListGui(arenaManager, this, AdminPlacementManager.getInstance()).open(admin);
-                break;
+        int newPrice;
+        try {
+            newPrice = Integer.parseInt(message);
+            if (newPrice < 0) {
+                admin.sendMessage("Le prix doit être un entier positif. Réessayez.");
+                return;
+            }
+        } catch (NumberFormatException e) {
+            admin.sendMessage("Le prix doit être un entier positif. Réessayez.");
+            return;
         }
+
+        shopManager.updateItemPrice(priceConv.getItem(), newPrice);
+        shopRepository.saveItem(priceConv.getItem());
+        admin.sendMessage("Prix mis à jour.");
+        cancelConversation(admin);
+        new ShopCategoryGui(shopManager, priceConv.getItem().getCategory()).open(admin);
     }
 
     /**
      * Annule la conversation pour l'administrateur donné.
      */
     public void cancelConversation(Player admin) {
-        conversations.remove(admin.getUniqueId());
+        UUID id = admin.getUniqueId();
+        conversations.remove(id);
+        priceConversations.remove(id);
     }
 
     /**
      * Vérifie si un joueur est actuellement dans une conversation.
      */
     public boolean isInConversation(Player admin) {
-        return conversations.containsKey(admin.getUniqueId());
+        UUID id = admin.getUniqueId();
+        return conversations.containsKey(id) || priceConversations.containsKey(id);
     }
 }

--- a/src/main/java/fr/heneria/nexus/admin/conversation/PriceUpdateConversation.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/PriceUpdateConversation.java
@@ -1,0 +1,27 @@
+package fr.heneria.nexus.admin.conversation;
+
+import fr.heneria.nexus.shop.model.ShopItem;
+
+import java.util.UUID;
+
+/**
+ * Conversation de modification de prix pour un item de boutique.
+ */
+public class PriceUpdateConversation {
+
+    private final UUID adminId;
+    private final ShopItem item;
+
+    public PriceUpdateConversation(UUID adminId, ShopItem item) {
+        this.adminId = adminId;
+        this.item = item;
+    }
+
+    public UUID getAdminId() {
+        return adminId;
+    }
+
+    public ShopItem getItem() {
+        return item;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -4,6 +4,7 @@ import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.gui.admin.AdminMenuGui;
 import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.shop.manager.ShopManager;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -21,9 +22,11 @@ import java.util.stream.Collectors;
 public class NexusAdminCommand implements CommandExecutor {
 
     private final ArenaManager arenaManager;
+    private final ShopManager shopManager;
 
-    public NexusAdminCommand(ArenaManager arenaManager) {
+    public NexusAdminCommand(ArenaManager arenaManager, ShopManager shopManager) {
         this.arenaManager = arenaManager;
+        this.shopManager = shopManager;
     }
 
     @Override
@@ -38,7 +41,7 @@ public class NexusAdminCommand implements CommandExecutor {
                 sender.sendMessage("Vous n'avez pas la permission nécessaire.");
                 return true;
             }
-            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance()).open((Player) sender);
+            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance(), shopManager).open((Player) sender);
             return true;
         }
 

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -10,6 +10,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.gui.admin.shop.ShopAdminGui;
 
 /**
  * Menu principal du centre de contrôle Nexus.
@@ -18,10 +20,12 @@ public class AdminMenuGui {
 
     private final ArenaManager arenaManager;
     private final AdminPlacementManager adminPlacementManager;
+    private final ShopManager shopManager;
 
-    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager) {
+    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager, ShopManager shopManager) {
         this.arenaManager = arenaManager;
         this.adminPlacementManager = adminPlacementManager;
+        this.shopManager = shopManager;
     }
 
     /**
@@ -48,6 +52,15 @@ public class AdminMenuGui {
 
         // Place l'item au centre
         gui.setItem(13, arenaManagement);
+
+        GuiItem shopManagement = ItemBuilder.from(Material.CHEST)
+                .name(Component.text("Gestion de la Boutique", NamedTextColor.GREEN))
+                .lore(Component.text("Configurer la boutique en jeu"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ShopAdminGui(shopManager).open((Player) event.getWhoClicked());
+                });
+        gui.setItem(15, shopManagement);
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopAdminGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopAdminGui.java
@@ -1,0 +1,52 @@
+package fr.heneria.nexus.gui.admin.shop;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.shop.manager.ShopManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * Interface d'administration de la boutique.
+ */
+public class ShopAdminGui {
+
+    private final ShopManager shopManager;
+
+    public ShopAdminGui(ShopManager shopManager) {
+        this.shopManager = shopManager;
+    }
+
+    public void open(Player player) {
+        Gui gui = Gui.gui()
+                .title(Component.text("Gestion de la Boutique"))
+                .rows(3)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        GuiItem armes = ItemBuilder.from(Material.DIAMOND_SWORD)
+                .name(Component.text("Armes", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ShopCategoryGui(shopManager, "Armes").open((Player) event.getWhoClicked());
+                });
+        GuiItem armures = ItemBuilder.from(Material.DIAMOND_CHESTPLATE)
+                .name(Component.text("Armures", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ShopCategoryGui(shopManager, "Armures").open((Player) event.getWhoClicked());
+                });
+        GuiItem utilitaires = ItemBuilder.from(Material.POTION)
+                .name(Component.text("Utilitaires", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ShopCategoryGui(shopManager, "Utilitaires").open((Player) event.getWhoClicked());
+                });
+
+        gui.addItem(armes, armures, utilitaires);
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopCategoryGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopCategoryGui.java
@@ -1,0 +1,53 @@
+package fr.heneria.nexus.gui.admin.shop;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.shop.model.ShopItem;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Interface d'édition des items d'une catégorie de boutique.
+ */
+public class ShopCategoryGui {
+
+    private final ShopManager shopManager;
+    private final String category;
+
+    public ShopCategoryGui(ShopManager shopManager, String category) {
+        this.shopManager = shopManager;
+        this.category = category;
+    }
+
+    public void open(Player player) {
+        List<ShopItem> items = shopManager.getItemsForCategory(category);
+        int rows = Math.min(6, Math.max(1, (int) Math.ceil(items.size() / 9.0)));
+
+        Gui gui = Gui.gui()
+                .title(Component.text("Boutique - " + category))
+                .rows(rows)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        for (ShopItem item : items) {
+            GuiItem guiItem = ItemBuilder.from(item.getMaterial())
+                    .name(Component.text(item.getDisplayName() != null ? item.getDisplayName() : item.getMaterial().name()))
+                    .lore(Component.text("Prix: " + item.getPrice() + " points", NamedTextColor.YELLOW))
+                    .asGuiItem(event -> {
+                        event.setCancelled(true);
+                        Player p = (Player) event.getWhoClicked();
+                        p.closeInventory();
+                        AdminConversationManager.getInstance().startPriceConversation(p, item);
+                    });
+            gui.addItem(guiItem);
+        }
+
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/shop/manager/ShopManager.java
+++ b/src/main/java/fr/heneria/nexus/shop/manager/ShopManager.java
@@ -1,0 +1,41 @@
+package fr.heneria.nexus.shop.manager;
+
+import fr.heneria.nexus.shop.model.ShopItem;
+import fr.heneria.nexus.shop.repository.ShopRepository;
+import org.bukkit.Material;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ShopManager {
+
+    private final ShopRepository repository;
+    private final Map<String, List<ShopItem>> itemsByCategory = new ConcurrentHashMap<>();
+
+    public ShopManager(ShopRepository repository) {
+        this.repository = repository;
+    }
+
+    public void loadItems() {
+        itemsByCategory.clear();
+        itemsByCategory.putAll(repository.loadAllItems());
+    }
+
+    public ShopItem getItem(String category, Material material) {
+        return itemsByCategory.getOrDefault(category, Collections.emptyList())
+                .stream()
+                .filter(i -> i.getMaterial() == material)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void updateItemPrice(ShopItem item, int newPrice) {
+        item.setPrice(newPrice);
+    }
+
+    public List<ShopItem> getItemsForCategory(String category) {
+        return itemsByCategory.getOrDefault(category, Collections.emptyList());
+    }
+}

--- a/src/main/java/fr/heneria/nexus/shop/model/ShopItem.java
+++ b/src/main/java/fr/heneria/nexus/shop/model/ShopItem.java
@@ -1,0 +1,79 @@
+package fr.heneria.nexus.shop.model;
+
+import org.bukkit.Material;
+
+/**
+ * Représente un item de boutique configurable.
+ */
+public class ShopItem {
+
+    private int id;
+    private final String category;
+    private final Material material;
+    private int price;
+    private boolean enabled;
+    private String displayName;
+    private String loreLines;
+
+    public ShopItem(int id, String category, Material material, int price, boolean enabled, String displayName, String loreLines) {
+        this.id = id;
+        this.category = category;
+        this.material = material;
+        this.price = price;
+        this.enabled = enabled;
+        this.displayName = displayName;
+        this.loreLines = loreLines;
+    }
+
+    public ShopItem(String category, Material material, int price, boolean enabled, String displayName, String loreLines) {
+        this(0, category, material, price, enabled, displayName, loreLines);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getLoreLines() {
+        return loreLines;
+    }
+
+    public void setLoreLines(String loreLines) {
+        this.loreLines = loreLines;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/shop/repository/JdbcShopRepository.java
+++ b/src/main/java/fr/heneria/nexus/shop/repository/JdbcShopRepository.java
@@ -1,0 +1,83 @@
+package fr.heneria.nexus.shop.repository;
+
+import fr.heneria.nexus.shop.model.ShopItem;
+import org.bukkit.Material;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.*;
+
+public class JdbcShopRepository implements ShopRepository {
+
+    private final DataSource dataSource;
+
+    public JdbcShopRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Map<String, List<ShopItem>> loadAllItems() {
+        Map<String, List<ShopItem>> items = new HashMap<>();
+        String sql = "SELECT id, item_category, material, price, is_enabled, display_name, lore_lines FROM shop_items";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                String category = rs.getString("item_category");
+                Material material;
+                try {
+                    material = Material.valueOf(rs.getString("material"));
+                } catch (IllegalArgumentException e) {
+                    continue;
+                }
+                ShopItem item = new ShopItem(
+                        rs.getInt("id"),
+                        category,
+                        material,
+                        rs.getInt("price"),
+                        rs.getBoolean("is_enabled"),
+                        rs.getString("display_name"),
+                        rs.getString("lore_lines")
+                );
+                items.computeIfAbsent(category, k -> new ArrayList<>()).add(item);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return items;
+    }
+
+    @Override
+    public void saveItem(ShopItem item) {
+        String sql = "INSERT INTO shop_items (item_category, material, price, is_enabled, display_name, lore_lines) VALUES (?, ?, ?, ?, ?, ?) " +
+                "ON DUPLICATE KEY UPDATE price = VALUES(price), is_enabled = VALUES(is_enabled), display_name = VALUES(display_name), lore_lines = VALUES(lore_lines)";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setString(1, item.getCategory());
+            stmt.setString(2, item.getMaterial().name());
+            stmt.setInt(3, item.getPrice());
+            stmt.setBoolean(4, item.isEnabled());
+            stmt.setString(5, item.getDisplayName());
+            stmt.setString(6, item.getLoreLines());
+            stmt.executeUpdate();
+            try (ResultSet rs = stmt.getGeneratedKeys()) {
+                if (rs.next()) {
+                    item.setId(rs.getInt(1));
+                } else if (item.getId() == 0) {
+                    String select = "SELECT id FROM shop_items WHERE item_category = ? AND material = ?";
+                    try (PreparedStatement sel = connection.prepareStatement(select)) {
+                        sel.setString(1, item.getCategory());
+                        sel.setString(2, item.getMaterial().name());
+                        try (ResultSet rs2 = sel.executeQuery()) {
+                            if (rs2.next()) {
+                                item.setId(rs2.getInt("id"));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/fr/heneria/nexus/shop/repository/ShopRepository.java
+++ b/src/main/java/fr/heneria/nexus/shop/repository/ShopRepository.java
@@ -1,0 +1,11 @@
+package fr.heneria.nexus.shop.repository;
+
+import fr.heneria.nexus.shop.model.ShopItem;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ShopRepository {
+    Map<String, List<ShopItem>> loadAllItems();
+    void saveItem(ShopItem item);
+}

--- a/src/main/resources/db/changelog/004_create_shop_items_table.sql
+++ b/src/main/resources/db/changelog/004_create_shop_items_table.sql
@@ -1,0 +1,12 @@
+-- liquibase formatted sql
+-- changeset gordox:5
+CREATE TABLE shop_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    item_category VARCHAR(32) NOT NULL,
+    material VARCHAR(64) NOT NULL,
+    price INT DEFAULT 0 NOT NULL,
+    is_enabled BOOLEAN DEFAULT TRUE NOT NULL,
+    display_name VARCHAR(128),
+    lore_lines TEXT,
+    UNIQUE KEY uk_category_material (item_category, material)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -8,5 +8,6 @@
     <include file="db/changelog/001_create_initial_arena_tables.sql"/>
     <include file="db/changelog/002_create_player_tables.sql"/>
     <include file="db/changelog/003_create_economy_tables.sql"/>
+    <include file="db/changelog/004_create_shop_items_table.sql"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add Liquibase migration for shop_items table
- implement ShopItem data model, JDBC repository, and service manager
- extend admin GUI and conversations to manage shop categories and prices

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not resolve org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c03bac00b88324b8255057a0d82eee