### PR TITLE
feat: add basic npc management

### DIFF
--- a/src/main/java/fr/heneria/nexus/admin/conversation/NpcConversationStep.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/NpcConversationStep.java
@@ -1,0 +1,9 @@
+package fr.heneria.nexus.admin.conversation;
+
+/**
+ * Steps for NPC creation conversation.
+ */
+public enum NpcConversationStep {
+    AWAITING_NAME,
+    AWAITING_COMMAND
+}

--- a/src/main/java/fr/heneria/nexus/admin/conversation/NpcCreationConversation.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/NpcCreationConversation.java
@@ -1,0 +1,52 @@
+package fr.heneria.nexus.admin.conversation;
+
+import fr.heneria.nexus.npc.NpcManager;
+import fr.heneria.nexus.gui.admin.npc.NpcListGui;
+
+import java.util.UUID;
+
+/**
+ * Conversation state for creating an NPC.
+ */
+public class NpcCreationConversation {
+
+    private final UUID adminId;
+    private final NpcManager npcManager;
+    private final NpcListGui reopenGui;
+    private NpcConversationStep step = NpcConversationStep.AWAITING_NAME;
+    private String name;
+
+    public NpcCreationConversation(UUID adminId, NpcManager npcManager, NpcListGui reopenGui) {
+        this.adminId = adminId;
+        this.npcManager = npcManager;
+        this.reopenGui = reopenGui;
+    }
+
+    public UUID getAdminId() {
+        return adminId;
+    }
+
+    public NpcManager getNpcManager() {
+        return npcManager;
+    }
+
+    public NpcListGui getReopenGui() {
+        return reopenGui;
+    }
+
+    public NpcConversationStep getStep() {
+        return step;
+    }
+
+    public void setStep(NpcConversationStep step) {
+        this.step = step;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -10,6 +10,7 @@ import fr.heneria.nexus.game.model.Match;
 import fr.heneria.nexus.game.model.MatchType;
 import fr.heneria.nexus.sanction.SanctionManager;
 import fr.heneria.nexus.game.kit.manager.KitManager;
+import fr.heneria.nexus.npc.NpcManager;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -32,12 +33,14 @@ public class NexusAdminCommand implements CommandExecutor {
     private final ShopManager shopManager;
     private final SanctionManager sanctionManager;
     private final KitManager kitManager;
+    private final NpcManager npcManager;
 
-    public NexusAdminCommand(ArenaManager arenaManager, ShopManager shopManager, SanctionManager sanctionManager, KitManager kitManager) {
+    public NexusAdminCommand(ArenaManager arenaManager, ShopManager shopManager, SanctionManager sanctionManager, KitManager kitManager, NpcManager npcManager) {
         this.arenaManager = arenaManager;
         this.shopManager = shopManager;
         this.sanctionManager = sanctionManager;
         this.kitManager = kitManager;
+        this.npcManager = npcManager;
     }
 
     @Override
@@ -99,7 +102,7 @@ public class NexusAdminCommand implements CommandExecutor {
                 sender.sendMessage("Vous n'avez pas la permission nécessaire.");
                 return true;
             }
-            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance(), shopManager, kitManager).open((Player) sender);
+            new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance(), shopManager, kitManager, npcManager).open((Player) sender);
             return true;
         }
 

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -14,6 +14,8 @@ import fr.heneria.nexus.shop.manager.ShopManager;
 import fr.heneria.nexus.game.kit.manager.KitManager;
 import fr.heneria.nexus.gui.admin.kit.KitListGui;
 import fr.heneria.nexus.gui.admin.shop.ShopAdminGui;
+import fr.heneria.nexus.gui.admin.npc.NpcListGui;
+import fr.heneria.nexus.npc.NpcManager;
 
 /**
  * Menu principal du centre de contrôle Nexus.
@@ -24,12 +26,14 @@ public class AdminMenuGui {
     private final AdminPlacementManager adminPlacementManager;
     private final ShopManager shopManager;
     private final KitManager kitManager;
+    private final NpcManager npcManager;
 
-    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager, ShopManager shopManager, KitManager kitManager) {
+    public AdminMenuGui(ArenaManager arenaManager, AdminPlacementManager adminPlacementManager, ShopManager shopManager, KitManager kitManager, NpcManager npcManager) {
         this.arenaManager = arenaManager;
         this.adminPlacementManager = adminPlacementManager;
         this.shopManager = shopManager;
         this.kitManager = kitManager;
+        this.npcManager = npcManager;
     }
 
     /**
@@ -83,6 +87,15 @@ public class AdminMenuGui {
                     new KitListGui(kitManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
                 });
         gui.setItem(17, kitManagement);
+
+        GuiItem npcManagement = ItemBuilder.from(Material.VILLAGER_SPAWN_EGG)
+                .name(Component.text("Gestion des PNJ", NamedTextColor.AQUA))
+                .lore(Component.text("Créer et placer des PNJ"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new NpcListGui(npcManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
+                });
+        gui.setItem(9, npcManagement);
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/npc/NpcEditorGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/npc/NpcEditorGui.java
@@ -1,0 +1,90 @@
+package fr.heneria.nexus.gui.admin.npc;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.npc.NpcManager;
+import fr.heneria.nexus.npc.model.Npc;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * GUI for editing a single NPC.
+ */
+public class NpcEditorGui {
+
+    private final NpcManager npcManager;
+    private final Npc npc;
+    private final AdminConversationManager conversationManager;
+    private final NpcListGui parent;
+
+    public NpcEditorGui(NpcManager npcManager, Npc npc, AdminConversationManager conversationManager, NpcListGui parent) {
+        this.npcManager = npcManager;
+        this.npc = npc;
+        this.conversationManager = conversationManager;
+        this.parent = parent;
+    }
+
+    public void open(Player player) {
+        Gui gui = Gui.gui()
+                .title(Component.text("Édition PNJ"))
+                .rows(3)
+                .create();
+        gui.setDefaultClickAction(e -> e.setCancelled(true));
+
+        GuiItem rename = ItemBuilder.from(Material.NAME_TAG)
+                .name(Component.text("Modifier le nom", NamedTextColor.YELLOW))
+                .asGuiItem(e -> {
+                    e.setCancelled(true);
+                    e.getWhoClicked().sendMessage("TODO: Modification du nom non implémentée");
+                });
+        gui.setItem(10, rename);
+
+        GuiItem command = ItemBuilder.from(Material.COMMAND_BLOCK)
+                .name(Component.text("Modifier la commande", NamedTextColor.GOLD))
+                .asGuiItem(e -> {
+                    e.setCancelled(true);
+                    e.getWhoClicked().sendMessage("TODO: Modification de la commande non implémentée");
+                });
+        gui.setItem(12, command);
+
+        GuiItem place = ItemBuilder.from(Material.ENDER_PEARL)
+                .name(Component.text("Placer/Déplacer le PNJ", NamedTextColor.GREEN))
+                .asGuiItem(e -> {
+                    e.setCancelled(true);
+                    Player p = (Player) e.getWhoClicked();
+                    p.closeInventory();
+                    npcManager.placeNpc(npc, p);
+                    parent.open(p);
+                });
+        gui.setItem(14, place);
+
+        GuiItem delete = ItemBuilder.from(Material.LAVA_BUCKET)
+                .name(Component.text("Supprimer", NamedTextColor.RED))
+                .asGuiItem(e -> {
+                    e.setCancelled(true);
+                    Player p = (Player) e.getWhoClicked();
+                    npcManager.deleteNpc(npc);
+                    parent.open(p);
+                });
+        gui.setItem(16, delete);
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(e -> {
+                    e.setCancelled(true);
+                    parent.open((Player) e.getWhoClicked());
+                });
+        gui.setItem(26, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
+        gui.open(player);
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/gui/admin/npc/NpcListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/npc/NpcListGui.java
@@ -1,0 +1,71 @@
+package fr.heneria.nexus.gui.admin.npc;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import fr.heneria.nexus.npc.NpcManager;
+import fr.heneria.nexus.npc.model.Npc;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * GUI listing NPCs and allowing creation of new ones.
+ */
+public class NpcListGui {
+
+    private final NpcManager npcManager;
+    private final AdminConversationManager conversationManager;
+
+    public NpcListGui(NpcManager npcManager, AdminConversationManager conversationManager) {
+        this.npcManager = npcManager;
+        this.conversationManager = conversationManager;
+    }
+
+    public void open(Player player) {
+        int count = npcManager.getNpcs().size();
+        int rows = Math.min(6, Math.max(1, (int) Math.ceil((count + 2) / 9.0)));
+        Gui gui = Gui.gui()
+                .title(Component.text("Gestion des PNJ"))
+                .rows(rows)
+                .create();
+        gui.setDefaultClickAction(e -> e.setCancelled(true));
+
+        for (Npc npc : npcManager.getNpcs().values()) {
+            GuiItem item = ItemBuilder.from(Material.PLAYER_HEAD)
+                    .name(Component.text(npc.getName(), NamedTextColor.AQUA))
+                    .asGuiItem(event -> {
+                        event.setCancelled(true);
+                        new NpcEditorGui(npcManager, npc, conversationManager, this).open((Player) event.getWhoClicked());
+                    });
+            gui.addItem(item);
+        }
+
+        GuiItem create = ItemBuilder.from(Material.NETHER_STAR)
+                .name(Component.text("Créer un PNJ", NamedTextColor.LIGHT_PURPLE))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    p.closeInventory();
+                    conversationManager.startNpcCreationConversation(p, this, npcManager);
+                });
+        gui.addItem(create);
+
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    ((Player) event.getWhoClicked()).performCommand("nx admin");
+                });
+        gui.setItem(rows * 9 - 1, back);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
+        gui.open(player);
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/npc/JdbcNpcRepository.java
+++ b/src/main/java/fr/heneria/nexus/npc/JdbcNpcRepository.java
@@ -1,0 +1,123 @@
+package fr.heneria.nexus.npc;
+
+import fr.heneria.nexus.npc.model.Npc;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * JDBC implementation of {@link NpcRepository}.
+ */
+public class JdbcNpcRepository implements NpcRepository {
+
+    private final DataSource dataSource;
+
+    public JdbcNpcRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void save(Npc npc) {
+        String sql = "INSERT INTO npcs (npc_name, world, x, y, z, yaw, pitch, click_command) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, npc.getName());
+            ps.setString(2, npc.getWorld());
+            ps.setDouble(3, npc.getX());
+            ps.setDouble(4, npc.getY());
+            ps.setDouble(5, npc.getZ());
+            ps.setFloat(6, npc.getYaw());
+            ps.setFloat(7, npc.getPitch());
+            ps.setString(8, npc.getClickCommand());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    npc.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void update(Npc npc) {
+        String sql = "UPDATE npcs SET npc_name=?, world=?, x=?, y=?, z=?, yaw=?, pitch=?, click_command=? WHERE id=?";
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setString(1, npc.getName());
+            ps.setString(2, npc.getWorld());
+            ps.setDouble(3, npc.getX());
+            ps.setDouble(4, npc.getY());
+            ps.setDouble(5, npc.getZ());
+            ps.setFloat(6, npc.getYaw());
+            ps.setFloat(7, npc.getPitch());
+            ps.setString(8, npc.getClickCommand());
+            ps.setInt(9, npc.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void delete(int id) {
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement ps = con.prepareStatement("DELETE FROM npcs WHERE id=?")) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public List<Npc> findAll() {
+        List<Npc> list = new ArrayList<>();
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement ps = con.prepareStatement("SELECT * FROM npcs")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(mapRow(rs));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    @Override
+    public Optional<Npc> findById(int id) {
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement ps = con.prepareStatement("SELECT * FROM npcs WHERE id=?")) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return Optional.empty();
+    }
+
+    private Npc mapRow(ResultSet rs) throws SQLException {
+        return new Npc(
+                rs.getInt("id"),
+                rs.getString("npc_name"),
+                rs.getString("world"),
+                rs.getDouble("x"),
+                rs.getDouble("y"),
+                rs.getDouble("z"),
+                rs.getFloat("yaw"),
+                rs.getFloat("pitch"),
+                rs.getString("click_command")
+        );
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/npc/NpcListener.java
+++ b/src/main/java/fr/heneria/nexus/npc/NpcListener.java
@@ -1,0 +1,36 @@
+package fr.heneria.nexus.npc;
+
+import fr.heneria.nexus.npc.model.Npc;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+
+import java.util.Optional;
+
+/**
+ * Listens for player interactions with NPCs and executes their command.
+ */
+public class NpcListener implements Listener {
+
+    private final NpcManager npcManager;
+
+    public NpcListener(NpcManager npcManager) {
+        this.npcManager = npcManager;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractAtEntityEvent event) {
+        Optional<Npc> npcOpt = npcManager.getNpcByEntity(event.getRightClicked());
+        if (npcOpt.isEmpty()) {
+            return;
+        }
+        event.setCancelled(true);
+        Npc npc = npcOpt.get();
+        String command = npc.getClickCommand();
+        if (command.startsWith("/")) {
+            command = command.substring(1);
+        }
+        event.getPlayer().performCommand(command);
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/npc/NpcManager.java
+++ b/src/main/java/fr/heneria/nexus/npc/NpcManager.java
@@ -1,0 +1,102 @@
+package fr.heneria.nexus.npc;
+
+import fr.heneria.nexus.npc.model.Npc;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Loads and manages lobby NPCs.
+ */
+public class NpcManager {
+
+    public static final String UNSET_WORLD = "UNSET";
+
+    private final NpcRepository repository;
+    private final Map<UUID, Npc> entityNpcMap = new HashMap<>();
+    private final Map<Integer, Npc> npcs = new HashMap<>();
+
+    public NpcManager(NpcRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Loads all NPCs from the database and spawns those with a valid location.
+     */
+    public void loadNpcs() {
+        for (Npc npc : repository.findAll()) {
+            npcs.put(npc.getId(), npc);
+            if (!UNSET_WORLD.equalsIgnoreCase(npc.getWorld())) {
+                spawnNpc(npc);
+            }
+        }
+    }
+
+    /**
+     * Spawns an NPC in the world.
+     */
+    public void spawnNpc(Npc npc) {
+        Location loc = npc.toLocation();
+        if (loc == null) return;
+        ArmorStand stand = loc.getWorld().spawn(loc, ArmorStand.class, as -> {
+            as.setCustomNameVisible(true);
+            as.customName(Component.text(npc.getName()));
+            as.setGravity(false);
+            as.setAI(false);
+            as.setInvulnerable(true);
+            as.setPersistent(true);
+        });
+        entityNpcMap.put(stand.getUniqueId(), npc);
+    }
+
+    public Optional<Npc> getNpcByEntity(Entity entity) {
+        return Optional.ofNullable(entityNpcMap.get(entity.getUniqueId()));
+    }
+
+    public void removeAll() {
+        for (UUID uuid : entityNpcMap.keySet()) {
+            Entity e = Bukkit.getEntity(uuid);
+            if (e != null) e.remove();
+        }
+        entityNpcMap.clear();
+    }
+
+    public Npc createNpc(String name, String command) {
+        Npc npc = new Npc(0, name, UNSET_WORLD, 0, 0, 0, 0, 0, command);
+        repository.save(npc);
+        npcs.put(npc.getId(), npc);
+        return npc;
+    }
+
+    public void placeNpc(Npc npc, Player admin) {
+        npc.setLocation(admin.getLocation());
+        repository.update(npc);
+        spawnNpc(npc);
+    }
+
+    public void deleteNpc(Npc npc) {
+        entityNpcMap.entrySet().removeIf(entry -> {
+            if (entry.getValue().getId() == npc.getId()) {
+                Entity e = Bukkit.getEntity(entry.getKey());
+                if (e != null) e.remove();
+                return true;
+            }
+            return false;
+        });
+        repository.delete(npc.getId());
+        npcs.remove(npc.getId());
+    }
+
+    public Map<Integer, Npc> getNpcs() {
+        return npcs;
+    }
+}
+

--- a/src/main/java/fr/heneria/nexus/npc/NpcRepository.java
+++ b/src/main/java/fr/heneria/nexus/npc/NpcRepository.java
@@ -1,0 +1,23 @@
+package fr.heneria.nexus.npc;
+
+import fr.heneria.nexus.npc.model.Npc;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for persisting NPC definitions.
+ */
+public interface NpcRepository {
+
+    void save(Npc npc);
+
+    void update(Npc npc);
+
+    void delete(int id);
+
+    List<Npc> findAll();
+
+    Optional<Npc> findById(int id);
+}
+

--- a/src/main/java/fr/heneria/nexus/npc/model/Npc.java
+++ b/src/main/java/fr/heneria/nexus/npc/model/Npc.java
@@ -1,0 +1,124 @@
+package fr.heneria.nexus.npc.model;
+
+import org.bukkit.Location;
+
+/**
+ * Represents an interactive NPC used in the lobby to open game mode selectors.
+ */
+public class Npc {
+
+    private int id;
+    private String name;
+    private String world;
+    private double x;
+    private double y;
+    private double z;
+    private float yaw;
+    private float pitch;
+    private String clickCommand;
+
+    public Npc(int id, String name, String world, double x, double y, double z, float yaw, float pitch, String clickCommand) {
+        this.id = id;
+        this.name = name;
+        this.world = world;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.yaw = yaw;
+        this.pitch = pitch;
+        this.clickCommand = clickCommand;
+    }
+
+    public Npc(String name, String clickCommand) {
+        this(0, name, null, 0, 0, 0, 0, 0, clickCommand);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getWorld() {
+        return world;
+    }
+
+    public void setWorld(String world) {
+        this.world = world;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public double getZ() {
+        return z;
+    }
+
+    public void setZ(double z) {
+        this.z = z;
+    }
+
+    public float getYaw() {
+        return yaw;
+    }
+
+    public void setYaw(float yaw) {
+        this.yaw = yaw;
+    }
+
+    public float getPitch() {
+        return pitch;
+    }
+
+    public void setPitch(float pitch) {
+        this.pitch = pitch;
+    }
+
+    public String getClickCommand() {
+        return clickCommand;
+    }
+
+    public void setClickCommand(String clickCommand) {
+        this.clickCommand = clickCommand;
+    }
+
+    public Location toLocation() {
+        if (world == null) return null;
+        org.bukkit.World w = org.bukkit.Bukkit.getWorld(world);
+        if (w == null) return null;
+        return new Location(w, x, y, z, yaw, pitch);
+    }
+
+    public void setLocation(Location location) {
+        this.world = location.getWorld().getName();
+        this.x = location.getX();
+        this.y = location.getY();
+        this.z = location.getZ();
+        this.yaw = location.getYaw();
+        this.pitch = location.getPitch();
+    }
+}
+

--- a/src/main/resources/db/changelog/009_create_npcs_table.sql
+++ b/src/main/resources/db/changelog/009_create_npcs_table.sql
@@ -1,0 +1,12 @@
+-- changeset gordox:12
+CREATE TABLE npcs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    npc_name VARCHAR(255) NOT NULL,
+    world VARCHAR(255) NOT NULL,
+    x DOUBLE NOT NULL,
+    y DOUBLE NOT NULL,
+    z DOUBLE NOT NULL,
+    yaw FLOAT NOT NULL,
+    pitch FLOAT NOT NULL,
+    click_command VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/changelog/master.xml
+++ b/src/main/resources/db/changelog/master.xml
@@ -13,5 +13,6 @@
     <include file="db/changelog/006_create_arena_objects_table.sql"/>
     <include file="db/changelog/007_create_sanctions_table.sql"/>
     <include file="db/changelog/008_create_kits_table.sql"/>
+    <include file="db/changelog/009_create_npcs_table.sql"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add database table for lobby NPCs
- manage and spawn lobby NPCs with simple listener
- extend admin menu and GUI to list and place NPCs

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c09acc00ec8324829781b5c147d706