### PR TITLE
feat: add matchmaking queue system

### DIFF
--- a/src/main/java/fr/heneria/nexus/command/PlayCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/PlayCommand.java
@@ -1,0 +1,34 @@
+package fr.heneria.nexus.command;
+
+import fr.heneria.nexus.game.queue.QueueManager;
+import fr.heneria.nexus.gui.player.GameModeSelectorGui;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Commande permettant d'ouvrir le sélecteur de mode de jeu pour rejoindre une file d'attente.
+ */
+public class PlayCommand implements CommandExecutor {
+
+    private final QueueManager queueManager;
+    private final JavaPlugin plugin;
+
+    public PlayCommand(QueueManager queueManager, JavaPlugin plugin) {
+        this.queueManager = queueManager;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+            return true;
+        }
+        Player player = (Player) sender;
+        new GameModeSelectorGui(queueManager, plugin).open(player);
+        return true;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
+++ b/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
@@ -135,4 +135,14 @@ public class GameManager {
             }
         }
     }
+
+    /**
+     * Vérifie si une arène est actuellement utilisée par une partie en cours.
+     *
+     * @param arena arène à vérifier
+     * @return {@code true} si l'arène est occupée, sinon {@code false}
+     */
+    public boolean isArenaInUse(Arena arena) {
+        return matches.values().stream().anyMatch(match -> match.getArena().equals(arena));
+    }
 }

