### PR TITLE
feat: implement preparation phase with kits and player shop

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -19,6 +19,7 @@ import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import fr.heneria.nexus.shop.manager.ShopManager;
 import fr.heneria.nexus.shop.repository.JdbcShopRepository;
 import fr.heneria.nexus.shop.repository.ShopRepository;
+import fr.heneria.nexus.game.kit.manager.KitManager;
 import fr.heneria.nexus.game.manager.GameManager;
 import fr.heneria.nexus.game.repository.MatchRepository;
 import fr.heneria.nexus.game.repository.JdbcMatchRepository;
@@ -39,6 +40,7 @@ public final class Nexus extends JavaPlugin {
     private PlayerManager playerManager;
     private EconomyManager economyManager;
     private ShopManager shopManager;
+    private KitManager kitManager;
     private GameManager gameManager;
     private QueueManager queueManager;
 
@@ -67,7 +69,9 @@ public final class Nexus extends JavaPlugin {
             this.playerManager = new PlayerManager(playerRepository);
             this.economyManager = new EconomyManager(this.playerManager, this.dataSourceProvider.getDataSource());
             this.shopManager = new ShopManager(shopRepository);
-            GameManager.init(this, this.arenaManager, this.playerManager, matchRepository);
+            this.kitManager = KitManager.getInstance();
+            this.kitManager.loadKits();
+            GameManager.init(this, this.arenaManager, this.playerManager, matchRepository, this.kitManager, this.shopManager, this.economyManager);
             this.gameManager = GameManager.getInstance();
             QueueManager.init(this.gameManager, this.arenaManager);
             this.queueManager = QueueManager.getInstance();

--- a/src/main/java/fr/heneria/nexus/game/kit/manager/KitManager.java
+++ b/src/main/java/fr/heneria/nexus/game/kit/manager/KitManager.java
@@ -1,0 +1,80 @@
+package fr.heneria.nexus.game.kit.manager;
+
+import fr.heneria.nexus.game.kit.model.Kit;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Gère les kits de départ disponibles.
+ */
+public class KitManager {
+
+    private static KitManager instance;
+
+    private final Map<String, Kit> kits = new ConcurrentHashMap<>();
+
+    private KitManager() {
+    }
+
+    public static KitManager getInstance() {
+        if (instance == null) {
+            instance = new KitManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Charge les kits par défaut en mémoire.
+     */
+    public void loadKits() {
+        kits.clear();
+
+        // Kit Solo
+        List<ItemStack> soloItems = new ArrayList<>();
+        soloItems.add(enchant(new ItemStack(Material.LEATHER_HELMET), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        soloItems.add(enchant(new ItemStack(Material.IRON_CHESTPLATE), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        soloItems.add(enchant(new ItemStack(Material.IRON_LEGGINGS), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        soloItems.add(enchant(new ItemStack(Material.LEATHER_BOOTS), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        soloItems.add(enchant(new ItemStack(Material.STONE_SWORD), Enchantment.DAMAGE_ALL, 2));
+        soloItems.add(new ItemStack(Material.BOW));
+        kits.put("Solo", new Kit("Solo", soloItems));
+
+        // Kit Équipe
+        List<ItemStack> teamItems = new ArrayList<>();
+        teamItems.add(enchant(new ItemStack(Material.LEATHER_HELMET), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        teamItems.add(enchant(new ItemStack(Material.LEATHER_CHESTPLATE), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        teamItems.add(enchant(new ItemStack(Material.LEATHER_LEGGINGS), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        teamItems.add(enchant(new ItemStack(Material.LEATHER_BOOTS), Enchantment.PROTECTION_ENVIRONMENTAL, 2));
+        teamItems.add(enchant(new ItemStack(Material.WOODEN_SWORD), Enchantment.DAMAGE_ALL, 2));
+        kits.put("Equipe", new Kit("Equipe", teamItems));
+    }
+
+    private ItemStack enchant(ItemStack item, Enchantment enchantment, int level) {
+        ItemMeta meta = item.getItemMeta();
+        meta.addEnchant(enchantment, level, true);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    public Kit getKit(String name) {
+        return kits.get(name);
+    }
+
+    public void applyKit(Player player, Kit kit) {
+        if (player == null || kit == null) {
+            return;
+        }
+        player.getInventory().clear();
+        for (ItemStack item : kit.getItems()) {
+            player.getInventory().addItem(item.clone());
+        }
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/kit/model/Kit.java
+++ b/src/main/java/fr/heneria/nexus/game/kit/model/Kit.java
@@ -1,0 +1,29 @@
+package fr.heneria.nexus.game.kit.model;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Représente un kit d'équipement de base pour un joueur.
+ */
+public class Kit {
+
+    private final String name;
+    private final List<ItemStack> items;
+
+    public Kit(String name, List<ItemStack> items) {
+        this.name = name;
+        this.items = new ArrayList<>(items);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<ItemStack> getItems() {
+        return Collections.unmodifiableList(items);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/model/Match.java
+++ b/src/main/java/fr/heneria/nexus/game/model/Match.java
@@ -15,6 +15,7 @@ public class Match {
     private GameState state = GameState.WAITING;
     private final Map<Integer, Team> teams = new ConcurrentHashMap<>();
     private BukkitTask countdownTask;
+    private BukkitTask shopPhaseTask;
     private Instant startTime;
     private Instant endTime;
     private final Map<UUID, Integer> kills = new ConcurrentHashMap<>();
@@ -55,6 +56,14 @@ public class Match {
 
     public void setCountdownTask(BukkitTask countdownTask) {
         this.countdownTask = countdownTask;
+    }
+
+    public BukkitTask getShopPhaseTask() {
+        return shopPhaseTask;
+    }
+
+    public void setShopPhaseTask(BukkitTask shopPhaseTask) {
+        this.shopPhaseTask = shopPhaseTask;
     }
 
     public Instant getStartTime() {

--- a/src/main/java/fr/heneria/nexus/gui/player/ShopCategoryViewGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/ShopCategoryViewGui.java
@@ -1,0 +1,85 @@
+package fr.heneria.nexus.gui.player;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.economy.manager.EconomyManager;
+import fr.heneria.nexus.economy.model.TransactionType;
+import fr.heneria.nexus.player.manager.PlayerManager;
+import fr.heneria.nexus.player.model.PlayerProfile;
+import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.shop.model.ShopItem;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+
+/**
+ * Vue détaillée d'une catégorie de la boutique.
+ */
+public class ShopCategoryViewGui {
+
+    private final ShopManager shopManager;
+    private final EconomyManager economyManager;
+    private final PlayerManager playerManager;
+    private final JavaPlugin plugin;
+    private final String category;
+
+    public ShopCategoryViewGui(ShopManager shopManager, EconomyManager economyManager, PlayerManager playerManager,
+                               JavaPlugin plugin, String category) {
+        this.shopManager = shopManager;
+        this.economyManager = economyManager;
+        this.playerManager = playerManager;
+        this.plugin = plugin;
+        this.category = category;
+    }
+
+    public void open(Player player) {
+        List<ShopItem> items = shopManager.getItemsForCategory(category);
+        int rows = Math.min(6, Math.max(1, (int) Math.ceil(items.size() / 9.0)));
+        Gui gui = Gui.gui()
+                .title(Component.text("Boutique - " + category))
+                .rows(rows)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        for (ShopItem item : items) {
+            if (!item.isEnabled()) {
+                continue;
+            }
+            GuiItem guiItem = ItemBuilder.from(item.getMaterial())
+                    .name(Component.text(item.getDisplayName() != null ? item.getDisplayName() : item.getMaterial().name()))
+                    .lore(Component.text("Prix: " + item.getPrice() + " points", NamedTextColor.YELLOW))
+                    .asGuiItem(event -> {
+                        event.setCancelled(true);
+                        Player p = (Player) event.getWhoClicked();
+                        PlayerProfile profile = playerManager.getPlayerProfile(p.getUniqueId());
+                        if (profile == null) {
+                            return;
+                        }
+                        if (!economyManager.hasEnoughPoints(p.getUniqueId(), item.getPrice())) {
+                            p.playSound(p.getLocation(), Sound.ENTITY_VILLAGER_NO, 1f, 1f);
+                            p.sendMessage("§cVous n'avez pas assez de points !");
+                            return;
+                        }
+                        economyManager.removePoints(p.getUniqueId(), item.getPrice(), TransactionType.SPEND_SHOP, "shop")
+                                .thenAccept(success -> {
+                                    if (success) {
+                                        Bukkit.getScheduler().runTask(plugin, () -> {
+                                            p.getInventory().addItem(new ItemStack(item.getMaterial()));
+                                            p.playSound(p.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1f);
+                                        });
+                                    }
+                                });
+                    });
+            gui.addItem(guiItem);
+        }
+
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/player/ShopGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/ShopGui.java
@@ -1,0 +1,60 @@
+package fr.heneria.nexus.gui.player;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.economy.manager.EconomyManager;
+import fr.heneria.nexus.player.manager.PlayerManager;
+import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.shop.model.ShopItem;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Interface de boutique pour les joueurs.
+ */
+public class ShopGui {
+
+    private final ShopManager shopManager;
+    private final EconomyManager economyManager;
+    private final PlayerManager playerManager;
+    private final JavaPlugin plugin;
+
+    public ShopGui(ShopManager shopManager, EconomyManager economyManager, PlayerManager playerManager, JavaPlugin plugin) {
+        this.shopManager = shopManager;
+        this.economyManager = economyManager;
+        this.playerManager = playerManager;
+        this.plugin = plugin;
+    }
+
+    public void open(Player player) {
+        Set<String> categories = shopManager.getCategories();
+        int rows = Math.min(6, Math.max(1, (int) Math.ceil(categories.size() / 9.0)));
+        Gui gui = Gui.gui()
+                .title(Component.text("Boutique"))
+                .rows(rows)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        for (String category : categories) {
+            List<ShopItem> items = shopManager.getItemsForCategory(category);
+            Material icon = items.isEmpty() ? Material.CHEST : items.get(0).getMaterial();
+            GuiItem guiItem = ItemBuilder.from(icon)
+                    .name(Component.text(category, NamedTextColor.GREEN))
+                    .asGuiItem(event -> {
+                        event.setCancelled(true);
+                        new ShopCategoryViewGui(shopManager, economyManager, playerManager, plugin, category)
+                                .open((Player) event.getWhoClicked());
+                    });
+            gui.addItem(guiItem);
+        }
+
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/shop/manager/ShopManager.java
+++ b/src/main/java/fr/heneria/nexus/shop/manager/ShopManager.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ShopManager {
@@ -37,5 +38,9 @@ public class ShopManager {
 
     public List<ShopItem> getItemsForCategory(String category) {
         return itemsByCategory.getOrDefault(category, Collections.emptyList());
+    }
+
+    public Set<String> getCategories() {
+        return itemsByCategory.keySet();
     }
 }


### PR DESCRIPTION
## Summary
- add kit system with default Solo and Équipe loadouts
- open player shop during match preparation and close after 20s
- enable purchasing items using points with feedback sounds

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c06c2c72d88324902e037c9a6d4b71