### PR TITLE
feat: add multi-round rounds and scoreboard system

### DIFF
--- a/src/main/java/fr/heneria/nexus/game/model/GameState.java
+++ b/src/main/java/fr/heneria/nexus/game/model/GameState.java
@@ -4,5 +4,6 @@ public enum GameState {
     WAITING,
     STARTING,
     IN_PROGRESS,
+    ROUND_ENDING,
     ENDING
 }

--- a/src/main/java/fr/heneria/nexus/game/model/Match.java
+++ b/src/main/java/fr/heneria/nexus/game/model/Match.java
@@ -26,6 +26,10 @@ public class Match {
     private PhaseManager phaseManager;
     private final Map<Integer, NexusCore> nexusCores = new ConcurrentHashMap<>();
     private final Set<Integer> eliminatedTeamIds = new HashSet<>();
+    private int currentRound = 1;
+    private final Map<Integer, Integer> teamScores = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> roundPoints = new ConcurrentHashMap<>();
+    public static final int ROUNDS_TO_WIN = 3;
 
     public Match(UUID matchId, Arena arena) {
         this.matchId = matchId;
@@ -54,6 +58,7 @@ public class Match {
 
     public void addTeam(Team team) {
         teams.put(team.getTeamId(), team);
+        teamScores.put(team.getTeamId(), 0);
     }
 
     public BukkitTask getCountdownTask() {
@@ -172,5 +177,21 @@ public class Match {
 
     public Set<Integer> getEliminatedTeamIds() {
         return eliminatedTeamIds;
+    }
+
+    public int getCurrentRound() {
+        return currentRound;
+    }
+
+    public void setCurrentRound(int currentRound) {
+        this.currentRound = currentRound;
+    }
+
+    public Map<Integer, Integer> getTeamScores() {
+        return teamScores;
+    }
+
+    public Map<UUID, Integer> getRoundPoints() {
+        return roundPoints;
     }
 }

--- a/src/main/java/fr/heneria/nexus/game/scoreboard/ScoreboardManager.java
+++ b/src/main/java/fr/heneria/nexus/game/scoreboard/ScoreboardManager.java
@@ -1,0 +1,107 @@
+package fr.heneria.nexus.game.scoreboard;
+
+import fr.heneria.nexus.game.model.Match;
+import fr.heneria.nexus.game.model.Team;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Gère l'affichage du scoreboard pour les parties.
+ */
+public class ScoreboardManager {
+
+    private static final ScoreboardManager INSTANCE = new ScoreboardManager();
+    private final Map<UUID, Scoreboard> scoreboards = new ConcurrentHashMap<>();
+
+    private ScoreboardManager() {
+    }
+
+    public static ScoreboardManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Crée le scoreboard d'une partie pour tous les joueurs.
+     *
+     * @param match partie
+     */
+    public void createMatchScoreboard(Match match) {
+        for (UUID playerId : match.getPlayers()) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player == null) {
+                continue;
+            }
+            Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
+            Objective obj = board.registerNewObjective("nexus", "dummy", "§e§lHeneria Nexus");
+            obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+            scoreboards.put(playerId, board);
+            player.setScoreboard(board);
+        }
+        updateScoreboard(match);
+    }
+
+    /**
+     * Met à jour le contenu du scoreboard pour tous les joueurs.
+     *
+     * @param match partie
+     */
+    public void updateScoreboard(Match match) {
+        for (UUID playerId : match.getPlayers()) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player == null) {
+                continue;
+            }
+            Scoreboard board = scoreboards.computeIfAbsent(playerId, id -> {
+                Scoreboard b = Bukkit.getScoreboardManager().getNewScoreboard();
+                Objective o = b.registerNewObjective("nexus", "dummy", "§e§lHeneria Nexus");
+                o.setDisplaySlot(DisplaySlot.SIDEBAR);
+                player.setScoreboard(b);
+                return b;
+            });
+            Objective obj = board.getObjective(DisplaySlot.SIDEBAR);
+            if (obj == null) {
+                obj = board.registerNewObjective("nexus", "dummy", "§e§lHeneria Nexus");
+                obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+            }
+            // Clear previous lines
+            for (String entry : board.getEntries()) {
+                board.resetScores(entry);
+            }
+            int line = 15;
+            obj.getScore("Manche: §a" + match.getCurrentRound() + "/5").setScore(line--);
+            obj.getScore(" ").setScore(line--);
+            for (Team team : match.getTeams().values()) {
+                int teamScore = match.getTeamScores().getOrDefault(team.getTeamId(), 0);
+                String name = switch (team.getTeamId()) {
+                    case 1 -> "§9Équipe Bleue";
+                    case 2 -> "§cÉquipe Rouge";
+                    default -> "Équipe " + team.getTeamId();
+                };
+                obj.getScore(name + ": §f" + teamScore).setScore(line--);
+            }
+            obj.getScore("  ").setScore(line--);
+            int points = match.getRoundPoints().getOrDefault(playerId, 0);
+            obj.getScore("Points: §6" + points).setScore(line);
+        }
+    }
+
+    /**
+     * Supprime le scoreboard d'un joueur.
+     *
+     * @param player joueur
+     */
+    public void removeScoreboard(Player player) {
+        if (player == null) {
+            return;
+        }
+        player.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+        scoreboards.remove(player.getUniqueId());
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/player/ShopGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/ShopGui.java
@@ -3,10 +3,10 @@ package fr.heneria.nexus.gui.player;
 import dev.triumphteam.gui.builder.item.ItemBuilder;
 import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
-import fr.heneria.nexus.economy.manager.EconomyManager;
 import fr.heneria.nexus.player.manager.PlayerManager;
 import fr.heneria.nexus.shop.manager.ShopManager;
 import fr.heneria.nexus.shop.model.ShopItem;
+import fr.heneria.nexus.game.model.Match;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -22,15 +22,15 @@ import java.util.Set;
 public class ShopGui {
 
     private final ShopManager shopManager;
-    private final EconomyManager economyManager;
     private final PlayerManager playerManager;
     private final JavaPlugin plugin;
+    private final Match match;
 
-    public ShopGui(ShopManager shopManager, EconomyManager economyManager, PlayerManager playerManager, JavaPlugin plugin) {
+    public ShopGui(ShopManager shopManager, PlayerManager playerManager, JavaPlugin plugin, Match match) {
         this.shopManager = shopManager;
-        this.economyManager = economyManager;
         this.playerManager = playerManager;
         this.plugin = plugin;
+        this.match = match;
     }
 
     public void open(Player player) {
@@ -49,7 +49,7 @@ public class ShopGui {
                     .name(Component.text(category, NamedTextColor.GREEN))
                     .asGuiItem(event -> {
                         event.setCancelled(true);
-                        new ShopCategoryViewGui(shopManager, economyManager, playerManager, plugin, category)
+                        new ShopCategoryViewGui(shopManager, playerManager, plugin, match, category)
                                 .open((Player) event.getWhoClicked());
                     });
             gui.addItem(guiItem);

--- a/src/main/java/fr/heneria/nexus/listener/GameListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/GameListener.java
@@ -55,7 +55,7 @@ public class GameListener implements Listener {
                 int winningTeamId = match.getTeams().values().stream()
                         .filter(t -> !t.getPlayers().isEmpty())
                         .findFirst().map(Team::getTeamId).orElse(0);
-                gameManager.endMatch(match, winningTeamId);
+                gameManager.endRound(match, winningTeamId);
             }
         }
     }
@@ -177,7 +177,7 @@ public class GameListener implements Listener {
             }
         }
         if (aliveTeams <= 1 && lastTeamId != -1) {
-            gameManager.endMatch(match, lastTeamId);
+            gameManager.endRound(match, lastTeamId);
         }
     }
 


### PR DESCRIPTION
## Summary
- support best-of-five matches with round scores and player round points
- show persistent sidebar scoreboard with rounds, team scores and points
- reset players and start next rounds or end game with rewards

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c082bb80f88324a645336e8bd8b4c8