### PR TITLE
feat: add sanction admin management gui

### DIFF
--- a/src/main/java/fr/heneria/nexus/admin/conversation/SanctionSearchConversation.java
+++ b/src/main/java/fr/heneria/nexus/admin/conversation/SanctionSearchConversation.java
@@ -1,0 +1,19 @@
+package fr.heneria.nexus.admin.conversation;
+
+import java.util.UUID;
+
+/**
+ * Conversation de recherche d'un joueur pour la gestion des sanctions.
+ */
+public class SanctionSearchConversation {
+
+    private final UUID adminId;
+
+    public SanctionSearchConversation(UUID adminId) {
+        this.adminId = adminId;
+    }
+
+    public UUID getAdminId() {
+        return adminId;
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -15,6 +15,7 @@ import fr.heneria.nexus.game.kit.manager.KitManager;
 import fr.heneria.nexus.gui.admin.kit.KitListGui;
 import fr.heneria.nexus.gui.admin.shop.ShopAdminGui;
 import fr.heneria.nexus.gui.admin.npc.NpcListGui;
+import fr.heneria.nexus.gui.admin.sanction.SanctionSearchGui;
 import fr.heneria.nexus.npc.NpcManager;
 
 /**
@@ -96,6 +97,15 @@ public class AdminMenuGui {
                     new NpcListGui(npcManager, AdminConversationManager.getInstance()).open((Player) event.getWhoClicked());
                 });
         gui.setItem(9, npcManagement);
+
+        GuiItem sanctionManagement = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Gestion des Sanctions", NamedTextColor.RED))
+                .lore(Component.text("Voir et pardonner les sanctions"))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new SanctionSearchGui().open((Player) event.getWhoClicked());
+                });
+        gui.setItem(22, sanctionManagement);
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/sanction/SanctionListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/sanction/SanctionListGui.java
@@ -1,0 +1,108 @@
+package fr.heneria.nexus.gui.admin.sanction;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import dev.triumphteam.gui.guis.PaginatedGui;
+import fr.heneria.nexus.sanction.SanctionManager;
+import fr.heneria.nexus.sanction.model.Sanction;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Affiche la liste des sanctions d'un joueur.
+ */
+public class SanctionListGui {
+
+    private final UUID targetUuid;
+    private final String playerName;
+    private final SanctionManager sanctionManager;
+
+    public SanctionListGui(UUID targetUuid, String playerName) {
+        this.targetUuid = targetUuid;
+        this.playerName = playerName;
+        this.sanctionManager = SanctionManager.getInstance();
+    }
+
+    public void open(Player player) {
+        PaginatedGui gui = Gui.paginated()
+                .title(Component.text("Sanctions de : " + playerName))
+                .rows(6)
+                .pageSize(45)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        List<Sanction> sanctions = sanctionManager.getSanctions(targetUuid);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault());
+
+        for (Sanction sanction : sanctions) {
+            Material mat = sanction.isActive() ? Material.WRITABLE_BOOK : Material.BOOK;
+            List<Component> lore = new ArrayList<>();
+            lore.add(Component.text("Type: Abandon de partie", NamedTextColor.GRAY));
+            if (sanction.getSanctionDate() != null) {
+                lore.add(Component.text("Date: " + formatter.format(sanction.getSanctionDate()), NamedTextColor.GRAY));
+            }
+            if (!sanction.isActive()) {
+                lore.add(Component.text("Expire le: Pardonné", NamedTextColor.GRAY));
+            } else if (sanction.getExpirationTime() != null) {
+                lore.add(Component.text("Expire le: " + formatter.format(sanction.getExpirationTime()), NamedTextColor.GRAY));
+            } else {
+                lore.add(Component.text("Expire le: Permanent", NamedTextColor.GRAY));
+            }
+            lore.add(Component.text("Statut: " + (sanction.isActive() ? "Actif" : "Inactif"),
+                    sanction.isActive() ? NamedTextColor.GREEN : NamedTextColor.GRAY));
+
+            ItemBuilder builder = ItemBuilder.from(mat)
+                    .name(Component.text("Sanction #" + sanction.getId(), NamedTextColor.YELLOW))
+                    .lore(lore);
+
+            GuiItem item;
+            if (sanction.isActive()) {
+                item = builder.asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new SanctionPardonConfirmGui(targetUuid, playerName).open((Player) event.getWhoClicked());
+                });
+            } else {
+                item = builder.asGuiItem(event -> event.setCancelled(true));
+            }
+            gui.addItem(item);
+        }
+
+        GuiItem prev = ItemBuilder.from(Material.ARROW)
+                .name(Component.text("Page précédente", NamedTextColor.YELLOW))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    gui.previous();
+                });
+        GuiItem next = ItemBuilder.from(Material.ARROW)
+                .name(Component.text("Page suivante", NamedTextColor.YELLOW))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    gui.next();
+                });
+        GuiItem back = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Retour", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new SanctionSearchGui().open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(45, prev);
+        gui.setItem(49, back);
+        gui.setItem(53, next);
+        gui.getFiller().fillBottom(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/sanction/SanctionPardonConfirmGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/sanction/SanctionPardonConfirmGui.java
@@ -1,0 +1,54 @@
+package fr.heneria.nexus.gui.admin.sanction;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.sanction.SanctionManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+/**
+ * GUI de confirmation pour le pardon d'une sanction.
+ */
+public class SanctionPardonConfirmGui {
+
+    private final UUID targetUuid;
+    private final String playerName;
+
+    public SanctionPardonConfirmGui(UUID targetUuid, String playerName) {
+        this.targetUuid = targetUuid;
+        this.playerName = playerName;
+    }
+
+    public void open(Player player) {
+        Gui gui = Gui.gui()
+                .title(Component.text("Pardonner la sanction ?", NamedTextColor.RED))
+                .rows(3)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        GuiItem yes = ItemBuilder.from(Material.LIME_CONCRETE)
+                .name(Component.text("OUI, PARDONNER", NamedTextColor.GREEN))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    SanctionManager.getInstance().pardonLastPenalty(targetUuid);
+                    new SanctionListGui(targetUuid, playerName).open((Player) event.getWhoClicked());
+                });
+
+        GuiItem no = ItemBuilder.from(Material.RED_CONCRETE)
+                .name(Component.text("NON, ANNULER", NamedTextColor.RED))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    new SanctionListGui(targetUuid, playerName).open((Player) event.getWhoClicked());
+                });
+
+        gui.setItem(12, yes);
+        gui.setItem(14, no);
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/gui/admin/sanction/SanctionSearchGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/sanction/SanctionSearchGui.java
@@ -1,0 +1,37 @@
+package fr.heneria.nexus.gui.admin.sanction;
+
+import dev.triumphteam.gui.builder.item.ItemBuilder;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import fr.heneria.nexus.admin.conversation.AdminConversationManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+/**
+ * Interface de recherche d'un joueur pour la gestion des sanctions.
+ */
+public class SanctionSearchGui {
+
+    public void open(Player player) {
+        Gui gui = Gui.gui()
+                .title(Component.text("Rechercher un joueur"))
+                .rows(1)
+                .create();
+
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+
+        GuiItem search = ItemBuilder.from(Material.PLAYER_HEAD)
+                .name(Component.text("Entrer le nom du joueur", NamedTextColor.AQUA))
+                .asGuiItem(event -> {
+                    event.setCancelled(true);
+                    Player p = (Player) event.getWhoClicked();
+                    p.closeInventory();
+                    AdminConversationManager.getInstance().startSanctionSearchConversation(p);
+                });
+
+        gui.setItem(4, search);
+        gui.open(player);
+    }
+}

