### PR TITLE
Refactor: Amélioration générale des GUIs et des commandes

### DIFF
--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -76,8 +76,18 @@ public class NexusAdminCommand implements CommandExecutor {
             return true;
         }
 
-        // Ouvre le GUI principal pour /nx ou /nx admin
-        if (args.length == 0 || "admin".equalsIgnoreCase(args[0])) {
+        // Affiche l'aide si aucune sous-commande ou demande d'aide
+        if (args.length == 0 || "help".equalsIgnoreCase(args[0])) {
+            sender.sendMessage("§6Commandes Nexus :");
+            sender.sendMessage("§e/nx admin §7- ouvre le centre de contrôle Nexus");
+            sender.sendMessage("§e/nx arena list §7- liste les arènes chargées");
+            sender.sendMessage("§e/nx arena save <nom> §7- sauvegarde l'arène spécifiée");
+            sender.sendMessage("§e/nx sanction pardon <joueur> §7- annule la dernière sanction du joueur");
+            return true;
+        }
+
+        // Ouvre le GUI principal pour /nx admin
+        if ("admin".equalsIgnoreCase(args[0])) {
             if (!(sender instanceof Player)) {
                 sender.sendMessage("Cette commande doit être exécutée par un joueur.");
                 return true;

--- a/src/main/java/fr/heneria/nexus/game/hologram/HologramManager.java
+++ b/src/main/java/fr/heneria/nexus/game/hologram/HologramManager.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.game.hologram;
 
 import eu.decentsoftware.holograms.api.DHAPI;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
+import fr.heneria.nexus.game.model.TeamColor;
 import org.bukkit.Location;
 
 import java.util.ArrayList;
@@ -45,11 +46,7 @@ public class HologramManager {
         Collections.sort(teamIds);
         for (int teamId : teamIds) {
             double progress = progresses.getOrDefault(teamId, 0D);
-            String name = switch (teamId) {
-                case 1 -> "§9Équipe Bleue";
-                case 2 -> "§cÉquipe Rouge";
-                default -> "Équipe " + teamId;
-            };
+            String name = TeamColor.coloredName(teamId);
             lines.add(name + ": §f" + (int) progress + " / 60s");
         }
         if (contested) {

--- a/src/main/java/fr/heneria/nexus/game/model/TeamColor.java
+++ b/src/main/java/fr/heneria/nexus/game/model/TeamColor.java
@@ -1,0 +1,56 @@
+package fr.heneria.nexus.game.model;
+
+import java.util.Map;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
+/**
+ * Couleurs centralisées des équipes pour une cohérence globale.
+ */
+public final class TeamColor {
+
+    private static final Map<Integer, NamedTextColor> COLORS = Map.of(
+            1, NamedTextColor.BLUE,
+            2, NamedTextColor.RED
+    );
+
+    private TeamColor() {
+    }
+
+    /**
+     * Récupère la couleur {@link NamedTextColor} associée à l'identifiant d'équipe donné.
+     *
+     * @param teamId identifiant de l'équipe
+     * @return couleur de l'équipe ou blanc par défaut
+     */
+    public static NamedTextColor of(int teamId) {
+        return COLORS.getOrDefault(teamId, NamedTextColor.WHITE);
+    }
+
+    /**
+     * Retourne le code couleur hérité (ex: "§9") correspondant à l'équipe.
+     *
+     * @param teamId identifiant de l'équipe
+     * @return code couleur legacy
+     */
+    public static String legacy(int teamId) {
+        return LegacyComponentSerializer.legacySection().serialize(Component.text("", of(teamId)));
+    }
+
+    /**
+     * Fournit un nom d'équipe coloré utilisant la couleur associée.
+     *
+     * @param teamId identifiant de l'équipe
+     * @return nom d'équipe coloré
+     */
+    public static String coloredName(int teamId) {
+        String base = switch (teamId) {
+            case 1 -> "Équipe Bleue";
+            case 2 -> "Équipe Rouge";
+            default -> "Équipe " + teamId;
+        };
+        return legacy(teamId) + base;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/scoreboard/ScoreboardManager.java
+++ b/src/main/java/fr/heneria/nexus/game/scoreboard/ScoreboardManager.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.game.scoreboard;
 
 import fr.heneria.nexus.game.model.Match;
 import fr.heneria.nexus.game.model.Team;
+import fr.heneria.nexus.game.model.TeamColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.DisplaySlot;
@@ -79,11 +80,7 @@ public class ScoreboardManager {
             obj.getScore(" ").setScore(line--);
             for (Team team : match.getTeams().values()) {
                 int teamScore = match.getTeamScores().getOrDefault(team.getTeamId(), 0);
-                String name = switch (team.getTeamId()) {
-                    case 1 -> "§9Équipe Bleue";
-                    case 2 -> "§cÉquipe Rouge";
-                    default -> "Équipe " + team.getTeamId();
-                };
+                String name = TeamColor.coloredName(team.getTeamId());
                 obj.getScore(name + ": §f" + teamScore).setScore(line--);
             }
             obj.getScore("  ").setScore(line--);

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaEditorGui.java
@@ -128,6 +128,10 @@ public class ArenaEditorGui {
         gui.setItem(24, delete);
         gui.setItem(26, back);
 
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         arenaManager.setEditingArena(player.getUniqueId(), arena);
         gui.open(player);
     }

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaGameObjectGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaGameObjectGui.java
@@ -84,6 +84,10 @@ public class ArenaGameObjectGui {
 
         gui.setItem(8, back);
 
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
@@ -70,6 +70,18 @@ public class ArenaListGui {
                 });
         gui.addItem(create);
 
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    ((Player) event.getWhoClicked()).performCommand("nx admin");
+                });
+        gui.setItem(rows * 9 - 1, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaSpawnManagerGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaSpawnManagerGui.java
@@ -89,6 +89,10 @@ public class ArenaSpawnManagerGui {
 
         gui.setItem(rows * 9 - 1, back);
 
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopAdminGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopAdminGui.java
@@ -46,7 +46,20 @@ public class ShopAdminGui {
                     new ShopCategoryGui(shopManager, "Utilitaires").open((Player) event.getWhoClicked());
                 });
 
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    ((Player) event.getWhoClicked()).performCommand("nx admin");
+                });
+
         gui.addItem(armes, armures, utilitaires);
+        gui.setItem(26, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopCategoryGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopCategoryGui.java
@@ -9,6 +9,7 @@ import fr.heneria.nexus.shop.model.ShopItem;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
+import org.bukkit.Material;
 
 import java.util.List;
 
@@ -47,6 +48,19 @@ public class ShopCategoryGui {
                     });
             gui.addItem(guiItem);
         }
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ShopAdminGui(shopManager).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(rows * 9 - 1, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
 
         gui.open(player);
     }

--- a/src/main/java/fr/heneria/nexus/gui/player/GameModeSelectorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/GameModeSelectorGui.java
@@ -7,6 +7,7 @@ import fr.heneria.nexus.game.model.MatchType;
 import fr.heneria.nexus.game.queue.GameMode;
 import fr.heneria.nexus.game.queue.QueueManager;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -33,12 +34,18 @@ public class GameModeSelectorGui {
         gui.setDefaultClickAction(event -> event.setCancelled(true));
 
         gui.addItem(ItemBuilder.from(Material.IRON_SWORD)
-                .name(Component.text("Partie Normale"))
+                .name(Component.text("Partie Normale", NamedTextColor.GREEN))
+                .lore(Component.text("Mode de jeu standard", NamedTextColor.GRAY))
                 .asGuiItem(e -> openModeMenu((Player) e.getWhoClicked(), MatchType.NORMAL)));
 
         gui.addItem(ItemBuilder.from(Material.DIAMOND_SWORD)
-                .name(Component.text("Partie Classée"))
+                .name(Component.text("Partie Classée", NamedTextColor.GREEN))
+                .lore(Component.text("Affrontez les meilleurs", NamedTextColor.GRAY))
                 .asGuiItem(e -> openModeMenu((Player) e.getWhoClicked(), MatchType.RANKED)));
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
 
         gui.open(player);
     }
@@ -59,6 +66,19 @@ public class GameModeSelectorGui {
                 gui.updateItem(mode.ordinal(), createItem(type, mode));
             }
         }, 20L, 40L);
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(e -> {
+                    e.setCancelled(true);
+                    task.cancel();
+                    open((Player) e.getWhoClicked());
+                });
+        gui.setItem(8, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
 
         gui.setCloseGuiAction(event -> task.cancel());
         gui.open(player);

--- a/src/main/java/fr/heneria/nexus/gui/player/ShopCategoryViewGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/ShopCategoryViewGui.java
@@ -16,6 +16,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Material;
 
 import java.util.List;
 
@@ -77,6 +78,18 @@ public class ShopCategoryViewGui {
                     });
             gui.addItem(guiItem);
         }
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ShopGui(shopManager, playerManager, plugin, match).open((Player) event.getWhoClicked());
+                });
+        gui.setItem(rows * 9 - 1, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
 
         gui.open(player);
     }

--- a/src/main/java/fr/heneria/nexus/gui/player/ShopGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/player/ShopGui.java
@@ -55,6 +55,10 @@ public class ShopGui {
             gui.addItem(guiItem);
         }
 
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         gui.open(player);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,6 +13,7 @@ commands:
   play:
     description: Ouvre la sélection de mode de jeu
     usage: /play
+    aliases: [jouer]
 permissions:
   nexus.admin:
     description: Accès à l'administration de Nexus


### PR DESCRIPTION
## Summary
- centralize team colors via new TeamColor helper and use it in scoreboard and holograms
- polish GUIs with back buttons, lore and glass pane fillers
- add /play alias `/jouer` and rework `/nx help` for clearer admin guidance

## Testing
- `mvn -q test` *(fails: Network is unreachable for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c090a0397883249f04e1065f1cc114