### PR TITLE
feat: distinguish ranked from normal queues

### DIFF
--- a/API.MD
+++ b/API.MD
@@ -245,7 +245,7 @@ public interface GameEngine {
      * @return Match créé
      * @throws ArenaNotAvailableException si l'arène n'est pas disponible
      */
-    [cite_start]Match createMatch(Arena arena, List<Team> teams) throws ArenaNotAvailableException; [cite: 589]
+    [cite_start]Match createMatch(Arena arena, List<Team> teams, MatchType type) throws ArenaNotAvailableException; [cite: 589]
     /**
      * Démarre un match.
      * @param match match à démarrer

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,7 +199,7 @@ public record ArenaConfig(
 ```java
 // GameEngine - Moteur principal
 public interface GameEngine {
-    Match createMatch(Arena arena, List<Team> teams);
+    Match createMatch(Arena arena, List<Team> teams, MatchType type);
     [cite_start]void startMatch(Match match); [cite: 170]
     void endMatch(Match match, MatchResult result);
     void pauseMatch(Match match);

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -7,6 +7,7 @@ import fr.heneria.nexus.arena.model.Arena;
 import fr.heneria.nexus.shop.manager.ShopManager;
 import fr.heneria.nexus.game.manager.GameManager;
 import fr.heneria.nexus.game.model.Match;
+import fr.heneria.nexus.game.model.MatchType;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -51,7 +52,7 @@ public class NexusAdminCommand implements CommandExecutor {
                     team2.add(p.getUniqueId());
                 }
             }
-            Match match = GameManager.getInstance().createMatch(arena, Arrays.asList(team1, team2));
+            Match match = GameManager.getInstance().createMatch(arena, Arrays.asList(team1, team2), MatchType.NORMAL);
             GameManager.getInstance().startMatchCountdown(match);
             sender.sendMessage("Match de test lancé.");
             return true;

--- a/src/main/java/fr/heneria/nexus/game/model/Match.java
+++ b/src/main/java/fr/heneria/nexus/game/model/Match.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Match {
     private final UUID matchId;
     private final Arena arena;
+    private final MatchType matchType;
     private GameState state = GameState.WAITING;
     private final Map<Integer, Team> teams = new ConcurrentHashMap<>();
     private BukkitTask countdownTask;
@@ -31,9 +32,10 @@ public class Match {
     private final Map<UUID, Integer> roundPoints = new ConcurrentHashMap<>();
     public static final int ROUNDS_TO_WIN = 3;
 
-    public Match(UUID matchId, Arena arena) {
+    public Match(UUID matchId, Arena arena, MatchType matchType) {
         this.matchId = matchId;
         this.arena = arena;
+        this.matchType = matchType;
     }
 
     public UUID getMatchId() {
@@ -42,6 +44,10 @@ public class Match {
 
     public Arena getArena() {
         return arena;
+    }
+
+    public MatchType getMatchType() {
+        return matchType;
     }
 
     public GameState getState() {

--- a/src/main/java/fr/heneria/nexus/game/model/MatchType.java
+++ b/src/main/java/fr/heneria/nexus/game/model/MatchType.java
@@ -1,0 +1,10 @@
+package fr.heneria.nexus.game.model;
+
+/**
+ * Type de partie possible.
+ */
+public enum MatchType {
+    NORMAL,
+    RANKED
+}
+


### PR DESCRIPTION
## Summary
- add MatchType to represent ranked or normal matches
- isolate Elo updates to ranked matches
- refactor QueueManager and GUI for separate ranked and normal queues

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c086eb71788324a09bb0dca9d92cf7