### PR TITLE
feat: introduce theme constants for UI

### DIFF
--- a/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
+++ b/src/main/java/fr/heneria/nexus/command/NexusAdminCommand.java
@@ -17,6 +17,11 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.Bukkit;
 
+import fr.heneria.nexus.utils.Theme;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -48,7 +53,7 @@ public class NexusAdminCommand implements CommandExecutor {
         if (args.length > 0 && "starttest".equalsIgnoreCase(args[0])) {
             Arena arena = arenaManager.getAllArenas().stream().findFirst().orElse(null);
             if (arena == null) {
-                sender.sendMessage("Aucune arène disponible.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Aucune arène disponible.", Theme.COLOR_ERROR)));
                 return true;
             }
             List<UUID> team1 = new ArrayList<>();
@@ -63,43 +68,49 @@ public class NexusAdminCommand implements CommandExecutor {
             }
             Match match = GameManager.getInstance().createMatch(arena, Arrays.asList(team1, team2), MatchType.NORMAL);
             GameManager.getInstance().startMatchCountdown(match);
-            sender.sendMessage("Match de test lancé.");
+            sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Match de test lancé.", Theme.COLOR_SUCCESS)));
             return true;
         }
 
         if (args.length >= 3 && "sanction".equalsIgnoreCase(args[0]) && "pardon".equalsIgnoreCase(args[1])) {
             if (!sender.hasPermission("nexus.admin.sanction")) {
-                sender.sendMessage("Vous n'avez pas la permission nécessaire.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Vous n'avez pas la permission nécessaire.", Theme.COLOR_ERROR)));
                 return true;
             }
             Player target = Bukkit.getPlayer(args[2]);
             if (target == null) {
-                sender.sendMessage("Joueur introuvable.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Joueur introuvable.", Theme.COLOR_ERROR)));
                 return true;
             }
             sanctionManager.pardonLastPenalty(target.getUniqueId());
-            sender.sendMessage("Sanction levée pour " + target.getName());
+            sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Sanction levée pour ")
+                    .append(Component.text(target.getName(), Theme.COLOR_SUCCESS))));
             return true;
         }
 
         // Affiche l'aide si aucune sous-commande ou demande d'aide
         if (args.length == 0 || "help".equalsIgnoreCase(args[0])) {
-            sender.sendMessage("§6Commandes Nexus :");
-            sender.sendMessage("§e/nx admin §7- ouvre le centre de contrôle Nexus");
-            sender.sendMessage("§e/nx arena list §7- liste les arènes chargées");
-            sender.sendMessage("§e/nx arena save <nom> §7- sauvegarde l'arène spécifiée");
-            sender.sendMessage("§e/nx sanction pardon <joueur> §7- annule la dernière sanction du joueur");
+            Component line = Component.text("---------------------------------------------", NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH);
+            sender.sendMessage(line);
+            sender.sendMessage(Component.text("Nexus Admin Help", Theme.COLOR_PRIMARY, TextDecoration.BOLD));
+            sender.sendMessage(Component.text(""));
+            sender.sendMessage(Component.text("/nx admin ", NamedTextColor.WHITE)
+                    .append(Component.text("- Ouvre le Centre de Contrôle principal.", NamedTextColor.GRAY)));
+            sender.sendMessage(Component.text("/nx sanction pardon <joueur> ", NamedTextColor.WHITE)
+                    .append(Component.text("- Pardonne la dernière sanction.", NamedTextColor.GRAY)));
+            sender.sendMessage(Component.text(""));
+            sender.sendMessage(line);
             return true;
         }
 
         // Ouvre le GUI principal pour /nx admin
         if ("admin".equalsIgnoreCase(args[0])) {
             if (!(sender instanceof Player)) {
-                sender.sendMessage("Cette commande doit être exécutée par un joueur.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Cette commande doit être exécutée par un joueur.", Theme.COLOR_ERROR)));
                 return true;
             }
             if (!sender.hasPermission("nexus.admin")) {
-                sender.sendMessage("Vous n'avez pas la permission nécessaire.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Vous n'avez pas la permission nécessaire.", Theme.COLOR_ERROR)));
                 return true;
             }
             new AdminMenuGui(arenaManager, AdminPlacementManager.getInstance(), shopManager, kitManager, npcManager).open((Player) sender);
