### PR TITLE
feat: add capture phase and arena objects

### DIFF
--- a/src/main/java/fr/heneria/nexus/admin/placement/AdminPlacementManager.java
+++ b/src/main/java/fr/heneria/nexus/admin/placement/AdminPlacementManager.java
@@ -1,5 +1,6 @@
 package fr.heneria.nexus.admin.placement;
 
+import fr.heneria.nexus.arena.model.ArenaGameObject;
 import org.bukkit.entity.Player;
 
 import java.util.Map;
@@ -21,7 +22,7 @@ public class AdminPlacementManager {
         return instance;
     }
 
-    private final Map<UUID, SpawnPlacementContext> placementSessions = new ConcurrentHashMap<>();
+    private final Map<UUID, PlacementContext> placementSessions = new ConcurrentHashMap<>();
 
     private AdminPlacementManager() {
     }
@@ -29,10 +30,16 @@ public class AdminPlacementManager {
     /**
      * Démarre le mode de placement pour un administrateur.
      */
-    public void startPlacementMode(Player admin, SpawnPlacementContext context) {
+    public void startPlacementMode(Player admin, PlacementContext context) {
         placementSessions.put(admin.getUniqueId(), context);
-        admin.sendMessage("§eMode placement activé. Cliquez-gauche sur un bloc pour définir le spawn de l'Équipe "
-                + context.teamId() + ", Spawn " + context.spawnNumber() + ". Clic-droit pour annuler.");
+        if (context instanceof SpawnPlacementContext spawn) {
+            admin.sendMessage("§eMode placement activé. Cliquez-gauche sur un bloc pour définir le spawn de l'Équipe "
+                    + spawn.teamId() + ", Spawn " + spawn.spawnNumber() + ". Clic-droit pour annuler.");
+        } else if (context instanceof GameObjectPlacementContext objectCtx) {
+            ArenaGameObject obj = objectCtx.gameObject();
+            admin.sendMessage("§eMode placement activé. Cliquez-gauche pour définir l'emplacement de "
+                    + obj.getObjectType() + " " + obj.getObjectIndex() + ". Clic-droit pour annuler.");
+        }
     }
 
     /**
@@ -49,7 +56,7 @@ public class AdminPlacementManager {
     /**
      * Récupère le contexte de placement d'un administrateur.
      */
-    public SpawnPlacementContext getPlacementContext(Player admin) {
+    public PlacementContext getPlacementContext(Player admin) {
         return placementSessions.get(admin.getUniqueId());
     }
 

--- a/src/main/java/fr/heneria/nexus/admin/placement/GameObjectPlacementContext.java
+++ b/src/main/java/fr/heneria/nexus/admin/placement/GameObjectPlacementContext.java
@@ -1,0 +1,10 @@
+package fr.heneria.nexus.admin.placement;
+
+import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.arena.model.ArenaGameObject;
+
+/**
+ * Contexte de placement pour un objet de jeu (ex: cellule d'énergie).
+ */
+public record GameObjectPlacementContext(Arena arena, ArenaGameObject gameObject) implements PlacementContext {
+}

--- a/src/main/java/fr/heneria/nexus/admin/placement/PlacementContext.java
+++ b/src/main/java/fr/heneria/nexus/admin/placement/PlacementContext.java
@@ -1,0 +1,7 @@
+package fr.heneria.nexus.admin.placement;
+
+/**
+ * Marqueur pour les différents contextes de placement.
+ */
+public interface PlacementContext {
+}

--- a/src/main/java/fr/heneria/nexus/admin/placement/SpawnPlacementContext.java
+++ b/src/main/java/fr/heneria/nexus/admin/placement/SpawnPlacementContext.java
@@ -5,6 +5,6 @@ import fr.heneria.nexus.arena.model.Arena;
 /**
  * Contexte de placement pour un point de spawn.
  */
-public record SpawnPlacementContext(Arena arena, int teamId, int spawnNumber) {
+public record SpawnPlacementContext(Arena arena, int teamId, int spawnNumber) implements PlacementContext {
 }
 

--- a/src/main/java/fr/heneria/nexus/arena/manager/ArenaManager.java
+++ b/src/main/java/fr/heneria/nexus/arena/manager/ArenaManager.java
@@ -32,6 +32,7 @@ public class ArenaManager {
     public void saveArena(Arena arena) {
         arenaRepository.saveArena(arena);
         arenaRepository.saveSpawns(arena);
+        arenaRepository.saveGameObjects(arena);
     }
 
     public void deleteArena(Arena arena) {

--- a/src/main/java/fr/heneria/nexus/arena/model/Arena.java
+++ b/src/main/java/fr/heneria/nexus/arena/model/Arena.java
@@ -3,7 +3,10 @@ package fr.heneria.nexus.arena.model;
 import org.bukkit.Location;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
 
 /**
  * Représente une arène en mémoire.
@@ -14,11 +17,13 @@ public class Arena {
     private final int maxPlayers;
     // Map<TeamID, Map<SpawnNumber, Location>>
     private final Map<Integer, Map<Integer, Location>> spawns;
+    private final List<ArenaGameObject> gameObjects;
 
     public Arena(String name, int maxPlayers) {
         this.name = name;
         this.maxPlayers = maxPlayers;
         this.spawns = new ConcurrentHashMap<>();
+        this.gameObjects = new CopyOnWriteArrayList<>();
     }
 
     public int getId() {
@@ -41,8 +46,27 @@ public class Arena {
         return spawns;
     }
 
+    public List<ArenaGameObject> getGameObjects() {
+        return gameObjects;
+    }
+
+    public Optional<ArenaGameObject> getGameObject(String type, int index) {
+        return gameObjects.stream()
+                .filter(obj -> obj.getObjectType().equalsIgnoreCase(type) && obj.getObjectIndex() == index)
+                .findFirst();
+    }
+
     // Méthode pour ajouter/modifier un spawn
     public void setSpawn(int teamId, int spawnNumber, Location location) {
         spawns.computeIfAbsent(teamId, k -> new ConcurrentHashMap<>()).put(spawnNumber, location);
+    }
+
+    public void setGameObjectLocation(String type, int index, Location location) {
+        ArenaGameObject obj = getGameObject(type, index).orElseGet(() -> {
+            ArenaGameObject newObj = new ArenaGameObject(type, index);
+            gameObjects.add(newObj);
+            return newObj;
+        });
+        obj.setLocation(location);
     }
 }

--- a/src/main/java/fr/heneria/nexus/arena/model/ArenaGameObject.java
+++ b/src/main/java/fr/heneria/nexus/arena/model/ArenaGameObject.java
@@ -1,0 +1,33 @@
+package fr.heneria.nexus.arena.model;
+
+import org.bukkit.Location;
+
+/**
+ * Représente un objet de jeu positionnable dans une arène (ex: cellule d'énergie).
+ */
+public class ArenaGameObject {
+    private final String objectType;
+    private final int objectIndex;
+    private Location location;
+
+    public ArenaGameObject(String objectType, int objectIndex) {
+        this.objectType = objectType;
+        this.objectIndex = objectIndex;
+    }
+
+    public String getObjectType() {
+        return objectType;
+    }
+
+    public int getObjectIndex() {
+        return objectIndex;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/arena/repository/ArenaRepository.java
+++ b/src/main/java/fr/heneria/nexus/arena/repository/ArenaRepository.java
@@ -10,6 +10,8 @@ public interface ArenaRepository {
     void saveArena(Arena arena);
     // Sauvegarde uniquement les spawns d'une arène existante.
     void saveSpawns(Arena arena);
+    // Sauvegarde les objets de jeu d'une arène.
+    void saveGameObjects(Arena arena);
     // Charge toutes les arènes et leurs spawns.
     Map<Integer, Arena> loadAllArenas();
     // Trouve une arène par son nom.

--- a/src/main/java/fr/heneria/nexus/arena/repository/JdbcArenaRepository.java
+++ b/src/main/java/fr/heneria/nexus/arena/repository/JdbcArenaRepository.java
@@ -1,6 +1,7 @@
 package fr.heneria.nexus.arena.repository;
 
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.arena.model.ArenaGameObject;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -81,10 +82,42 @@ public class JdbcArenaRepository implements ArenaRepository {
     }
 
     @Override
+    public void saveGameObjects(Arena arena) {
+        String deleteSql = "DELETE FROM arena_game_objects WHERE arena_id = ?";
+        String insertSql = "INSERT INTO arena_game_objects (arena_id, object_type, object_index, world, x, y, z, yaw, pitch) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (Connection connection = dataSource.getConnection()) {
+            try (PreparedStatement deleteStmt = connection.prepareStatement(deleteSql)) {
+                deleteStmt.setInt(1, arena.getId());
+                deleteStmt.executeUpdate();
+            }
+            try (PreparedStatement insertStmt = connection.prepareStatement(insertSql)) {
+                for (ArenaGameObject obj : arena.getGameObjects()) {
+                    if (obj.getLocation() == null) continue;
+                    Location loc = obj.getLocation();
+                    insertStmt.setInt(1, arena.getId());
+                    insertStmt.setString(2, obj.getObjectType());
+                    insertStmt.setInt(3, obj.getObjectIndex());
+                    insertStmt.setString(4, loc.getWorld().getName());
+                    insertStmt.setDouble(5, loc.getX());
+                    insertStmt.setDouble(6, loc.getY());
+                    insertStmt.setDouble(7, loc.getZ());
+                    insertStmt.setFloat(8, loc.getYaw());
+                    insertStmt.setFloat(9, loc.getPitch());
+                    insertStmt.addBatch();
+                }
+                insertStmt.executeBatch();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public Map<Integer, Arena> loadAllArenas() {
         Map<Integer, Arena> arenas = new HashMap<>();
         String arenaSql = "SELECT id, name, max_players FROM arenas";
         String spawnSql = "SELECT arena_id, team_id, spawn_number, world, x, y, z, yaw, pitch FROM arena_spawns";
+        String objectSql = "SELECT arena_id, object_type, object_index, world, x, y, z, yaw, pitch FROM arena_game_objects";
         try (Connection connection = dataSource.getConnection()) {
             try (PreparedStatement stmt = connection.prepareStatement(arenaSql);
                  ResultSet rs = stmt.executeQuery()) {
@@ -114,6 +147,27 @@ public class JdbcArenaRepository implements ArenaRepository {
                         World world = Bukkit.getWorld(worldName);
                         if (world != null) {
                             arena.setSpawn(teamId, spawnNumber, new Location(world, x, y, z, yaw, pitch));
+                        }
+                    }
+                }
+            }
+            try (PreparedStatement stmt = connection.prepareStatement(objectSql);
+                 ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    int arenaId = rs.getInt("arena_id");
+                    String type = rs.getString("object_type");
+                    int index = rs.getInt("object_index");
+                    String worldName = rs.getString("world");
+                    double x = rs.getDouble("x");
+                    double y = rs.getDouble("y");
+                    double z = rs.getDouble("z");
+                    float yaw = rs.getFloat("yaw");
+                    float pitch = rs.getFloat("pitch");
+                    Arena arena = arenas.get(arenaId);
+                    if (arena != null) {
+                        World world = Bukkit.getWorld(worldName);
+                        if (world != null) {
+                            arena.setGameObjectLocation(type, index, new Location(world, x, y, z, yaw, pitch));
                         }
                     }
                 }
@@ -150,6 +204,26 @@ public class JdbcArenaRepository implements ArenaRepository {
                                 World world = Bukkit.getWorld(worldName);
                                 if (world != null) {
                                     arena.setSpawn(teamId, spawnNumber, new Location(world, x, y, z, yaw, pitch));
+                                }
+                            }
+                        }
+                    }
+                    try (PreparedStatement objStmt = connection.prepareStatement(
+                            "SELECT object_type, object_index, world, x, y, z, yaw, pitch FROM arena_game_objects WHERE arena_id = ?")) {
+                        objStmt.setInt(1, arena.getId());
+                        try (ResultSet objRs = objStmt.executeQuery()) {
+                            while (objRs.next()) {
+                                String type = objRs.getString("object_type");
+                                int index = objRs.getInt("object_index");
+                                String worldName = objRs.getString("world");
+                                double x = objRs.getDouble("x");
+                                double y = objRs.getDouble("y");
+                                double z = objRs.getDouble("z");
+                                float yaw = objRs.getFloat("yaw");
+                                float pitch = objRs.getFloat("pitch");
+                                World world = Bukkit.getWorld(worldName);
+                                if (world != null) {
+                                    arena.setGameObjectLocation(type, index, new Location(world, x, y, z, yaw, pitch));
                                 }
                             }
                         }

--- a/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
+++ b/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
@@ -9,6 +9,8 @@ import fr.heneria.nexus.game.model.GameState;
 import fr.heneria.nexus.game.model.Match;
 import fr.heneria.nexus.game.model.Team;
 import fr.heneria.nexus.game.repository.MatchRepository;
+import fr.heneria.nexus.game.phase.GamePhase;
+import fr.heneria.nexus.game.phase.PhaseManager;
 import fr.heneria.nexus.gui.player.ShopGui;
 import fr.heneria.nexus.shop.manager.ShopManager;
 import fr.heneria.nexus.player.manager.PlayerManager;
@@ -63,6 +65,7 @@ public class GameManager {
     public Match createMatch(Arena arena, List<List<UUID>> playerTeams) {
         UUID matchId = UUID.randomUUID();
         Match match = new Match(matchId, arena);
+        match.setPhaseManager(new PhaseManager(plugin));
         for (int i = 0; i < playerTeams.size(); i++) {
             Team team = new Team(i + 1);
             for (UUID uuid : playerTeams.get(i)) {
@@ -128,6 +131,9 @@ public class GameManager {
                     p.closeInventory();
                     p.sendMessage("La phase d'achat est terminée !");
                 }
+            }
+            if (match.getPhaseManager() != null) {
+                match.getPhaseManager().transitionTo(match, GamePhase.CAPTURE);
             }
         }, 400L);
         match.setShopPhaseTask(task);

--- a/src/main/java/fr/heneria/nexus/game/model/Match.java
+++ b/src/main/java/fr/heneria/nexus/game/model/Match.java
@@ -1,6 +1,8 @@
 package fr.heneria.nexus.game.model;
 
 import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.game.phase.GamePhase;
+import fr.heneria.nexus.game.phase.PhaseManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
@@ -20,6 +22,8 @@ public class Match {
     private Instant endTime;
     private final Map<UUID, Integer> kills = new ConcurrentHashMap<>();
     private final Map<UUID, Integer> deaths = new ConcurrentHashMap<>();
+    private GamePhase currentPhase = GamePhase.PREPARATION;
+    private PhaseManager phaseManager;
 
     public Match(UUID matchId, Arena arena) {
         this.matchId = matchId;
@@ -130,5 +134,21 @@ public class Match {
 
     public Map<UUID, Integer> getDeathsMap() {
         return deaths;
+    }
+
+    public GamePhase getCurrentPhase() {
+        return currentPhase;
+    }
+
+    public void setCurrentPhase(GamePhase currentPhase) {
+        this.currentPhase = currentPhase;
+    }
+
+    public PhaseManager getPhaseManager() {
+        return phaseManager;
+    }
+
+    public void setPhaseManager(PhaseManager phaseManager) {
+        this.phaseManager = phaseManager;
     }
 }

--- a/src/main/java/fr/heneria/nexus/game/phase/CapturePhase.java
+++ b/src/main/java/fr/heneria/nexus/game/phase/CapturePhase.java
@@ -1,0 +1,102 @@
+package fr.heneria.nexus.game.phase;
+
+import fr.heneria.nexus.arena.model.ArenaGameObject;
+import fr.heneria.nexus.game.model.Match;
+import fr.heneria.nexus.game.model.Team;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Phase de capture d'une cellule d'énergie.
+ */
+public class CapturePhase implements IPhase {
+
+    private final JavaPlugin plugin;
+    private BukkitTask task;
+    private EnergyCell energyCell;
+
+    public CapturePhase(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onStart(Match match) {
+        ArenaGameObject obj = match.getArena().getGameObject("ENERGY_CELL", 1).orElse(null);
+        if (obj == null || obj.getLocation() == null) {
+            match.broadcastMessage("§cAucune Cellule d'Énergie définie pour cette arène.");
+            return;
+        }
+        BossBar bossBar = Bukkit.createBossBar("Cellule d'Énergie", BarColor.WHITE, BarStyle.SOLID);
+        for (UUID playerId : match.getPlayers()) {
+            Player p = Bukkit.getPlayer(playerId);
+            if (p != null) {
+                bossBar.addPlayer(p);
+            }
+        }
+        this.energyCell = new EnergyCell(obj.getLocation(), bossBar);
+        this.task = Bukkit.getScheduler().runTaskTimer(plugin, () -> tick(match), 20L, 20L);
+    }
+
+    @Override
+    public void onEnd(Match match) {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+        if (energyCell != null) {
+            energyCell.getBossBar().removeAll();
+        }
+    }
+
+    @Override
+    public void tick(Match match) {
+        if (energyCell == null) return;
+        Location loc = energyCell.getLocation();
+        List<Player> nearby = loc.getWorld().getPlayers().stream()
+                .filter(p -> match.getPlayers().contains(p.getUniqueId()))
+                .filter(p -> p.getLocation().distance(loc) <= 5)
+                .toList();
+        if (nearby.isEmpty()) {
+            energyCell.getBossBar().setTitle("Cellule contestée");
+            return;
+        }
+        Map<Integer, Long> counts = new HashMap<>();
+        for (Player p : nearby) {
+            Team team = match.getTeamOfPlayer(p.getUniqueId());
+            if (team != null) {
+                counts.merge(team.getTeamId(), 1L, Long::sum);
+            }
+        }
+        int total = nearby.size();
+        int winningTeamId = -1;
+        long max = 0;
+        for (Map.Entry<Integer, Long> entry : counts.entrySet()) {
+            if (entry.getValue() > max) {
+                max = entry.getValue();
+                winningTeamId = entry.getKey();
+            }
+        }
+        if (winningTeamId == -1 || max <= total - max) {
+            energyCell.getBossBar().setTitle("Cellule contestée");
+            return;
+        }
+        double progress = energyCell.getCaptureProgress().merge(winningTeamId, 1D, Double::sum);
+        energyCell.getBossBar().setColor(BarColor.GREEN);
+        energyCell.getBossBar().setTitle("Équipe " + winningTeamId + " - " + (int) progress + "s");
+        energyCell.getBossBar().setProgress(Math.min(progress, 60.0) / 60.0);
+        if (progress >= 60) {
+            match.broadcastMessage("§aL'équipe " + winningTeamId + " a capturé la Cellule d'Énergie !");
+        }
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/phase/EnergyCell.java
+++ b/src/main/java/fr/heneria/nexus/game/phase/EnergyCell.java
@@ -1,0 +1,33 @@
+package fr.heneria.nexus.game.phase;
+
+import org.bukkit.Location;
+import org.bukkit.boss.BossBar;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Représente une cellule d'énergie active dans une partie.
+ */
+public class EnergyCell {
+    private final Location location;
+    private final Map<Integer, Double> captureProgress = new HashMap<>();
+    private final BossBar bossBar;
+
+    public EnergyCell(Location location, BossBar bossBar) {
+        this.location = location;
+        this.bossBar = bossBar;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public Map<Integer, Double> getCaptureProgress() {
+        return captureProgress;
+    }
+
+    public BossBar getBossBar() {
+        return bossBar;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/phase/GamePhase.java
+++ b/src/main/java/fr/heneria/nexus/game/phase/GamePhase.java
@@ -1,0 +1,12 @@
+package fr.heneria.nexus.game.phase;
+
+/**
+ * Représente les différentes phases d'une partie.
+ */
+public enum GamePhase {
+    PREPARATION,
+    CAPTURE,
+    TRANSPORT,
+    DESTRUCTION,
+    ELIMINATION
+}

--- a/src/main/java/fr/heneria/nexus/game/phase/IPhase.java
+++ b/src/main/java/fr/heneria/nexus/game/phase/IPhase.java
@@ -1,0 +1,9 @@
+package fr.heneria.nexus.game.phase;
+
+import fr.heneria.nexus.game.model.Match;
+
+public interface IPhase {
+    void onStart(Match match);
+    void onEnd(Match match);
+    void tick(Match match);
+}

--- a/src/main/java/fr/heneria/nexus/game/phase/PhaseManager.java
+++ b/src/main/java/fr/heneria/nexus/game/phase/PhaseManager.java
@@ -1,0 +1,43 @@
+package fr.heneria.nexus.game.phase;
+
+import fr.heneria.nexus.game.model.Match;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Gère les transitions entre les phases du jeu pour une partie.
+ */
+public class PhaseManager {
+
+    private final JavaPlugin plugin;
+    private final Map<GamePhase, IPhase> phases = new EnumMap<>(GamePhase.class);
+
+    public PhaseManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        // Enregistre les phases connues
+        phases.put(GamePhase.CAPTURE, new CapturePhase(plugin));
+    }
+
+    public IPhase getPhase(GamePhase phase) {
+        return phases.get(phase);
+    }
+
+    public void transitionTo(Match match, GamePhase nextPhase) {
+        GamePhase current = match.getCurrentPhase();
+        IPhase currentImpl = phases.get(current);
+        if (currentImpl != null) {
+            currentImpl.onEnd(match);
+        }
+        match.setCurrentPhase(nextPhase);
+        IPhase nextImpl = phases.get(nextPhase);
+        if (nextImpl != null) {
+            nextImpl.onStart(match);
+        }
+    }
+
+    public JavaPlugin getPlugin() {
+        return plugin;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
@@ -7,6 +7,7 @@ import fr.heneria.nexus.arena.manager.ArenaManager;
 import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.gui.admin.ArenaGameObjectGui;
 import org.bukkit.Location;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -65,6 +66,15 @@ public class ArenaEditorGui {
                     new ArenaSpawnManagerGui(arenaManager, arena, adminPlacementManager).open(p);
                 });
 
+        GuiItem manageObjects = ItemBuilder.from(Material.BEACON)
+                .name(Component.text("§6Gérer les Objets de Jeu"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    gui.setCloseGuiAction(closeEvent -> {});
+                    new ArenaGameObjectGui(arenaManager, arena, adminPlacementManager).open(p);
+                });
+
         GuiItem save = ItemBuilder.from(Material.ANVIL)
                 .name(Component.text("Sauvegarder l'arène", NamedTextColor.DARK_GREEN))
                 .asGuiItem(event -> {
@@ -111,8 +121,9 @@ public class ArenaEditorGui {
                 });
 
         gui.setItem(13, info);
-        gui.setItem(11, setSpawns);
-        gui.setItem(15, save);
+        gui.setItem(10, setSpawns);
+        gui.setItem(12, manageObjects);
+        gui.setItem(14, save);
         gui.setItem(20, teleport);
         gui.setItem(24, delete);
         gui.setItem(26, back);

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaGameObjectGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaGameObjectGui.java
@@ -1,0 +1,70 @@
+package fr.heneria.nexus.gui.admin;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.admin.placement.AdminPlacementManager;
+import fr.heneria.nexus.admin.placement.GameObjectPlacementContext;
+import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.arena.model.Arena;
+import fr.heneria.nexus.arena.model.ArenaGameObject;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * GUI pour gérer les objets de jeu d'une arène.
+ */
+public class ArenaGameObjectGui {
+
+    private final ArenaManager arenaManager;
+    private final Arena arena;
+    private final AdminPlacementManager adminPlacementManager;
+
+    public ArenaGameObjectGui(ArenaManager arenaManager, Arena arena, AdminPlacementManager adminPlacementManager) {
+        this.arenaManager = arenaManager;
+        this.arena = arena;
+        this.adminPlacementManager = adminPlacementManager;
+    }
+
+    public void open(Player player) {
+        Component title = Component.text("Objets de Jeu: ", NamedTextColor.GOLD)
+                .append(Component.text(arena.getName(), NamedTextColor.YELLOW));
+
+        Gui gui = Gui.gui()
+                .title(title)
+                .rows(1)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+        gui.setCloseGuiAction(event -> {});
+
+        ArenaGameObject cell = arena.getGameObject("ENERGY_CELL", 1).orElseGet(() -> {
+            ArenaGameObject obj = new ArenaGameObject("ENERGY_CELL", 1);
+            arena.getGameObjects().add(obj);
+            return obj;
+        });
+
+        GuiItem energyCellItem = ItemBuilder.from(Material.BEACON)
+                .name(Component.text("Cellule d'Énergie 1", NamedTextColor.AQUA))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    p.closeInventory();
+                    adminPlacementManager.startPlacementMode(p, new GameObjectPlacementContext(arena, cell));
+                });
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ArenaEditorGui(arenaManager, arena, adminPlacementManager).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(0, energyCellItem);
+        gui.setItem(8, back);
+
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/listener/AdminPlacementListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/AdminPlacementListener.java
@@ -1,9 +1,7 @@
 package fr.heneria.nexus.listener;
 
-import fr.heneria.nexus.admin.placement.AdminPlacementManager;
-import fr.heneria.nexus.admin.placement.SpawnPlacementContext;
-import fr.heneria.nexus.gui.admin.ArenaSpawnManagerGui;
-import fr.heneria.nexus.arena.manager.ArenaManager;
+import fr.heneria.nexus.admin.placement.*;
+import fr.heneria.nexus.gui.admin.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -36,24 +34,44 @@ public class AdminPlacementListener implements Listener {
             return;
         }
         event.setCancelled(true);
-        SpawnPlacementContext context = placementManager.getPlacementContext(player);
+        PlacementContext context = placementManager.getPlacementContext(player);
         Action action = event.getAction();
-        if (action == Action.LEFT_CLICK_BLOCK && event.getClickedBlock() != null) {
-            Block block = event.getClickedBlock();
-            Location loc = block.getLocation().add(0.5, 1, 0.5);
-            Location playerLoc = player.getLocation();
-            loc.setYaw(playerLoc.getYaw());
-            loc.setPitch(playerLoc.getPitch());
-            context.arena().setSpawn(context.teamId(), context.spawnNumber(), loc);
-            player.sendMessage("§aSpawn défini pour l'équipe §e" + context.teamId() + " §a, spawn §e" + context.spawnNumber() + "§a.");
-            placementManager.endPlacementMode(player);
-            Bukkit.getScheduler().runTask(plugin, () ->
-                    new ArenaSpawnManagerGui(arenaManager, context.arena(), placementManager).open(player));
-        } else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
-            player.sendMessage("§cPlacement du spawn annulé.");
-            placementManager.endPlacementMode(player);
-            Bukkit.getScheduler().runTask(plugin, () ->
-                    new ArenaSpawnManagerGui(arenaManager, context.arena(), placementManager).open(player));
+        if (context instanceof SpawnPlacementContext spawnCtx) {
+            if (action == Action.LEFT_CLICK_BLOCK && event.getClickedBlock() != null) {
+                Block block = event.getClickedBlock();
+                Location loc = block.getLocation().add(0.5, 1, 0.5);
+                Location playerLoc = player.getLocation();
+                loc.setYaw(playerLoc.getYaw());
+                loc.setPitch(playerLoc.getPitch());
+                spawnCtx.arena().setSpawn(spawnCtx.teamId(), spawnCtx.spawnNumber(), loc);
+                player.sendMessage("§aSpawn défini pour l'équipe §e" + spawnCtx.teamId() + " §a, spawn §e" + spawnCtx.spawnNumber() + "§a.");
+                placementManager.endPlacementMode(player);
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        new ArenaSpawnManagerGui(arenaManager, spawnCtx.arena(), placementManager).open(player));
+            } else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+                player.sendMessage("§cPlacement du spawn annulé.");
+                placementManager.endPlacementMode(player);
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        new ArenaSpawnManagerGui(arenaManager, spawnCtx.arena(), placementManager).open(player));
+            }
+        } else if (context instanceof GameObjectPlacementContext objCtx) {
+            if (action == Action.LEFT_CLICK_BLOCK && event.getClickedBlock() != null) {
+                Block block = event.getClickedBlock();
+                Location loc = block.getLocation().add(0.5, 1, 0.5);
+                Location playerLoc = player.getLocation();
+                loc.setYaw(playerLoc.getYaw());
+                loc.setPitch(playerLoc.getPitch());
+                objCtx.gameObject().setLocation(loc);
+                player.sendMessage("§aEmplacement défini pour " + objCtx.gameObject().getObjectType() + " "+ objCtx.gameObject().getObjectIndex() +".");
+                placementManager.endPlacementMode(player);
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        new ArenaGameObjectGui(arenaManager, objCtx.arena(), placementManager).open(player));
+            } else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+                player.sendMessage("§cPlacement annulé.");
+                placementManager.endPlacementMode(player);
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        new ArenaGameObjectGui(arenaManager, objCtx.arena(), placementManager).open(player));
+            }
         }
     }
 }

--- a/src/main/resources/db/changelog/006_create_arena_objects_table.sql
+++ b/src/main/resources/db/changelog/006_create_arena_objects_table.sql
@@ -1,0 +1,13 @@
+-- liquibase formatted sql
+-- changeset gordox:8
+CREATE TABLE arena_game_objects (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    arena_id INT NOT NULL,
+    object_type VARCHAR(32) NOT NULL, -- Ex: 'ENERGY_CELL', 'NEXUS_CORE'
+    object_index INT DEFAULT 1 NOT NULL, -- Pour les arènes avec plusieurs objets du même type
+    world VARCHAR(255) NOT NULL,
+    x DOUBLE NOT NULL, y DOUBLE NOT NULL, z DOUBLE NOT NULL,
+    yaw FLOAT, pitch FLOAT,
+    UNIQUE KEY uk_arena_object (arena_id, object_type, object_index),
+    FOREIGN KEY (arena_id) REFERENCES arenas(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -10,5 +10,6 @@
     <include file="db/changelog/003_create_economy_tables.sql"/>
     <include file="db/changelog/004_create_shop_items_table.sql"/>
     <include file="db/changelog/005_create_match_tables.sql"/>
+    <include file="db/changelog/006_create_arena_objects_table.sql"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add Liquibase migration and repository support for arena game objects
- introduce phase management system with capture phase and energy cell logic
- extend admin GUI to configure energy cell location

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c06e6c37e88324ace7b7fc9dc2aab3