### PR TITLE
Fix: preserve inventory and improve preparation phase

### DIFF
--- a/src/main/java/fr/heneria/nexus/listener/GameListener.java
+++ b/src/main/java/fr/heneria/nexus/listener/GameListener.java
@@ -76,7 +76,12 @@ public class GameListener implements Listener {
         if (match == null) {
             return;
         }
-        event.getDrops().clear();
+        Team team = match.getTeamOfPlayer(uuid);
+        if (team == null || !match.getEliminatedTeamIds().contains(team.getTeamId())) {
+            event.setKeepInventory(true);
+        } else {
+            event.getDrops().clear();
+        }
         event.setDeathMessage(null);
 
         match.incrementDeath(uuid);
@@ -85,7 +90,6 @@ public class GameListener implements Listener {
             match.incrementKill(killer.getUniqueId());
         }
 
-        Team team = match.getTeamOfPlayer(uuid);
         Location spawn = null;
         if (team != null) {
             Map<Integer, Location> spawns = match.getArena().getSpawns().get(team.getTeamId());


### PR DESCRIPTION
## Summary
- retain player inventory between deaths outside elimination with keepInventory gamerule
- immobilize players during shop phase and display countdown via action bar
- toggle keepInventory rule at match start and end

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c08e4a12d08324b2540836bd824b6d