@@ -108,12 +119,12 @@ public class NexusAdminCommand implements CommandExecutor {
 
         // Anciennes sous-commandes pour la gestion des arènes
         if (!"arena".equalsIgnoreCase(args[0])) {
-            sender.sendMessage("Usage: /" + label + " arena <list|save>");
+            sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Usage: /" + label + " arena <list|save>", Theme.COLOR_ERROR)));
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage("Usage: /" + label + " arena <list|save>");
+            sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Usage: /" + label + " arena <list|save>", Theme.COLOR_ERROR)));
             return true;
         }
 
@@ -123,23 +134,23 @@ public class NexusAdminCommand implements CommandExecutor {
                 String arenas = arenaManager.getAllArenas().stream()
                         .map(Arena::getName)
                         .collect(Collectors.joining(", "));
-                sender.sendMessage("Arènes: " + arenas);
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Arènes: " + arenas, Theme.COLOR_PRIMARY)));
                 return true;
             case "save":
                 if (args.length < 3) {
-                    sender.sendMessage("Usage: /" + label + " arena save <nomArène>");
+                    sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Usage: /" + label + " arena save <nomArène>", Theme.COLOR_ERROR)));
                     return true;
                 }
                 Arena toSave = arenaManager.getArena(args[2]);
                 if (toSave == null) {
-                    sender.sendMessage("Arène introuvable.");
+                    sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Arène introuvable.", Theme.COLOR_ERROR)));
                     return true;
                 }
                 arenaManager.saveArena(toSave);
-                sender.sendMessage("Arène sauvegardée.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Arène sauvegardée.", Theme.COLOR_SUCCESS)));
                 return true;
             default:
-                sender.sendMessage("Sous-commande inconnue.");
+                sender.sendMessage(Theme.PREFIX_MAIN.append(Component.text("Sous-commande inconnue.", Theme.COLOR_ERROR)));
                 return true;
         }
     }

--- a/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/AdminMenuGui.java
@@ -17,6 +17,7 @@ import fr.heneria.nexus.gui.admin.shop.ShopAdminGui;
 import fr.heneria.nexus.gui.admin.npc.NpcListGui;
 import fr.heneria.nexus.gui.admin.sanction.SanctionSearchGui;
 import fr.heneria.nexus.npc.NpcManager;
