### PR TITLE
feat: implement elo ranking system

### DIFF
--- a/src/main/java/fr/heneria/nexus/player/manager/PlayerManager.java
+++ b/src/main/java/fr/heneria/nexus/player/manager/PlayerManager.java
@@ -40,10 +40,14 @@ public class PlayerManager {
     public PlayerProfile getPlayerProfile(UUID uuid) {
         return profileCache.get(uuid);
     }
-    
+
     // CORRECTION: Ajout de la méthode pour sauvegarder tous les profils à la désactivation
     public void unloadAllProfiles() {
         profileCache.values().forEach(playerRepository::saveProfile);
         profileCache.clear();
+    }
+
+    public PlayerRepository getPlayerRepository() {
+        return playerRepository;
     }
 }

--- a/src/main/java/fr/heneria/nexus/ranking/EloCalculator.java
+++ b/src/main/java/fr/heneria/nexus/ranking/EloCalculator.java
@@ -1,0 +1,23 @@
+package fr.heneria.nexus.ranking;
+
+/**
+ * Provides methods related to Elo rating calculations.
+ */
+public class EloCalculator {
+
+    /**
+     * Calculates the Elo rating change for a player.
+     *
+     * @param playerElo          current Elo of the player
+     * @param opponentAverageElo average Elo of the opponents
+     * @param playerWon          {@code true} if the player won the match
+     * @param kFactor            adjustment factor
+     * @return the Elo rating change rounded to the nearest integer
+     */
+    public int calculateEloChange(int playerElo, int opponentAverageElo, boolean playerWon, int kFactor) {
+        double expected = 1.0 / (1.0 + Math.pow(10, (opponentAverageElo - playerElo) / 400.0));
+        double score = playerWon ? 1.0 : 0.0;
+        double change = kFactor * (score - expected);
+        return (int) Math.round(change);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/ranking/RankManager.java
+++ b/src/main/java/fr/heneria/nexus/ranking/RankManager.java
@@ -1,0 +1,51 @@
+package fr.heneria.nexus.ranking;
+
+import fr.heneria.nexus.player.rank.PlayerRank;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Handles the association between Elo values and {@link PlayerRank}.
+ */
+public class RankManager {
+
+    private static final RankManager INSTANCE = new RankManager();
+
+    private final Map<PlayerRank, Integer> rankThresholds = new EnumMap<>(PlayerRank.class);
+
+    private RankManager() {
+        rankThresholds.put(PlayerRank.UNRANKED, 0);
+        rankThresholds.put(PlayerRank.BRONZE, 800);
+        rankThresholds.put(PlayerRank.SILVER, 1100);
+        rankThresholds.put(PlayerRank.GOLD, 1400);
+        rankThresholds.put(PlayerRank.PLATINUM, 1700);
+        rankThresholds.put(PlayerRank.DIAMOND, 2000);
+        rankThresholds.put(PlayerRank.MASTER, 2300);
+        rankThresholds.put(PlayerRank.GRANDMASTER, 2600);
+        rankThresholds.put(PlayerRank.CHAMPION, 2900);
+    }
+
+    public static RankManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Returns the rank corresponding to the provided Elo value.
+     *
+     * @param elo current Elo rating
+     * @return the matching {@link PlayerRank}
+     */
+    public PlayerRank getRankFromElo(int elo) {
+        PlayerRank current = PlayerRank.UNRANKED;
+        for (PlayerRank rank : PlayerRank.values()) {
+            int threshold = rankThresholds.getOrDefault(rank, Integer.MAX_VALUE);
+            if (elo >= threshold) {
+                current = rank;
+            } else {
+                break;
+            }
+        }
+        return current;
+    }
+}


### PR DESCRIPTION
## Summary
- add EloCalculator and RankManager utilities for competitive progression
- expose PlayerRepository via PlayerManager
- compute and apply Elo changes at game end with player feedback

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c08521494c83249e3a01de55e3623c