### PR TITLE
fix: stabilize gameplay core and dependency loading

### DIFF
--- a/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
+++ b/src/main/java/fr/heneria/nexus/game/manager/GameManager.java
@@ -11,6 +11,7 @@ import fr.heneria.nexus.game.model.MatchType;
 import fr.heneria.nexus.game.model.Team;
 import fr.heneria.nexus.game.repository.MatchRepository;
 import fr.heneria.nexus.game.phase.GamePhase;
+import fr.heneria.nexus.game.phase.IPhase;
 import fr.heneria.nexus.game.phase.PhaseManager;
 import fr.heneria.nexus.gui.player.ShopGui;
 import fr.heneria.nexus.shop.manager.ShopManager;
@@ -367,6 +368,19 @@ public class GameManager {
                 if (p != null) {
                     p.sendMessage(entry.getValue());
                 }
+            }
+        }
+        // Annuler toutes les tâches actives pour ce match
+        if (match.getCountdownTask() != null && !match.getCountdownTask().isCancelled()) {
+            match.getCountdownTask().cancel();
+        }
+        if (match.getShopPhaseTask() != null && !match.getShopPhaseTask().isCancelled()) {
+            match.getShopPhaseTask().cancel();
+        }
+        if (match.getPhaseManager() != null) {
+            IPhase currentPhase = match.getPhaseManager().getPhase(match.getCurrentPhase());
+            if (currentPhase != null) {
+                currentPhase.onEnd(match);
             }
         }
 

--- a/src/main/java/fr/heneria/nexus/game/scoreboard/ScoreboardManager.java
+++ b/src/main/java/fr/heneria/nexus/game/scoreboard/ScoreboardManager.java
@@ -1,5 +1,6 @@
 package fr.heneria.nexus.game.scoreboard;
 
+import fr.heneria.nexus.game.GameConfig;
 import fr.heneria.nexus.game.model.Match;
 import fr.heneria.nexus.game.model.Team;
 import fr.heneria.nexus.game.model.TeamColor;
@@ -80,7 +81,8 @@ public class ScoreboardManager {
             board.resetScores(entry);
         }
         int line = 15;
-        obj.getScore("Manche: §a" + match.getCurrentRound() + "/5").setScore(line--);
+        int roundsToWin = GameConfig.get().getRoundsToWin();
+        obj.getScore("Manche: §a" + match.getCurrentRound() + "/" + roundsToWin).setScore(line--);
         obj.getScore(" ").setScore(line--);
         for (Team team : match.getTeams().values()) {
             int teamScore = match.getTeamScores().getOrDefault(team.getTeamId(), 0);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: fr.heneria.nexus.Nexus
 api-version: '1.21'
 author: Projet Heneria
 description: Plugin principal pour le mode de jeu Nexus sur le serveur Heneria.
-softdepend: [PlaceholderAPI]
+softdepend: [PlaceholderAPI, DecentHolograms]
 commands:
   nx:
     description: Centre de contrôle de Nexus


### PR DESCRIPTION
## Summary
- ensure DecentHolograms loads before plugin
- sync scoreboard round count with GameConfig
- clean up running tasks when a match ends

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3c6c18083248ae0ac489dabaafe