--- a/src/main/java/fr/heneria/nexus/game/queue/GameMode.java
+++ b/src/main/java/fr/heneria/nexus/game/queue/GameMode.java
@@ -1,0 +1,22 @@
+package fr.heneria.nexus.game.queue;
+
+/**
+ * Représente les différents modes de jeu disponibles pour le matchmaking.
+ */
+public enum GameMode {
+    SOLO_1V1(2),
+    TEAM_2V2(4);
+
+    private final int requiredPlayers;
+
+    GameMode(int requiredPlayers) {
+        this.requiredPlayers = requiredPlayers;
+    }
+
+    /**
+     * @return le nombre total de joueurs requis pour lancer une partie dans ce mode.
+     */
+    public int getRequiredPlayers() {
+        return requiredPlayers;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/queue/MatchmakingQueue.java
+++ b/src/main/java/fr/heneria/nexus/game/queue/MatchmakingQueue.java
@@ -1,0 +1,38 @@
+package fr.heneria.nexus.game.queue;
+
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Représente une file d'attente pour un mode de jeu spécifique.
+ */
+public class MatchmakingQueue {
+
+    private final GameMode gameMode;
+    private final Queue<UUID> players = new ConcurrentLinkedQueue<>();
+
+    public MatchmakingQueue(GameMode gameMode) {
+        this.gameMode = gameMode;
+    }
+
+    public GameMode getGameMode() {
+        return gameMode;
+    }
+
+    public Queue<UUID> getPlayers() {
+        return players;
+    }
+
+    public void addPlayer(UUID uuid) {
+        players.add(uuid);
+    }
+
+    public void removePlayer(UUID uuid) {
+        players.remove(uuid);
+    }
+
+    public boolean isFull() {
+        return players.size() >= gameMode.getRequiredPlayers();
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/queue/QueueManager.java
+++ b/src/main/java/fr/heneria/nexus/game/queue/QueueManager.java
@@ -1,0 +1,105 @@
+package fr.heneria.nexus.game.queue;
+
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.game.manager.GameManager;
+import fr.heneria.nexus.game.model.Match;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Gère les différentes files d'attente de matchmaking.
+ */
+public class QueueManager {
+
+    private static QueueManager instance;
+
+    private final GameManager gameManager;
+    private final ArenaManager arenaManager;
+    private final Map<GameMode, MatchmakingQueue> queues = new ConcurrentHashMap<>();
+    private final Map<UUID, GameMode> playerQueues = new ConcurrentHashMap<>();
+
+    private QueueManager(GameManager gameManager, ArenaManager arenaManager) {
+        this.gameManager = gameManager;
+        this.arenaManager = arenaManager;
+        for (GameMode mode : GameMode.values()) {
+            queues.put(mode, new MatchmakingQueue(mode));
+        }
+    }
+
+    public static void init(GameManager gameManager, ArenaManager arenaManager) {
+        instance = new QueueManager(gameManager, arenaManager);
+    }
+
+    public static QueueManager getInstance() {
+        return instance;
+    }
+
+    public void joinQueue(Player player, GameMode mode) {
+        GameMode current = playerQueues.get(player.getUniqueId());
+        if (current == mode) {
+            // déjà dans cette file, quitter
+            leaveQueue(player);
+            return;
+        }
+        if (current != null) {
+            queues.get(current).removePlayer(player.getUniqueId());
+        }
+        MatchmakingQueue queue = queues.get(mode);
+        queue.addPlayer(player.getUniqueId());
+        playerQueues.put(player.getUniqueId(), mode);
+        player.sendMessage("\u00a7aVous avez rejoint la file " + mode.name());
+        if (queue.isFull()) {
+            tryStartMatch(queue);
+        }
+    }
+
+    public void leaveQueue(Player player) {
+        GameMode mode = playerQueues.remove(player.getUniqueId());
+        if (mode != null) {
+            queues.get(mode).removePlayer(player.getUniqueId());
+            player.sendMessage("\u00a7cVous avez quitté la file " + mode.name());
+        }
+    }
+
+    public GameMode getPlayerQueue(UUID playerId) {
+        return playerQueues.get(playerId);
+    }
+
+    public int getQueueSize(GameMode mode) {
+        MatchmakingQueue queue = queues.get(mode);
+        return queue == null ? 0 : queue.getPlayers().size();
+    }
+
+    private void tryStartMatch(MatchmakingQueue queue) {
+        // Cherche une arène libre et compatible
+        Arena arena = arenaManager.getAllArenas().stream()
+                .filter(a -> a.getMaxPlayers() >= queue.getGameMode().getRequiredPlayers())
+                .filter(a -> !gameManager.isArenaInUse(a))
+                .findFirst().orElse(null);
+        if (arena == null) {
+            return;
+        }
+        List<UUID> players = new ArrayList<>();
+        for (int i = 0; i < queue.getGameMode().getRequiredPlayers(); i++) {
+            UUID uuid = queue.getPlayers().poll();
+            if (uuid != null) {
+                players.add(uuid);
+                playerQueues.remove(uuid);
+            }
+        }
+        if (players.size() < queue.getGameMode().getRequiredPlayers()) {
+            // pas assez de joueurs (devrait pas arriver)
+            players.forEach(uuid -> queue.addPlayer(uuid));
+            return;
+        }
+        int teamSize = players.size() / 2;
+        List<List<UUID>> teams = new ArrayList<>();
+        teams.add(new ArrayList<>(players.subList(0, teamSize)));
+        teams.add(new ArrayList<>(players.subList(teamSize, players.size())));
+        Match match = gameManager.createMatch(arena, teams);
+        gameManager.startMatchCountdown(match);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/player/GameModeSelectorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/GameModeSelectorGui.java
@@ -1,0 +1,72 @@
+package fr.heneria.nexus.gui.player;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.game.queue.GameMode;
+import fr.heneria.nexus.game.queue.QueueManager;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Interface permettant aux joueurs de sélectionner un mode de jeu et de rejoindre une file d'attente.
+ */
+public class GameModeSelectorGui {
+
+    private final QueueManager queueManager;
+    private final JavaPlugin plugin;
+
+    public GameModeSelectorGui(QueueManager queueManager, JavaPlugin plugin) {
+        this.queueManager = queueManager;
+        this.plugin = plugin;
+    }
+
+    public void open(Player player) {
+        Gui gui = Gui.gui()
+                .title(Component.text("Sélection du mode"))
+                .rows(1)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        for (GameMode mode : GameMode.values()) {
+            gui.addItem(createItem(mode));
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+            for (GameMode mode : GameMode.values()) {
+                gui.updateItem(mode.ordinal(), createItem(mode));
+            }
+        }, 20L, 40L);
+
+        gui.setCloseGuiAction(event -> task.cancel());
+        gui.open(player);
+    }
+
+    private GuiItem createItem(GameMode mode) {
+        Material material;
+        switch (mode) {
+            case TEAM_2V2:
+                material = Material.DIAMOND_SWORD;
+                break;
+            case SOLO_1V1:
+            default:
+                material = Material.IRON_SWORD;
+                break;
+        }
+        int size = queueManager.getQueueSize(mode);
+        return ItemBuilder.from(material)
+                .name(Component.text(mode.name()))
+                .lore(Component.text(size + "/" + mode.getRequiredPlayers() + " joueurs"))
+                .asGuiItem(event -> {
+                    Player p = (Player) event.getWhoClicked();
+                    if (queueManager.getPlayerQueue(p.getUniqueId()) == mode) {
+                        queueManager.leaveQueue(p);
+                    } else {
+                        queueManager.joinQueue(p, mode);
+                    }
+                });
+    }
+}

--- a/src/main/java/fr/heneria/nexus/listener/GameListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/GameListener.java
@@ -3,6 +3,7 @@ package fr.heneria.nexus.listener;
 import fr.heneria.nexus.game.manager.GameManager;
 import fr.heneria.nexus.game.model.Match;
 import fr.heneria.nexus.game.model.Team;
+import fr.heneria.nexus.game.queue.QueueManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -19,15 +20,18 @@ public class GameListener implements Listener {
 
     private final GameManager gameManager;
     private final JavaPlugin plugin;
+    private final QueueManager queueManager;
 
-    public GameListener(GameManager gameManager, JavaPlugin plugin) {
+    public GameListener(GameManager gameManager, JavaPlugin plugin, QueueManager queueManager) {
         this.gameManager = gameManager;
         this.plugin = plugin;
+        this.queueManager = queueManager;
     }
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         UUID uuid = event.getPlayer().getUniqueId();
+        queueManager.leaveQueue(event.getPlayer());
         Match match = gameManager.getPlayerMatch(uuid);
         if (match != null) {
             match.broadcastMessage(event.getPlayer().getName() + " a quitté la partie.");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,9 @@ commands:
     description: Centre de contrôle de Nexus
     usage: /nx
     permission: nexus.admin
+  play:
+    description: Ouvre la sélection de mode de jeu
+    usage: /play
 permissions:
   nexus.admin:
     description: Accès à l'administration de Nexus


### PR DESCRIPTION
## Summary
- introduce game mode enum and matchmaking queues
- add queue manager and player game mode selector GUI
- wire queue system into plugin commands and listeners

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c06a3085d083248e2f47ebd4ac381a