+import fr.heneria.nexus.utils.Theme;
 
 /**
  * Menu principal du centre de contrôle Nexus.
@@ -44,7 +45,7 @@ public class AdminMenuGui {
      */
     public void open(Player player) {
         Gui gui = Gui.gui()
-                .title(Component.text("Centre de Contrôle Nexus"))
+                .title(Component.text("Centre de Contrôle Nexus", Theme.COLOR_PRIMARY))
                 .rows(3)
                 .create();
 
@@ -52,7 +53,7 @@ public class AdminMenuGui {
         gui.setDefaultClickAction(event -> event.setCancelled(true));
 
         GuiItem arenaManagement = ItemBuilder.from(Material.GRASS_BLOCK)
-                .name(Component.text("Gestion des Arènes", NamedTextColor.GREEN))
+                .name(Component.text("Gestion des Arènes", Theme.COLOR_SUCCESS))
                 .lore(Component.text("Configurer et gérer les arènes"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
@@ -72,7 +73,7 @@ public class AdminMenuGui {
         gui.setItem(11, rulesManagement);
 
         GuiItem shopManagement = ItemBuilder.from(Material.CHEST)
-                .name(Component.text("Gestion de la Boutique", NamedTextColor.GREEN))
+                .name(Component.text("Gestion de la Boutique", Theme.COLOR_SUCCESS))
                 .lore(Component.text("Configurer la boutique en jeu"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
@@ -99,13 +100,23 @@ public class AdminMenuGui {
         gui.setItem(9, npcManagement);
 
         GuiItem sanctionManagement = ItemBuilder.from(Material.BARRIER)
-                .name(Component.text("Gestion des Sanctions", NamedTextColor.RED))
+                .name(Component.text("Gestion des Sanctions", Theme.COLOR_ERROR))
                 .lore(Component.text("Voir et pardonner les sanctions"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     new SanctionSearchGui().open((Player) event.getWhoClicked());
                 });
         gui.setItem(22, sanctionManagement);
+
+        GuiItem close = ItemBuilder.from(Material.BARRIER)
+                .name(Component.text("Fermer", Theme.COLOR_ERROR))
+                .asGuiItem(event -> event.getWhoClicked().closeInventory());
+        gui.setItem(26, close);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
+
         gui.open(player);
     }
 }

--- a/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ArenaListGui.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import fr.heneria.nexus.utils.Theme;
 
 import java.util.Map;
 
@@ -39,7 +40,7 @@ public class ArenaListGui {
         int rows = Math.min(6, Math.max(1, (int) Math.ceil((arenaCount + 1) / 9.0)));
 
         Gui gui = Gui.gui()
-                .title(Component.text("Gestion des Arènes"))
+                .title(Component.text("Gestion des Arènes", Theme.COLOR_PRIMARY))
                 .rows(rows)
                 .create();
         gui.setDefaultClickAction(event -> event.setCancelled(true));
@@ -60,7 +61,7 @@ public class ArenaListGui {
         }
 
         GuiItem create = ItemBuilder.from(Material.NETHER_STAR)
-                .name(Component.text("Créer une nouvelle arène", NamedTextColor.AQUA))
+                .name(Component.text("Créer une nouvelle arène", Theme.COLOR_PRIMARY))
                 .lore(Component.text("Démarre une conversation"))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
@@ -71,7 +72,7 @@ public class ArenaListGui {
         gui.addItem(create);
 
         GuiItem back = ItemBuilder.from(Material.BARRIER)
-                .name(Component.text("Retour", NamedTextColor.RED))
+                .name(Component.text("Retour", Theme.COLOR_ERROR))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     ((Player) event.getWhoClicked()).performCommand("nx admin");

--- a/src/main/java/fr/heneria/nexus/gui/admin/ConfirmDeleteGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/ConfirmDeleteGui.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import fr.heneria.nexus.utils.Theme;
 
 /**
  * GUI de confirmation de suppression d'une arène.
@@ -41,7 +42,7 @@ public class ConfirmDeleteGui {
         gui.setCloseGuiAction(event -> {});
 
         GuiItem yes = ItemBuilder.from(Material.LIME_CONCRETE)
-                .name(Component.text("OUI, SUPPRIMER", NamedTextColor.GREEN))
+                .name(Component.text("OUI, SUPPRIMER", Theme.COLOR_SUCCESS))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     Player p = (Player) event.getWhoClicked();
@@ -51,7 +52,7 @@ public class ConfirmDeleteGui {
                 });
 
         GuiItem no = ItemBuilder.from(Material.RED_CONCRETE)
-                .name(Component.text("NON, ANNULER", NamedTextColor.RED))
+                .name(Component.text("NON, ANNULER", Theme.COLOR_ERROR))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     new ArenaEditorGui(arenaManager, arena, adminPlacementManager).open((Player) event.getWhoClicked());
@@ -59,6 +60,10 @@ public class ConfirmDeleteGui {
 
         gui.setItem(12, yes);
         gui.setItem(14, no);
+
+        gui.getFiller().fill(ItemBuilder.from(Material.GRAY_STAINED_GLASS_PANE)
+                .name(Component.text(" "))
+                .asGuiItem());
 
         gui.open(player);
     }

--- a/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopAdminGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopAdminGui.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import fr.heneria.nexus.utils.Theme;
 
 /**
  * Interface d'administration de la boutique.
@@ -22,32 +23,32 @@ public class ShopAdminGui {
 
     public void open(Player player) {
         Gui gui = Gui.gui()
-                .title(Component.text("Gestion de la Boutique"))
+                .title(Component.text("Gestion de la Boutique", Theme.COLOR_PRIMARY))
                 .rows(3)
                 .create();
         gui.setDefaultClickAction(event -> event.setCancelled(true));
 
         GuiItem armes = ItemBuilder.from(Material.DIAMOND_SWORD)
-                .name(Component.text("Armes", NamedTextColor.GREEN))
+                .name(Component.text("Armes", Theme.COLOR_SUCCESS))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     new ShopCategoryGui(shopManager, "Armes").open((Player) event.getWhoClicked());
                 });
         GuiItem armures = ItemBuilder.from(Material.DIAMOND_CHESTPLATE)
-                .name(Component.text("Armures", NamedTextColor.GREEN))
+                .name(Component.text("Armures", Theme.COLOR_SUCCESS))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     new ShopCategoryGui(shopManager, "Armures").open((Player) event.getWhoClicked());
                 });
         GuiItem utilitaires = ItemBuilder.from(Material.POTION)
-                .name(Component.text("Utilitaires", NamedTextColor.GREEN))
+                .name(Component.text("Utilitaires", Theme.COLOR_SUCCESS))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     new ShopCategoryGui(shopManager, "Utilitaires").open((Player) event.getWhoClicked());
                 });
 
         GuiItem back = ItemBuilder.from(Material.BARRIER)
-                .name(Component.text("Retour", NamedTextColor.RED))
+                .name(Component.text("Retour", Theme.COLOR_ERROR))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     ((Player) event.getWhoClicked()).performCommand("nx admin");

--- a/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopCategoryGui.java
+++ b/src/main/java/fr/heneria/nexus/gui/admin/shop/ShopCategoryGui.java
@@ -10,6 +10,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.bukkit.Material;
+import fr.heneria.nexus.utils.Theme;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class ShopCategoryGui {
         int rows = Math.min(6, Math.max(1, (int) Math.ceil(items.size() / 9.0)));
 
         Gui gui = Gui.gui()
-                .title(Component.text("Boutique - " + category))
+                .title(Component.text("Boutique - " + category, Theme.COLOR_PRIMARY))
                 .rows(rows)
                 .create();
         gui.setDefaultClickAction(event -> event.setCancelled(true));
@@ -50,7 +51,7 @@ public class ShopCategoryGui {
         }
 
         GuiItem back = ItemBuilder.from(Material.BARRIER)
-                .name(Component.text("Retour", NamedTextColor.RED))
+                .name(Component.text("Retour", Theme.COLOR_ERROR))
                 .asGuiItem(event -> {
                     event.setCancelled(true);
                     new ShopAdminGui(shopManager).open((Player) event.getWhoClicked());

--- a/src/main/java/fr/heneria/nexus/utils/Theme.java
+++ b/src/main/java/fr/heneria/nexus/utils/Theme.java
@@ -1,0 +1,21 @@
+package fr.heneria.nexus.utils;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Defines global UI colors and message prefixes to keep a coherent style
+ * across all commands and interfaces.
+ */
+public final class Theme {
+
+    private Theme() {
+        // Utility class
+    }
+
+    public static final NamedTextColor COLOR_PRIMARY = NamedTextColor.AQUA;
+    public static final NamedTextColor COLOR_SUCCESS = NamedTextColor.GREEN;
+    public static final NamedTextColor COLOR_ERROR = NamedTextColor.RED;
+
+    public static final Component PREFIX_MAIN = Component.text("[Nexus] ", COLOR_PRIMARY);
+}


### PR DESCRIPTION
## Summary
- centralize colors and prefix in new `Theme` class
- refresh `/nx` help output and admin messages to use Adventure components
- polish several admin GUIs with theme colors and filler panes

## Testing
- `mvn -q test` *(failed: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c407bfa483249a3dc4efebb515c6