### PR TITLE
feat: add core game engine skeleton

### DIFF
--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -5,11 +5,15 @@ import fr.heneria.nexus.gui.admin.AdminMenuGui;
 import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.game.manager.GameManager;
+import fr.heneria.nexus.game.model.Match;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
 
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -31,6 +35,28 @@ public class NexusAdminCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length > 0 && "starttest".equalsIgnoreCase(args[0])) {
+            Arena arena = arenaManager.getAllArenas().stream().findFirst().orElse(null);
+            if (arena == null) {
+                sender.sendMessage("Aucune arène disponible.");
+                return true;
+            }
+            List<UUID> team1 = new ArrayList<>();
+            List<UUID> team2 = new ArrayList<>();
+            int i = 0;
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (i++ % 2 == 0) {
+                    team1.add(p.getUniqueId());
+                } else {
+                    team2.add(p.getUniqueId());
+                }
+            }
+            Match match = GameManager.getInstance().createMatch(arena, Arrays.asList(team1, team2));
+            GameManager.getInstance().startMatchCountdown(match);
+            sender.sendMessage("Match de test lancé.");
+            return true;
+        }
+
         // Ouvre le GUI principal pour /nx ou /nx admin
         if (args.length == 0 || "admin".equalsIgnoreCase(args[0])) {
             if (!(sender instanceof Player)) {

--- a/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
+++ b/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
@@ -1,0 +1,138 @@
+package fr.heneria.nexus.game.manager;
+
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.game.model.GameState;
+import fr.heneria.nexus.game.model.Match;
+import fr.heneria.nexus.game.model.Team;
+import fr.heneria.nexus.game.repository.MatchRepository;
+import fr.heneria.nexus.player.manager.PlayerManager;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class GameManager {
+
+    private static GameManager instance;
+
+    private final JavaPlugin plugin;
+    private final ArenaManager arenaManager;
+    private final PlayerManager playerManager;
+    private final MatchRepository matchRepository;
+    private final Map<UUID, Match> matches = new ConcurrentHashMap<>();
+    private final Map<UUID, Match> playerMatches = new ConcurrentHashMap<>();
+
+    private GameManager(JavaPlugin plugin, ArenaManager arenaManager, PlayerManager playerManager, MatchRepository matchRepository) {
+        this.plugin = plugin;
+        this.arenaManager = arenaManager;
+        this.playerManager = playerManager;
+        this.matchRepository = matchRepository;
+    }
+
+    public static void init(JavaPlugin plugin, ArenaManager arenaManager, PlayerManager playerManager, MatchRepository matchRepository) {
+        instance = new GameManager(plugin, arenaManager, playerManager, matchRepository);
+    }
+
+    public static GameManager getInstance() {
+        return instance;
+    }
+
+    public Match createMatch(Arena arena, List<List<UUID>> playerTeams) {
+        UUID matchId = UUID.randomUUID();
+        Match match = new Match(matchId, arena);
+        for (int i = 0; i < playerTeams.size(); i++) {
+            Team team = new Team(i + 1);
+            for (UUID uuid : playerTeams.get(i)) {
+                team.addPlayer(uuid);
+                playerMatches.put(uuid, match);
+            }
+            match.addTeam(team);
+        }
+        matches.put(matchId, match);
+        return match;
+    }
+
+    public void startMatchCountdown(Match match) {
+        match.setState(GameState.STARTING);
+        BukkitRunnable runnable = new BukkitRunnable() {
+            int counter = 10;
+            @Override
+            public void run() {
+                if (counter <= 0) {
+                    cancel();
+                    startMatch(match);
+                    return;
+                }
+                match.broadcastMessage("La partie commence dans " + counter + " seconde(s)");
+                counter--;
+            }
+        };
+        match.setCountdownTask(runnable.runTaskTimer(plugin, 0L, 20L));
+    }
+
+    public void startMatch(Match match) {
+        match.setState(GameState.IN_PROGRESS);
+        match.setStartTime(Instant.now());
+        for (Team team : match.getTeams().values()) {
+            Map<Integer, Location> spawns = match.getArena().getSpawns().get(team.getTeamId());
+            Location spawn = null;
+            if (spawns != null && !spawns.isEmpty()) {
+                spawn = spawns.values().iterator().next();
+            }
+            for (UUID playerId : team.getPlayers()) {
+                Player player = Bukkit.getPlayer(playerId);
+                if (player != null) {
+                    if (spawn != null) {
+                        player.teleport(spawn);
+                    }
+                    player.getInventory().clear();
+                    player.setGameMode(GameMode.SURVIVAL);
+                    player.setHealth(player.getMaxHealth());
+                    player.setFoodLevel(20);
+                }
+            }
+        }
+    }
+
+    public void endMatch(Match match, int winningTeamId) {
+        match.setState(GameState.ENDING);
+        match.setEndTime(Instant.now());
+        matchRepository.saveMatchResult(match, winningTeamId);
+        matchRepository.saveMatchParticipants(match);
+        Location lobby = plugin.getServer().getWorlds().get(0).getSpawnLocation();
+        for (UUID playerId : match.getPlayers()) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null) {
+                player.getInventory().clear();
+                if (lobby != null) {
+                    player.teleport(lobby);
+                }
+            }
+            playerMatches.remove(playerId);
+        }
+        matches.remove(match.getMatchId());
+    }
+
+    public Match getPlayerMatch(UUID playerId) {
+        return playerMatches.get(playerId);
+    }
+
+    public void removePlayer(UUID playerId) {
+        Match match = playerMatches.remove(playerId);
+        if (match != null) {
+            Team team = match.getTeamOfPlayer(playerId);
+            if (team != null) {
+                team.removePlayer(playerId);
+            }
+        }
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/model/GameState.java
+++ b/src/main/java/fr/heneria/nexus/game/model/GameState.java
@@ -1,0 +1,8 @@
+package fr.heneria.nexus.game.model;
+
+public enum GameState {
+    WAITING,
+    STARTING,
+    IN_PROGRESS,
+    ENDING
+}

--- a/src/main/java/fr/heneria/nexus/game/model/Match.java
+++ b/src/main/java/fr/heneria/nexus/game/model/Match.java
@@ -1,0 +1,125 @@
+package fr.heneria.nexus.game.model;
+
+import fr.heneria.nexus.arena.model.Arena;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Match {
+    private final UUID matchId;
+    private final Arena arena;
+    private GameState state = GameState.WAITING;
+    private final Map<Integer, Team> teams = new ConcurrentHashMap<>();
+    private BukkitTask countdownTask;
+    private Instant startTime;
+    private Instant endTime;
+    private final Map<UUID, Integer> kills = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> deaths = new ConcurrentHashMap<>();
+
+    public Match(UUID matchId, Arena arena) {
+        this.matchId = matchId;
+        this.arena = arena;
+    }
+
+    public UUID getMatchId() {
+        return matchId;
+    }
+
+    public Arena getArena() {
+        return arena;
+    }
+
+    public GameState getState() {
+        return state;
+    }
+
+    public void setState(GameState state) {
+        this.state = state;
+    }
+
+    public Map<Integer, Team> getTeams() {
+        return teams;
+    }
+
+    public void addTeam(Team team) {
+        teams.put(team.getTeamId(), team);
+    }
+
+    public BukkitTask getCountdownTask() {
+        return countdownTask;
+    }
+
+    public void setCountdownTask(BukkitTask countdownTask) {
+        this.countdownTask = countdownTask;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Instant startTime) {
+        this.startTime = startTime;
+    }
+
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Instant endTime) {
+        this.endTime = endTime;
+    }
+
+    public Set<UUID> getPlayers() {
+        Set<UUID> all = new HashSet<>();
+        for (Team t : teams.values()) {
+            all.addAll(t.getPlayers());
+        }
+        return all;
+    }
+
+    public Team getTeamOfPlayer(UUID playerId) {
+        for (Team t : teams.values()) {
+            if (t.getPlayers().contains(playerId)) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    public void broadcastMessage(String message) {
+        for (UUID playerId : getPlayers()) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null) {
+                player.sendMessage(message);
+            }
+        }
+    }
+
+    public void incrementKill(UUID playerId) {
+        kills.merge(playerId, 1, Integer::sum);
+    }
+
+    public void incrementDeath(UUID playerId) {
+        deaths.merge(playerId, 1, Integer::sum);
+    }
+
+    public int getKills(UUID playerId) {
+        return kills.getOrDefault(playerId, 0);
+    }
+
+    public int getDeaths(UUID playerId) {
+        return deaths.getOrDefault(playerId, 0);
+    }
+
+    public Map<UUID, Integer> getKillsMap() {
+        return kills;
+    }
+
+    public Map<UUID, Integer> getDeathsMap() {
+        return deaths;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/model/Team.java
+++ b/src/main/java/fr/heneria/nexus/game/model/Team.java
@@ -1,0 +1,30 @@
+package fr.heneria.nexus.game.model;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Team {
+    private final int teamId;
+    private final Set<UUID> players = ConcurrentHashMap.newKeySet();
+
+    public Team(int teamId) {
+        this.teamId = teamId;
+    }
+
+    public int getTeamId() {
+        return teamId;
+    }
+
+    public void addPlayer(UUID playerId) {
+        players.add(playerId);
+    }
+
+    public void removePlayer(UUID playerId) {
+        players.remove(playerId);
+    }
+
+    public Set<UUID> getPlayers() {
+        return players;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/repository/JdbcMatchRepository.java
+++ b/src/main/java/fr/heneria/nexus/game/repository/JdbcMatchRepository.java
@@ -1,0 +1,58 @@
+package fr.heneria.nexus.game.repository;
+
+import fr.heneria.nexus.game.model.Match;
+import fr.heneria.nexus.game.model.Team;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.time.Instant;
+import java.util.UUID;
+
+public class JdbcMatchRepository implements MatchRepository {
+
+    private final DataSource dataSource;
+
+    public JdbcMatchRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void saveMatchResult(Match match, int winningTeamId) {
+        String sql = "INSERT INTO matches (id, arena_id, start_time, end_time, winning_team_id) VALUES (?, ?, ?, ?, ?)";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, match.getMatchId().toString());
+            stmt.setInt(2, match.getArena().getId());
+            Instant start = match.getStartTime() != null ? match.getStartTime() : Instant.now();
+            Instant end = match.getEndTime() != null ? match.getEndTime() : Instant.now();
+            stmt.setTimestamp(3, Timestamp.from(start));
+            stmt.setTimestamp(4, Timestamp.from(end));
+            stmt.setInt(5, winningTeamId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void saveMatchParticipants(Match match) {
+        String sql = "INSERT INTO match_participants (match_id, player_uuid, team_id, kills, deaths, assists) VALUES (?, ?, ?, ?, ?, ?)";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql)) {
+            for (UUID playerId : match.getPlayers()) {
+                stmt.setString(1, match.getMatchId().toString());
+                stmt.setString(2, playerId.toString());
+                Team team = match.getTeamOfPlayer(playerId);
+                int teamId = team != null ? team.getTeamId() : 0;
+                stmt.setInt(3, teamId);
+                stmt.setInt(4, match.getKills(playerId));
+                stmt.setInt(5, match.getDeaths(playerId));
+                stmt.setInt(6, 0);
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/repository/MatchRepository.java
+++ b/src/main/java/fr/heneria/nexus/game/repository/MatchRepository.java
@@ -1,0 +1,8 @@
+package fr.heneria.nexus.game.repository;
+
+import fr.heneria.nexus.game.model.Match;
+
+public interface MatchRepository {
+    void saveMatchResult(Match match, int winningTeamId);
+    void saveMatchParticipants(Match match);
+}

--- a/src/main/java/fr/heneria/nexus/listener/GameListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/GameListener.java
@@ -1,0 +1,78 @@
+package fr.heneria.nexus.listener;
+
+import fr.heneria.nexus.game.manager.GameManager;
+import fr.heneria.nexus.game.model.Match;
+import fr.heneria.nexus.game.model.Team;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class GameListener implements Listener {
+
+    private final GameManager gameManager;
+    private final JavaPlugin plugin;
+
+    public GameListener(GameManager gameManager, JavaPlugin plugin) {
+        this.gameManager = gameManager;
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        UUID uuid = event.getPlayer().getUniqueId();
+        Match match = gameManager.getPlayerMatch(uuid);
+        if (match != null) {
+            match.broadcastMessage(event.getPlayer().getName() + " a quitté la partie.");
+            gameManager.removePlayer(uuid);
+            long remainingTeams = match.getTeams().values().stream().filter(t -> !t.getPlayers().isEmpty()).count();
+            if (remainingTeams <= 1) {
+                int winningTeamId = match.getTeams().values().stream()
+                        .filter(t -> !t.getPlayers().isEmpty())
+                        .findFirst().map(Team::getTeamId).orElse(0);
+                gameManager.endMatch(match, winningTeamId);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        UUID uuid = player.getUniqueId();
+        Match match = gameManager.getPlayerMatch(uuid);
+        if (match == null) {
+            return;
+        }
+        event.getDrops().clear();
+        event.setDeathMessage(null);
+
+        match.incrementDeath(uuid);
+        Player killer = player.getKiller();
+        if (killer != null) {
+            match.incrementKill(killer.getUniqueId());
+        }
+
+        Team team = match.getTeamOfPlayer(uuid);
+        Location spawn = null;
+        if (team != null) {
+            Map<Integer, Location> spawns = match.getArena().getSpawns().get(team.getTeamId());
+            if (spawns != null && !spawns.isEmpty()) {
+                spawn = spawns.values().iterator().next();
+            }
+        }
+        Location finalSpawn = spawn;
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            player.spigot().respawn();
+            if (finalSpawn != null) {
+                player.teleport(finalSpawn);
+            }
+        }, 1L);
+    }
+}

--- a/src/main/resources/db/changelog/005_create_match_tables.sql
+++ b/src/main/resources/db/changelog/005_create_match_tables.sql
@@ -1,0 +1,23 @@
+-- liquibase formatted sql
+-- changeset gordox:6
+CREATE TABLE matches (
+    id VARCHAR(36) PRIMARY KEY,
+    arena_id INT NOT NULL,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP,
+    winning_team_id INT,
+    FOREIGN KEY (arena_id) REFERENCES arenas(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- changeset gordox:7
+CREATE TABLE match_participants (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    match_id VARCHAR(36) NOT NULL,
+    player_uuid CHAR(36) NOT NULL,
+    team_id INT NOT NULL,
+    kills INT DEFAULT 0 NOT NULL,
+    deaths INT DEFAULT 0 NOT NULL,
+    assists INT DEFAULT 0 NOT NULL, -- Pour le futur
+    FOREIGN KEY (match_id) REFERENCES matches(id) ON DELETE CASCADE,
+    FOREIGN KEY (player_uuid) REFERENCES player_profiles(player_uuid) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -9,5 +9,6 @@
     <include file="db/changelog/002_create_player_tables.sql"/>
     <include file="db/changelog/003_create_economy_tables.sql"/>
     <include file="db/changelog/004_create_shop_items_table.sql"/>
+    <include file="db/changelog/005_create_match_tables.sql"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add Liquibase migration for matches and participants
- implement core game model and manager
- handle players during matches and add temporary starttest command

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0423d560c83248cd2c6a39e7fc368