### PR TITLE
feat: add admin kit management

### DIFF
--- a/src/main/java/fr/heneria/nexus/Nexus.java
+++ b/src/main/java/fr/heneria/nexus/Nexus.java
@@ -20,6 +20,8 @@ import fr.heneria.nexus.shop.manager.ShopManager;
 import fr.heneria.nexus.shop.repository.JdbcShopRepository;
 import fr.heneria.nexus.shop.repository.ShopRepository;
 import fr.heneria.nexus.game.kit.manager.KitManager;
+import fr.heneria.nexus.game.kit.repository.KitRepository;
+import fr.heneria.nexus.game.kit.repository.JdbcKitRepository;
 import fr.heneria.nexus.game.manager.GameManager;
 import fr.heneria.nexus.game.repository.MatchRepository;
 import fr.heneria.nexus.game.repository.JdbcMatchRepository;
@@ -68,6 +70,7 @@ public final class Nexus extends JavaPlugin {
             // CORRECTION: L'instance du plugin n'est plus passée ici
             PlayerRepository playerRepository = new JdbcPlayerRepository(this.dataSourceProvider.getDataSource());
             ShopRepository shopRepository = new JdbcShopRepository(this.dataSourceProvider.getDataSource());
+            KitRepository kitRepository = new JdbcKitRepository(this.dataSourceProvider.getDataSource());
             MatchRepository matchRepository = new JdbcMatchRepository(this.dataSourceProvider.getDataSource());
             SanctionRepository sanctionRepository = new JdbcSanctionRepository(this.dataSourceProvider.getDataSource());
 
@@ -75,6 +78,7 @@ public final class Nexus extends JavaPlugin {
             this.playerManager = new PlayerManager(playerRepository);
             this.economyManager = new EconomyManager(this.playerManager, this.dataSourceProvider.getDataSource());
             this.shopManager = new ShopManager(shopRepository);
+            KitManager.init(kitRepository);
             this.kitManager = KitManager.getInstance();
             this.kitManager.loadKits();
             GameConfig.init(this);
@@ -85,13 +89,13 @@ public final class Nexus extends JavaPlugin {
             QueueManager.init(this.gameManager, this.arenaManager, this.sanctionManager);
             this.queueManager = QueueManager.getInstance();
 
-            AdminConversationManager.init(this.arenaManager, this.shopManager, shopRepository, this);
+            AdminConversationManager.init(this.arenaManager, this.shopManager, shopRepository, this.kitManager, this);
             AdminPlacementManager.init();
             this.arenaManager.loadArenas();
             this.shopManager.loadItems();
             getLogger().info(this.arenaManager.getAllArenas().size() + " arène(s) chargée(s).");
 
-            getCommand("nx").setExecutor(new NexusAdminCommand(this.arenaManager, this.shopManager, this.sanctionManager));
+            getCommand("nx").setExecutor(new NexusAdminCommand(this.arenaManager, this.shopManager, this.sanctionManager, this.kitManager));
             getCommand("play").setExecutor(new PlayCommand(this.queueManager, this));
             // CORRECTION: L'instance du plugin (this) est maintenant passée au listener
             getServer().getPluginManager().registerEvents(new PlayerConnectionListener(this.playerManager, this.arenaManager, AdminPlacementManager.getInstance(), this), this);

--- a/src/main/java/fr/heneria/nexus/admin/conversation/KitCreationConversation.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/KitCreationConversation.java
@@ -1,0 +1,19 @@
+package fr.heneria.nexus.admin.conversation;
+
+import java.util.UUID;
+
+/**
+ * Représente une conversation de création de kit.
+ */
+public class KitCreationConversation {
+
+    private final UUID adminId;
+
+    public KitCreationConversation(UUID adminId) {
+        this.adminId = adminId;
+    }
+
+    public UUID getAdminId() {
+        return adminId;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -9,6 +9,7 @@ import fr.heneria.nexus.game.manager.GameManager;
 import fr.heneria.nexus.game.model.Match;
 import fr.heneria.nexus.game.model.MatchType;
 import fr.heneria.nexus.sanction.SanctionManager;
+import fr.heneria.nexus.game.kit.manager.KitManager;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -30,11 +31,13 @@ public class NexusAdminCommand implements CommandExecutor {
     private final ArenaManager arenaManager;
     private final ShopManager shopManager;
     private final SanctionManager sanctionManager;
+    private final KitManager kitManager;
 
-    public NexusAdminCommand(ArenaManager arenaManager, ShopManager shopManager, SanctionManager sanctionManager) {
+    public NexusAdminCommand(ArenaManager arenaManager, ShopManager shopManager, SanctionManager sanctionManager, KitManager kitManager) {
         this.arenaManager = arenaManager;
         this.shopManager = shopManager;
         this.sanctionManager = sanctionManager;
+        this.kitManager = kitManager;
     }
 
     @Override
@@ -96,7 +99,7 @@ public class NexusAdminCommand implements CommandExecutor {
                 sender.sendMessage("Vous n'avez pas la permission nécessaire.");
                 return true;
             }
-            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance(), shopManager).open((Player) sender);
+            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance(), shopManager, kitManager).open((Player) sender);
             return true;
         }
 

--- a/src/main/java/fr/heneria/nexus/game/kit/model/Kit.java
+++ b/src/main/java/fr/heneria/nexus/game/kit/model/Kit.java
@@ -2,9 +2,7 @@ package fr.heneria.nexus.game.kit.model;
 
 import org.bukkit.inventory.ItemStack;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Arrays;
 
 /**
  * Représente un kit d'équipement de base pour un joueur.
@@ -12,18 +10,22 @@ import java.util.List;
 public class Kit {
 
     private final String name;
-    private final List<ItemStack> items;
+    private ItemStack[] contents;
 
-    public Kit(String name, List<ItemStack> items) {
+    public Kit(String name, ItemStack[] contents) {
         this.name = name;
-        this.items = new ArrayList<>(items);
+        this.contents = contents != null ? Arrays.copyOf(contents, contents.length) : new ItemStack[0];
     }
 
     public String getName() {
         return name;
     }
 
-    public List<ItemStack> getItems() {
-        return Collections.unmodifiableList(items);
+    public ItemStack[] getContents() {
+        return Arrays.copyOf(contents, contents.length);
+    }
+
+    public void setContents(ItemStack[] contents) {
+        this.contents = Arrays.copyOf(contents, contents.length);
     }
 }

--- a/src/main/java/fr/heneria/nexus/game/kit/repository/JdbcKitRepository.java
+++ b/src/main/java/fr/heneria/nexus/game/kit/repository/JdbcKitRepository.java
@@ -1,0 +1,67 @@
+package fr.heneria.nexus.game.kit.repository;
+
+import fr.heneria.nexus.game.kit.model.Kit;
+import fr.heneria.nexus.game.kit.serializer.ItemSerializer;
+import org.bukkit.inventory.ItemStack;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JdbcKitRepository implements KitRepository {
+
+    private final DataSource dataSource;
+
+    public JdbcKitRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void saveKit(Kit kit) {
+        String sql = "INSERT INTO kits (kit_name, inventory_content) VALUES (?, ?) " +
+                "ON DUPLICATE KEY UPDATE inventory_content = VALUES(inventory_content)";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, kit.getName());
+            stmt.setString(2, ItemSerializer.serialize(kit.getContents()));
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void deleteKit(String kitName) {
+        String sql = "DELETE FROM kits WHERE kit_name = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, kitName);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<String, Kit> loadAllKits() {
+        Map<String, Kit> kits = new HashMap<>();
+        String sql = "SELECT kit_name, inventory_content FROM kits";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                String name = rs.getString("kit_name");
+                String content = rs.getString("inventory_content");
+                ItemStack[] items = ItemSerializer.deserialize(content);
+                kits.put(name, new Kit(name, items));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return kits;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/game/kit/repository/KitRepository.java
+++ b/src/main/java/fr/heneria/nexus/game/kit/repository/KitRepository.java
@@ -1,0 +1,11 @@
+package fr.heneria.nexus.game.kit.repository;
+
+import fr.heneria.nexus.game.kit.model.Kit;
+
+import java.util.Map;
+
+public interface KitRepository {
+    void saveKit(Kit kit);
+    void deleteKit(String kitName);
+    Map<String, Kit> loadAllKits();
+}

--- a/src/main/java/fr/heneria/nexus/game/kit/serializer/ItemSerializer.java
+++ b/src/main/java/fr/heneria/nexus/game/kit/serializer/ItemSerializer.java
@@ -1,0 +1,46 @@
+package fr.heneria.nexus.game.kit.serializer;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * Utility class to serialize and deserialize item arrays to Base64 strings.
+ */
+public final class ItemSerializer {
+
+    private ItemSerializer() {
+    }
+
+    public static String serialize(ItemStack[] items) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream)) {
+            dataOutput.writeInt(items.length);
+            for (ItemStack item : items) {
+                dataOutput.writeObject(item);
+            }
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to serialize item stacks", e);
+        }
+    }
+
+    public static ItemStack[] deserialize(String data) {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(data));
+             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream)) {
+            int length = dataInput.readInt();
+            ItemStack[] items = new ItemStack[length];
+            for (int i = 0; i < length; i++) {
+                items[i] = (ItemStack) dataInput.readObject();
+            }
+            return items;
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to deserialize item stacks", e);
+        }
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -11,6 +11,8 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import fr.heneria.nexus.admin.conversation.AdminConversationManager;
 import fr.heneria.nexus.admin.placement.AdminPlacementManager;
 import fr.heneria.nexus.shop.manager.ShopManager;