--- a/src/main/java/fr/heneria/nexus/sanction/SanctionManager.java
+++ b/src/main/java/fr/heneria/nexus/sanction/SanctionManager.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 
 public class SanctionManager {
 
@@ -65,5 +66,9 @@ public class SanctionManager {
 
     public void pardonLastPenalty(UUID playerId) {
         sanctionRepository.deactivateLastSanction(playerId);
+    }
+
+    public List<Sanction> getSanctions(UUID playerId) {
+        return sanctionRepository.findSanctionsByUuid(playerId);
     }
 }

--- a/src/main/java/fr/heneria/nexus/sanction/repository/JdbcSanctionRepository.java
+++ b/src/main/java/fr/heneria/nexus/sanction/repository/JdbcSanctionRepository.java
@@ -5,6 +5,8 @@ import fr.heneria.nexus.sanction.model.Sanction;
 import javax.sql.DataSource;
 import java.sql.*;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -76,5 +78,33 @@ public class JdbcSanctionRepository implements SanctionRepository {
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public List<Sanction> findSanctionsByUuid(UUID playerUuid) {
+        String sql = "SELECT id, player_uuid, sanction_type, expiration_time, sanction_date, is_active, reason " +
+                "FROM player_sanctions WHERE player_uuid = ? ORDER BY sanction_date DESC";
+        List<Sanction> sanctions = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, playerUuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    int id = rs.getInt("id");
+                    String uuidStr = rs.getString("player_uuid");
+                    String type = rs.getString("sanction_type");
+                    Timestamp exp = rs.getTimestamp("expiration_time");
+                    Timestamp date = rs.getTimestamp("sanction_date");
+                    boolean active = rs.getBoolean("is_active");
+                    String reason = rs.getString("reason");
+                    Instant expiration = exp != null ? exp.toInstant() : null;
+                    Instant sanctionDate = date != null ? date.toInstant() : null;
+                    sanctions.add(new Sanction(id, UUID.fromString(uuidStr), type, expiration, sanctionDate, active, reason));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return sanctions;
     }
 }

--- a/src/main/java/fr/heneria/nexus/sanction/repository/SanctionRepository.java
+++ b/src/main/java/fr/heneria/nexus/sanction/repository/SanctionRepository.java
@@ -2,6 +2,7 @@ package fr.heneria.nexus.sanction.repository;
 
 import fr.heneria.nexus.sanction.model.Sanction;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -9,4 +10,5 @@ public interface SanctionRepository {
     void save(Sanction sanction);
     Optional<Sanction> findActiveSanction(UUID playerId, String sanctionType);
     void deactivateLastSanction(UUID playerId);
+    List<Sanction> findSanctionsByUuid(UUID playerUuid);
 }


### PR DESCRIPTION
## Summary
- add search and list GUIs to manage player sanctions from admin menu
- extend sanction repository and manager to expose sanction history
- integrate new sanction management entry into admin control panel

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c131f3488324942dbd9fdbbe6b52