+import fr.heneria.nexus.game.kit.manager.KitManager;
+import fr.heneria.nexus.gui.admin.kit.KitListGui;
 import fr.heneria.nexus.gui.admin.shop.ShopAdminGui;
 
 /**
@@ -21,11 +23,13 @@ public class AdminMenuGui {
     private final ArenaManager arenaManager;
     private final AdminPlacementManager adminPlacementManager;
     private final ShopManager shopManager;
+    private final KitManager kitManager;
 
-    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager, ShopManager shopManager) {
+    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager, ShopManager shopManager, KitManager kitManager) {
         this.arenaManager = arenaManager;
         this.adminPlacementManager = adminPlacementManager;
         this.shopManager = shopManager;
+        this.kitManager = kitManager;
     }
 
     /**
@@ -70,6 +74,15 @@ public class AdminMenuGui {
                     new ShopAdminGui(shopManager).open((Player) event.getWhoClicked());
                 });
         gui.setItem(15, shopManagement);
+
+        GuiItem kitManagement = ItemBuilder.from(Material.IRON_CHESTPLATE)
+                .name(Component.text("Gestion des Kits", NamedTextColor.LIGHT_PURPLE))
+                .lore(Component.text("Créer et modifier les kits"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new KitListGui(kitManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
+                });
+        gui.setItem(17, kitManagement);
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/kit/ConfirmDeleteKitGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/kit/ConfirmDeleteKitGui.java
@@ -1,0 +1,54 @@
+package fr.heneria.nexus.gui.admin.kit;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.game.kit.manager.KitManager;
+import fr.heneria.nexus.game.kit.model.Kit;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * GUI de confirmation de suppression d'un kit.
+ */
+public class ConfirmDeleteKitGui {
+
+    private final KitManager kitManager;
+    private final Kit kit;
+
+    public ConfirmDeleteKitGui(KitManager kitManager, Kit kit) {
+        this.kitManager = kitManager;
+        this.kit = kit;
+    }
+
+    public void open(Player player) {
+        Component title = Component.text("Supprimer ", NamedTextColor.DARK_RED)
+                .append(Component.text(kit.getName(), NamedTextColor.RED))
+                .append(Component.text(" ?", NamedTextColor.DARK_RED));
+        Gui gui = Gui.gui()
+                .title(title)
+                .rows(3)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        GuiItem yes = ItemBuilder.from(Material.LIME_CONCRETE)
+                .name(Component.text("OUI, SUPPRIMER", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    kitManager.deleteKit(kit.getName());
+                    new KitListGui(kitManager, fr.heneria.nexus.admin.conversation.AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
+                });
+        GuiItem no = ItemBuilder.from(Material.RED_CONCRETE)
+                .name(Component.text("NON, ANNULER", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new KitEditorGui(kitManager, kit).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(12, yes);
+        gui.setItem(14, no);
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/kit/KitEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/kit/KitEditorGui.java
@@ -1,0 +1,69 @@
+package fr.heneria.nexus.gui.admin.kit;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.game.kit.manager.KitManager;
+import fr.heneria.nexus.game.kit.model.Kit;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * GUI d'édition d'un kit, permettant de modifier l'inventaire complet.
+ */
+public class KitEditorGui {
+
+    private final KitManager kitManager;
+    private final Kit kit;
+
+    public KitEditorGui(KitManager kitManager, Kit kit) {
+        this.kitManager = kitManager;
+        this.kit = kit;
+    }
+
+    public void open(Player player) {
+        Component title = Component.text("Édition du Kit : ", NamedTextColor.DARK_GRAY)
+                .append(Component.text(kit.getName(), NamedTextColor.LIGHT_PURPLE));
+        Gui gui = Gui.gui()
+                .title(title)
+                .rows(6)
+                .create();
+
+        // Autoriser les interactions par défaut
+        gui.setDefaultClickAction(event -> {});
+
+        gui.getInventory().setContents(kit.getContents());
+
+        GuiItem save = ItemBuilder.from(Material.EMERALD_BLOCK)
+                .name(Component.text("Sauvegarder", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    ItemStack[] contents = gui.getInventory().getContents();
+                    kit.setContents(contents);
+                    kitManager.saveKit(kit);
+                    player.sendMessage("§aKit sauvegardé.");
+                });
+        gui.setItem(53, save);
+
+        GuiItem delete = ItemBuilder.from(Material.TNT)
+                .name(Component.text("Supprimer", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new ConfirmDeleteKitGui(kitManager, kit).open((Player) event.getWhoClicked());
+                });
+        gui.setItem(52, delete);
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new KitListGui(kitManager, fr.heneria.nexus.admin.conversation.AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
+                });
+        gui.setItem(45, back);
+
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/kit/KitListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/kit/KitListGui.java
@@ -1,0 +1,71 @@
+package fr.heneria.nexus.gui.admin.kit;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.game.kit.manager.KitManager;
+import fr.heneria.nexus.game.kit.model.Kit;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * Affiche la liste des kits disponibles et permet d'en créer de nouveaux.
+ */
+public class KitListGui {
+
+    private final KitManager kitManager;
+    private final AdminConversationManager conversationManager;
+
+    public KitListGui(KitManager kitManager, AdminConversationManager conversationManager) {
+        this.kitManager = kitManager;
+        this.conversationManager = conversationManager;
+    }
+
+    public void open(Player player) {
+        int kitCount = kitManager.getAllKits().size();
+        int rows = Math.min(6, Math.max(1, (int) Math.ceil((kitCount + 2) / 9.0)));
+        Gui gui = Gui.gui()
+                .title(Component.text("Gestion des Kits"))
+                .rows(rows)
+                .create();
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        for (Kit kit : kitManager.getAllKits().values()) {
+            GuiItem item = ItemBuilder.from(Material.CHEST)
+                    .name(Component.text(kit.getName(), NamedTextColor.AQUA))
+                    .asGuiItem(event -> {
+                        event.setCancelled(true);
+                        new KitEditorGui(kitManager, kit).open((Player) event.getWhoClicked());
+                    });
+            gui.addItem(item);
+        }
+
+        GuiItem create = ItemBuilder.from(Material.NETHER_STAR)
+                .name(Component.text("Créer un nouveau kit", NamedTextColor.LIGHT_PURPLE))
+                .lore(Component.text("Démarre une conversation"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    p.closeInventory();
+                    conversationManager.startKitCreationConversation(p);
+                });
+        gui.addItem(create);
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    ((Player) event.getWhoClicked()).performCommand("nx admin");
+                });
+        gui.setItem(rows * 9 - 1, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
+        gui.open(player);
+    }
+}

--- a/src/main/resources/db/changelog/008_create_kits_table.sql
+++ b/src/main/resources/db/changelog/008_create_kits_table.sql
@@ -1,0 +1,8 @@
+-- liquibase formatted sql
+-- changeset gordox:11
+CREATE TABLE kits (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    kit_name VARCHAR(50) NOT NULL UNIQUE,
+    -- stocke l'inventaire complet (items + armure) sérialisé en Base64 ou JSON
+    inventory_content TEXT NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -12,5 +12,6 @@
     <include file="db/changelog/005_create_match_tables.sql"/>
     <include file="db/changelog/006_create_arena_objects_table.sql"/>
     <include file="db/changelog/007_create_sanctions_table.sql"/>
+    <include file="db/changelog/008_create_kits_table.sql"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- persist kits in database and load them dynamically
- add GUI and conversations to create, edit, and delete kits
- wire kit repository and manager into plugin lifecycle

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0985d369483248af5ba58e1c1d5b1