### PR TITLE
Initialize Nexus plugin skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.heneria</groupId>
+    <artifactId>nexus</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>Nexus</name>
+    <description>Nexus core plugin for PaperMC servers</description>
+    <url>https://example.com/nexus</url>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>All Rights Reserved</name>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <paper.version>1.21.1-R0.1-SNAPSHOT</paper.version>
+        <mariadb.version>3.3.3</mariadb.version>
+        <hikari.version>5.1.0</hikari.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>${mariadb.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                    <configuration>
+                        <release>${java.version}</release>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <useDefaultDelimiters>true</useDefaultDelimiters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <minimizeJar>true</minimizeJar>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.zaxxer.hikari</pattern>
+                                    <shadedPattern>com.heneria.nexus.lib.hikari</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.mariadb.jdbc</pattern>
+                                    <shadedPattern>com.heneria.nexus.lib.mariadb</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -1,0 +1,184 @@
+package com.heneria.nexus;
+
+import com.heneria.nexus.command.NexusCommand;
+import com.heneria.nexus.config.ConfigBundle;
+import com.heneria.nexus.config.ConfigManager;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.scheduler.GamePhase;
+import com.heneria.nexus.scheduler.RingScheduler;
+import com.heneria.nexus.scheduler.RingScheduler.TaskProfile;
+import com.heneria.nexus.service.ExecutorPools;
+import com.heneria.nexus.service.ServiceRegistry;
+import com.heneria.nexus.util.DumpUtil;
+import com.heneria.nexus.util.MessageFacade;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Main entry point for the Nexus plugin.
+ */
+public final class NexusPlugin extends JavaPlugin {
+
+    private static final String LOG_PREFIX = "[NEXUS] ";
+
+    private NexusLogger logger;
+    private ConfigManager configManager;
+    private ConfigBundle bundle;
+    private MessageFacade messageFacade;
+    private ServiceRegistry serviceRegistry;
+    private ExecutorPools executorPools;
+    private RingScheduler ringScheduler;
+    private DbProvider dbProvider;
+
+    @Override
+    public void onLoad() {
+        this.logger = new NexusLogger(getLogger(), LOG_PREFIX);
+        this.serviceRegistry = new ServiceRegistry(logger);
+    }
+
+    @Override
+    public void onEnable() {
+        this.logger = new NexusLogger(getLogger(), LOG_PREFIX);
+        this.configManager = new ConfigManager(this, logger);
+        ConfigManager.LoadResult loadResult = configManager.initialLoad();
+        if (!loadResult.success()) {
+            loadResult.errors().forEach(error -> logger.error("Erreur de configuration: " + error));
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        this.bundle = loadResult.bundle();
+        this.messageFacade = new MessageFacade(bundle.messages(), logger);
+        this.executorPools = new ExecutorPools(logger, bundle.config().threadSettings());
+        this.ringScheduler = new RingScheduler(this, logger);
+        this.ringScheduler.applyPerfSettings(bundle.config().perfSettings());
+        this.ringScheduler.registerProfile(TaskProfile.HUD,
+                EnumSet.of(GamePhase.LOBBY, GamePhase.STARTING, GamePhase.PLAYING),
+                () -> {
+                });
+        this.ringScheduler.registerProfile(TaskProfile.SCOREBOARD,
+                EnumSet.of(GamePhase.STARTING, GamePhase.PLAYING, GamePhase.RESET),
+                () -> {
+                });
+        this.dbProvider = new DbProvider(logger);
+
+        serviceRegistry.register(RingScheduler.class, ringScheduler);
+        serviceRegistry.register(DbProvider.class, dbProvider);
+
+        registerCommands();
+        logEnvironment();
+        configureDatabase(bundle.config().databaseSettings());
+    }
+
+    @Override
+    public void onDisable() {
+        if (serviceRegistry != null) {
+            serviceRegistry.shutdown().join();
+        }
+        if (executorPools != null) {
+            executorPools.close();
+        }
+        logger.info("Nexus désactivé proprement");
+    }
+
+    private void configureDatabase(com.heneria.nexus.config.NexusConfig.DatabaseSettings settings) {
+        ExecutorService ioExecutor = executorPools.ioExecutor();
+        CompletableFuture<Boolean> future = dbProvider.applyConfiguration(settings, ioExecutor);
+        future.thenAccept(success -> {
+            if (!success) {
+                logger.warn("Mode dégradé activé : MariaDB indisponible");
+            }
+        });
+    }
+
+    private void registerCommands() {
+        PluginCommand command = Objects.requireNonNull(getCommand("nexus"), "Command nexus not registered in plugin.yml");
+        NexusCommand executor = new NexusCommand(this);
+        command.setExecutor(executor);
+        command.setTabCompleter(executor);
+    }
+
+    private void logEnvironment() {
+        logger.info("Démarrage de Nexus %s".formatted(getDescription().getVersion()));
+        logger.info("Java: %s".formatted(System.getProperty("java.version")));
+        logger.info("Paper: %s".formatted(getServer().getVersion()));
+        logger.info("Fuseau horaire: %s".formatted(bundle.config().timezone()));
+        logger.info("HUD: %d Hz, scoreboard: %d Hz".formatted(
+                bundle.config().perfSettings().hudHz(),
+                bundle.config().perfSettings().scoreboardHz()));
+        logger.info("Threads: io=%d compute=%d".formatted(
+                bundle.config().threadSettings().ioPool(),
+                bundle.config().threadSettings().computePool()));
+    }
+
+    public void sendHelp(CommandSender sender) {
+        messageFacade.send(sender, "commands.help.header");
+        messageFacade.send(sender, "commands.help.help");
+        if (sender.hasPermission("nexus.admin.reload")) {
+            messageFacade.send(sender, "commands.help.reload");
+        }
+        if (sender.hasPermission("nexus.admin.dump")) {
+            messageFacade.send(sender, "commands.help.dump");
+        }
+    }
+
+    public void handleReload(CommandSender sender) {
+        if (!sender.hasPermission("nexus.admin.reload")) {
+            messageFacade.send(sender, "commands.errors.no-permission");
+            return;
+        }
+        messageFacade.send(sender, "commands.reload.start");
+        ConfigManager.LoadResult reload = configManager.reloadFromDisk();
+        if (!reload.success()) {
+            messageFacade.send(sender, "commands.errors.invalid-config");
+            reload.errors().forEach(error -> sender.sendMessage(Component.text(" • " + error, NamedTextColor.RED)));
+            return;
+        }
+        ConfigBundle previous = this.bundle;
+        try {
+            applyBundle(reload.bundle());
+            messageFacade.send(sender, "commands.reload.success");
+        } catch (Exception exception) {
+            this.bundle = previous;
+            configManager.applyBundle(previous);
+            messageFacade.send(sender, "commands.reload.failure");
+            logger.error("Erreur lors du rechargement", exception);
+        }
+    }
+
+    private synchronized void applyBundle(ConfigBundle newBundle) {
+        executorPools.reconfigure(newBundle.config().threadSettings());
+        ringScheduler.applyPerfSettings(newBundle.config().perfSettings());
+        messageFacade.update(newBundle.messages());
+        this.bundle = newBundle;
+        configManager.applyBundle(newBundle);
+        configureDatabase(newBundle.config().databaseSettings());
+    }
+
+    public void handleDump(CommandSender sender) {
+        if (!sender.hasPermission("nexus.admin.dump")) {
+            messageFacade.send(sender, "commands.errors.no-permission");
+            return;
+        }
+        messageFacade.send(sender, "commands.dump.header");
+        List<Component> lines = DumpUtil.createDump(getServer(), bundle, executorPools, ringScheduler, dbProvider);
+        lines.forEach(sender::sendMessage);
+        messageFacade.send(sender, "commands.dump.success");
+    }
+
+    public MessageFacade messages() {
+        return messageFacade;
+    }
+
+    public ConfigBundle bundle() {
+        return bundle;
+    }
+}

--- a/src/main/java/com/heneria/nexus/command/NexusCommand.java
+++ b/src/main/java/com/heneria/nexus/command/NexusCommand.java
@@ -1,0 +1,69 @@
+package com.heneria.nexus.command;
+
+import com.heneria.nexus.NexusPlugin;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+/**
+ * Main command entry point.
+ */
+public final class NexusCommand implements CommandExecutor, TabCompleter {
+
+    private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump");
+
+    private final NexusPlugin plugin;
+
+    public NexusCommand(NexusPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            plugin.sendHelp(sender);
+            return true;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        return switch (sub) {
+            case "help" -> {
+                plugin.sendHelp(sender);
+                yield true;
+            }
+            case "reload" -> {
+                plugin.handleReload(sender);
+                yield true;
+            }
+            case "dump" -> {
+                plugin.handleDump(sender);
+                yield true;
+            }
+            default -> {
+                plugin.sendHelp(sender);
+                yield true;
+            }
+        };
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            String prefix = args[0].toLowerCase(Locale.ROOT);
+            return SUB_COMMANDS.stream()
+                    .filter(sub -> {
+                        if (sub.equals("reload") || sub.equals("dump")) {
+                            return sender.hasPermission("nexus.admin." + sub);
+                        }
+                        return true;
+                    })
+                    .filter(sub -> sub.startsWith(prefix))
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/ConfigBundle.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigBundle.java
@@ -1,0 +1,32 @@
+package com.heneria.nexus.config;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Aggregates configuration objects that must be reloaded atomically.
+ */
+public final class ConfigBundle {
+
+    private final NexusConfig config;
+    private final MessageBundle messages;
+    private final Instant loadedAt;
+
+    public ConfigBundle(NexusConfig config, MessageBundle messages, Instant loadedAt) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.messages = Objects.requireNonNull(messages, "messages");
+        this.loadedAt = Objects.requireNonNull(loadedAt, "loadedAt");
+    }
+
+    public NexusConfig config() {
+        return config;
+    }
+
+    public MessageBundle messages() {
+        return messages;
+    }
+
+    public Instant loadedAt() {
+        return loadedAt;
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/ConfigLoadException.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigLoadException.java
@@ -1,0 +1,26 @@
+package com.heneria.nexus.config;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exception thrown when parsing configuration files fails.
+ */
+public final class ConfigLoadException extends Exception {
+
+    private final List<String> errors;
+
+    public ConfigLoadException(String message) {
+        super(message);
+        this.errors = List.of(message);
+    }
+
+    public ConfigLoadException(List<String> errors) {
+        super("Configuration invalid: " + String.join(", ", errors));
+        this.errors = List.copyOf(errors);
+    }
+
+    public List<String> errors() {
+        return Collections.unmodifiableList(errors);
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/ConfigManager.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigManager.java
@@ -1,0 +1,258 @@
+package com.heneria.nexus.config;
+
+import com.heneria.nexus.util.NexusLogger;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Handles configuration files and provides atomic reloads.
+ */
+public final class ConfigManager {
+
+    private static final String DEFAULT_LANGUAGE = "fr";
+    private static final String DEFAULT_TIMEZONE = "Europe/Paris";
+    private static final String DEFAULT_JDBC = "jdbc:mariadb://127.0.0.1:3306/nexus";
+    private static final String DEFAULT_DB_USER = "nexus";
+    private static final String DEFAULT_DB_PASSWORD = "change_me";
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final Path dataDirectory;
+    private final AtomicReference<ConfigBundle> bundleRef = new AtomicReference<>();
+
+    public ConfigManager(JavaPlugin plugin, NexusLogger logger) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.dataDirectory = plugin.getDataFolder().toPath();
+    }
+
+    public LoadResult initialLoad() {
+        ensureDefaults();
+        try {
+            ConfigBundle bundle = loadBundle();
+            bundleRef.set(bundle);
+            return LoadResult.success(bundle);
+        } catch (ConfigLoadException exception) {
+            logger.error("Configuration invalide lors du démarrage", exception);
+            return LoadResult.failure(exception.errors());
+        }
+    }
+
+    public LoadResult reloadFromDisk() {
+        try {
+            ConfigBundle bundle = loadBundle();
+            return LoadResult.success(bundle);
+        } catch (ConfigLoadException exception) {
+            logger.warn("Rechargement de configuration impossible", exception);
+            return LoadResult.failure(exception.errors());
+        }
+    }
+
+    public ConfigBundle currentBundle() {
+        return Optional.ofNullable(bundleRef.get())
+                .orElseThrow(() -> new IllegalStateException("Configuration not loaded yet"));
+    }
+
+    public void applyBundle(ConfigBundle bundle) {
+        bundleRef.set(bundle);
+    }
+
+    private void ensureDefaults() {
+        try {
+            if (Files.notExists(dataDirectory)) {
+                Files.createDirectories(dataDirectory);
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException("Unable to create plugin data directory", exception);
+        }
+
+        copyResourceIfMissing("config.yml");
+        copyResourceIfMissing("messages.yml");
+        copyResourceIfMissing("economy.yml");
+        copyResourceIfMissing("maps.yml");
+    }
+
+    private void copyResourceIfMissing(String resource) {
+        File target = dataDirectory.resolve(resource).toFile();
+        if (!target.exists()) {
+            plugin.saveResource(resource, false);
+        }
+    }
+
+    private ConfigBundle loadBundle() throws ConfigLoadException {
+        File configFile = dataDirectory.resolve("config.yml").toFile();
+        File messagesFile = dataDirectory.resolve("messages.yml").toFile();
+
+        YamlConfiguration configYaml = YamlConfiguration.loadConfiguration(configFile);
+        applyDefaults(configYaml, "config.yml");
+        YamlConfiguration messagesYaml = YamlConfiguration.loadConfiguration(messagesFile);
+        applyDefaults(messagesYaml, "messages.yml");
+
+        List<String> errors = new ArrayList<>();
+        NexusConfig config = parseConfig(configYaml, errors);
+        MessageBundle messages = parseMessages(messagesYaml, config.language(), errors);
+
+        if (!errors.isEmpty()) {
+            throw new ConfigLoadException(errors);
+        }
+
+        return new ConfigBundle(config, messages, Instant.now());
+    }
+
+    private void applyDefaults(YamlConfiguration configuration, String resourceName) {
+        try (InputStream inputStream = plugin.getResource(resourceName)) {
+            if (inputStream == null) {
+                return;
+            }
+            YamlConfiguration defaults = new YamlConfiguration();
+            defaults.load(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            configuration.setDefaults(defaults);
+            configuration.options().copyDefaults(true);
+        } catch (IOException | InvalidConfigurationException exception) {
+            logger.warn("Impossible de charger les valeurs par défaut pour " + resourceName, exception);
+        }
+    }
+
+    private NexusConfig parseConfig(FileConfiguration yaml, List<String> errors) {
+        String serverMode = yaml.getString("server.mode", "nexus");
+        String languageTag = yaml.getString("server.language", DEFAULT_LANGUAGE);
+        Locale language = Locale.forLanguageTag(languageTag);
+        String timezoneId = yaml.getString("server.timezone", DEFAULT_TIMEZONE);
+        ZoneId timezone;
+        try {
+            timezone = ZoneId.of(timezoneId);
+        } catch (Exception exception) {
+            errors.add("server.timezone: " + exception.getMessage());
+            timezone = ZoneId.of(DEFAULT_TIMEZONE);
+        }
+
+        int hudHz = yaml.getInt("perf.hud_hz", 5);
+        if (hudHz <= 0) {
+            errors.add("perf.hud_hz doit être > 0");
+            hudHz = 5;
+        }
+        int scoreboardHz = yaml.getInt("perf.scoreboard_hz", 3);
+        if (scoreboardHz <= 0) {
+            errors.add("perf.scoreboard_hz doit être > 0");
+            scoreboardHz = 3;
+        }
+        int particlesSoft = yaml.getInt("perf.particles_soft_cap", 1200);
+        int particlesHard = yaml.getInt("perf.particles_hard_cap", 2000);
+        if (particlesHard < particlesSoft) {
+            errors.add("perf.particles_hard_cap doit être >= perf.particles_soft_cap");
+            particlesHard = particlesSoft;
+        }
+
+        int ioPool = yaml.getInt("threads.io_pool", 3);
+        if (ioPool <= 0) {
+            errors.add("threads.io_pool doit être > 0");
+            ioPool = 1;
+        }
+        int computePool = yaml.getInt("threads.compute_pool", 1);
+        if (computePool <= 0) {
+            errors.add("threads.compute_pool doit être > 0");
+            computePool = 1;
+        }
+
+        boolean dbEnabled = yaml.getBoolean("database.enabled", true);
+        String jdbcUrl = yaml.getString("database.jdbc", DEFAULT_JDBC);
+        if (jdbcUrl == null || jdbcUrl.isBlank()) {
+            errors.add("database.jdbc manquant");
+            jdbcUrl = DEFAULT_JDBC;
+        }
+        String username = yaml.getString("database.user", DEFAULT_DB_USER);
+        if (username == null || username.isBlank()) {
+            errors.add("database.user manquant");
+            username = DEFAULT_DB_USER;
+        }
+        String password = yaml.getString("database.password", DEFAULT_DB_PASSWORD);
+        if (password == null) {
+            password = DEFAULT_DB_PASSWORD;
+        }
+        int maxSize = yaml.getInt("database.pool.maxSize", 10);
+        if (maxSize <= 0) {
+            errors.add("database.pool.maxSize doit être > 0");
+            maxSize = 10;
+        }
+        int minIdle = yaml.getInt("database.pool.minIdle", 2);
+        if (minIdle < 0) {
+            errors.add("database.pool.minIdle doit être >= 0");
+            minIdle = 0;
+        }
+        long timeoutMs = yaml.getLong("database.pool.connTimeoutMs", 3000L);
+        if (timeoutMs <= 0L) {
+            errors.add("database.pool.connTimeoutMs doit être > 0");
+            timeoutMs = 3000L;
+        }
+
+        NexusConfig.PerfSettings perfSettings;
+        NexusConfig.ThreadSettings threadSettings;
+        NexusConfig.PoolSettings poolSettings;
+        try {
+            perfSettings = new NexusConfig.PerfSettings(hudHz, scoreboardHz, particlesSoft, particlesHard);
+        } catch (IllegalArgumentException exception) {
+            errors.add("perf: " + exception.getMessage());
+            perfSettings = new NexusConfig.PerfSettings(5, 3, particlesSoft, particlesHard);
+        }
+        try {
+            threadSettings = new NexusConfig.ThreadSettings(ioPool, computePool);
+        } catch (IllegalArgumentException exception) {
+            errors.add("threads: " + exception.getMessage());
+            threadSettings = new NexusConfig.ThreadSettings(Math.max(1, ioPool), Math.max(1, computePool));
+        }
+        try {
+            poolSettings = new NexusConfig.PoolSettings(maxSize, minIdle, timeoutMs);
+        } catch (IllegalArgumentException exception) {
+            errors.add("database.pool: " + exception.getMessage());
+            poolSettings = new NexusConfig.PoolSettings(10, 2, 3000L);
+        }
+        NexusConfig.DatabaseSettings databaseSettings =
+                new NexusConfig.DatabaseSettings(dbEnabled, jdbcUrl, username, password, poolSettings);
+
+        return new NexusConfig(serverMode, language, timezone, perfSettings, threadSettings, databaseSettings);
+    }
+
+    private MessageBundle parseMessages(FileConfiguration yaml, Locale locale, List<String> errors) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (String key : yaml.getKeys(true)) {
+            Object value = yaml.get(key);
+            if (value instanceof String stringValue) {
+                map.put(key, stringValue);
+            }
+        }
+        if (map.isEmpty()) {
+            errors.add("messages: aucune entrée chargée");
+        }
+        return new MessageBundle(map, locale, Instant.now());
+    }
+
+    public record LoadResult(boolean success, ConfigBundle bundle, List<String> errors) {
+
+        public static LoadResult success(ConfigBundle bundle) {
+            return new LoadResult(true, bundle, List.of());
+        }
+
+        public static LoadResult failure(List<String> errors) {
+            return new LoadResult(false, null, List.copyOf(errors));
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/MessageBundle.java
+++ b/src/main/java/com/heneria/nexus/config/MessageBundle.java
@@ -1,0 +1,40 @@
+package com.heneria.nexus.config;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable snapshot of the MiniMessage templates loaded from disk.
+ */
+public final class MessageBundle {
+
+    private final Map<String, String> messages;
+    private final Locale locale;
+    private final Instant loadedAt;
+
+    public MessageBundle(Map<String, String> messages, Locale locale, Instant loadedAt) {
+        this.messages = Collections.unmodifiableMap(messages);
+        this.locale = Objects.requireNonNull(locale, "locale");
+        this.loadedAt = Objects.requireNonNull(loadedAt, "loadedAt");
+    }
+
+    public Optional<String> message(String key) {
+        return Optional.ofNullable(messages.get(key));
+    }
+
+    public Map<String, String> messages() {
+        return messages;
+    }
+
+    public Locale locale() {
+        return locale;
+    }
+
+    public Instant loadedAt() {
+        return loadedAt;
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/NexusConfig.java
+++ b/src/main/java/com/heneria/nexus/config/NexusConfig.java
@@ -1,0 +1,107 @@
+package com.heneria.nexus.config;
+
+import java.time.ZoneId;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Immutable view over the main nexus configuration.
+ */
+public final class NexusConfig {
+
+    private final String serverMode;
+    private final Locale language;
+    private final ZoneId timezone;
+    private final PerfSettings perfSettings;
+    private final ThreadSettings threadSettings;
+    private final DatabaseSettings databaseSettings;
+
+    public NexusConfig(String serverMode,
+                       Locale language,
+                       ZoneId timezone,
+                       PerfSettings perfSettings,
+                       ThreadSettings threadSettings,
+                       DatabaseSettings databaseSettings) {
+        this.serverMode = Objects.requireNonNull(serverMode, "serverMode");
+        this.language = Objects.requireNonNull(language, "language");
+        this.timezone = Objects.requireNonNull(timezone, "timezone");
+        this.perfSettings = Objects.requireNonNull(perfSettings, "perfSettings");
+        this.threadSettings = Objects.requireNonNull(threadSettings, "threadSettings");
+        this.databaseSettings = Objects.requireNonNull(databaseSettings, "databaseSettings");
+    }
+
+    public String serverMode() {
+        return serverMode;
+    }
+
+    public Locale language() {
+        return language;
+    }
+
+    public ZoneId timezone() {
+        return timezone;
+    }
+
+    public PerfSettings perfSettings() {
+        return perfSettings;
+    }
+
+    public ThreadSettings threadSettings() {
+        return threadSettings;
+    }
+
+    public DatabaseSettings databaseSettings() {
+        return databaseSettings;
+    }
+
+    public record PerfSettings(int hudHz, int scoreboardHz, int particlesSoftCap, int particlesHardCap) {
+        public PerfSettings {
+            if (hudHz <= 0) {
+                throw new IllegalArgumentException("hudHz must be positive");
+            }
+            if (scoreboardHz <= 0) {
+                throw new IllegalArgumentException("scoreboardHz must be positive");
+            }
+            if (particlesSoftCap < 0) {
+                throw new IllegalArgumentException("particlesSoftCap must be >= 0");
+            }
+            if (particlesHardCap < particlesSoftCap) {
+                throw new IllegalArgumentException("particlesHardCap must be >= particlesSoftCap");
+            }
+        }
+    }
+
+    public record ThreadSettings(int ioPool, int computePool) {
+        public ThreadSettings {
+            if (ioPool <= 0) {
+                throw new IllegalArgumentException("ioPool must be positive");
+            }
+            if (computePool <= 0) {
+                throw new IllegalArgumentException("computePool must be positive");
+            }
+        }
+    }
+
+    public record DatabaseSettings(boolean enabled, String jdbcUrl, String username, String password, PoolSettings poolSettings) {
+        public DatabaseSettings {
+            Objects.requireNonNull(jdbcUrl, "jdbcUrl");
+            Objects.requireNonNull(username, "username");
+            Objects.requireNonNull(password, "password");
+            Objects.requireNonNull(poolSettings, "poolSettings");
+        }
+    }
+
+    public record PoolSettings(int maxSize, int minIdle, long connectionTimeoutMs) {
+        public PoolSettings {
+            if (maxSize <= 0) {
+                throw new IllegalArgumentException("maxSize must be positive");
+            }
+            if (minIdle < 0) {
+                throw new IllegalArgumentException("minIdle must be >= 0");
+            }
+            if (connectionTimeoutMs <= 0) {
+                throw new IllegalArgumentException("connectionTimeoutMs must be positive");
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/db/DbProvider.java
+++ b/src/main/java/com/heneria/nexus/db/DbProvider.java
@@ -1,0 +1,163 @@
+package com.heneria.nexus.db;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.util.NexusLogger;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Provides access to the MariaDB datasource.
+ */
+public final class DbProvider implements LifecycleAware {
+
+    private static final Duration LEAK_DETECTION = Duration.ofSeconds(15);
+
+    private final NexusLogger logger;
+    private final AtomicReference<HikariDataSource> dataSourceRef = new AtomicReference<>();
+    private final AtomicReference<NexusConfig.DatabaseSettings> settingsRef = new AtomicReference<>();
+    private final AtomicLong failedAttempts = new AtomicLong();
+    private volatile boolean degraded;
+
+    public DbProvider(NexusLogger logger) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    public CompletableFuture<Boolean> applyConfiguration(NexusConfig.DatabaseSettings settings, ExecutorService executor) {
+        settingsRef.set(settings);
+        if (!settings.enabled()) {
+            logger.info("Persistance désactivée, fonctionnement en mémoire");
+            degraded = false;
+            closeDataSource();
+            return CompletableFuture.completedFuture(true);
+        }
+        logger.info("Initialisation de la base de données MariaDB %s".formatted(settings.jdbcUrl()));
+        HikariConfig hikariConfig = toHikariConfig(settings);
+        HikariDataSource candidate = new HikariDataSource(hikariConfig);
+        return CompletableFuture.supplyAsync(() -> testConnection(candidate), executor)
+                .handle((success, throwable) -> {
+                    if (throwable != null || Boolean.FALSE.equals(success)) {
+                        degraded = true;
+                        long attempts = failedAttempts.incrementAndGet();
+                        closeQuietly(candidate);
+                        if (throwable != null) {
+                            logger.warn("Connexion MariaDB impossible (tentative %d)".formatted(attempts), throwable);
+                        } else {
+                            logger.warn("Connexion MariaDB impossible (tentative %d)".formatted(attempts));
+                        }
+                        return false;
+                    }
+                    failedAttempts.set(0);
+                    degraded = false;
+                    HikariDataSource previous = dataSourceRef.getAndSet(candidate);
+                    closeQuietly(previous);
+                    logger.info("Connexion MariaDB opérationnelle (%s)".formatted(settings.jdbcUrl()));
+                    return true;
+                });
+    }
+
+    private boolean testConnection(HikariDataSource dataSource) {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement("SELECT 1");
+             ResultSet resultSet = statement.executeQuery()) {
+            return resultSet.next();
+        } catch (SQLException exception) {
+            return false;
+        }
+    }
+
+    private HikariConfig toHikariConfig(NexusConfig.DatabaseSettings settings) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(settings.jdbcUrl());
+        config.setUsername(settings.username());
+        config.setPassword(settings.password());
+        config.setMaximumPoolSize(settings.poolSettings().maxSize());
+        config.setMinimumIdle(settings.poolSettings().minIdle());
+        config.setConnectionTimeout(settings.poolSettings().connectionTimeoutMs());
+        config.setLeakDetectionThreshold(Math.max(LEAK_DETECTION.toMillis(), TimeUnit.SECONDS.toMillis(2)));
+        config.setInitializationFailTimeout(TimeUnit.SECONDS.toMillis(5));
+        config.setValidationTimeout(TimeUnit.SECONDS.toMillis(2));
+        config.setConnectionTestQuery("SELECT 1");
+        config.setPoolName("Nexus-Hikari");
+        return config;
+    }
+
+    public boolean isDegraded() {
+        return degraded;
+    }
+
+    public <T> CompletableFuture<T> execute(QueryTask<T> task, ExecutorService executor) {
+        HikariDataSource dataSource = dataSourceRef.get();
+        if (dataSource == null) {
+            return CompletableFuture.failedFuture(new IllegalStateException("Database not available"));
+        }
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = dataSource.getConnection()) {
+                return task.apply(connection);
+            } catch (SQLException exception) {
+                throw new RuntimeException(exception);
+            }
+        }, executor);
+    }
+
+    public Diagnostics diagnostics() {
+        HikariDataSource dataSource = dataSourceRef.get();
+        HikariPoolMXBean pool = dataSource != null ? dataSource.getHikariPoolMXBean() : null;
+        NexusConfig.DatabaseSettings settings = settingsRef.get();
+        return new Diagnostics(
+                settings,
+                degraded,
+                pool != null ? pool.getActiveConnections() : 0,
+                pool != null ? pool.getIdleConnections() : 0,
+                pool != null ? pool.getTotalConnections() : 0,
+                pool != null ? pool.getThreadsAwaitingConnection() : 0,
+                failedAttempts.get());
+    }
+
+    private void closeQuietly(HikariDataSource dataSource) {
+        if (dataSource == null) {
+            return;
+        }
+        try {
+            dataSource.close();
+        } catch (Exception exception) {
+            logger.warn("Erreur lors de la fermeture de la datasource", exception);
+        }
+    }
+
+    private void closeDataSource() {
+        closeQuietly(dataSourceRef.getAndSet(null));
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        closeDataSource();
+        return LifecycleAware.super.stop();
+    }
+
+    @FunctionalInterface
+    public interface QueryTask<T> {
+        T apply(Connection connection) throws SQLException;
+    }
+
+    public record Diagnostics(NexusConfig.DatabaseSettings settings,
+                              boolean degraded,
+                              int activeConnections,
+                              int idleConnections,
+                              int totalConnections,
+                              int awaitingThreads,
+                              long failedAttempts) {
+    }
+}

--- a/src/main/java/com/heneria/nexus/scheduler/GamePhase.java
+++ b/src/main/java/com/heneria/nexus/scheduler/GamePhase.java
@@ -1,0 +1,12 @@
+package com.heneria.nexus.scheduler;
+
+/**
+ * Represents the global lifecycle of a Nexus match.
+ */
+public enum GamePhase {
+    LOBBY,
+    STARTING,
+    PLAYING,
+    RESET,
+    END
+}

--- a/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
+++ b/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
@@ -1,0 +1,149 @@
+package com.heneria.nexus.scheduler;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Phase aware scheduler that distributes work across ticks.
+ *
+ * <p>It uses the traditional Bukkit scheduler as the plugin targets the
+ * non-Folia branch of Paper. The design keeps the door open for the
+ * GlobalRegionScheduler documented in
+ * https://docs.papermc.io/paper/dev/scheduler if we migrate later.</p>
+ */
+public final class RingScheduler implements LifecycleAware {
+
+    public enum TaskProfile {
+        HUD,
+        SCOREBOARD
+    }
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final AtomicReference<GamePhase> phase = new AtomicReference<>(GamePhase.LOBBY);
+    private final AtomicLong tick = new AtomicLong();
+    private final LongAdder executedTasks = new LongAdder();
+    private final LongAdder totalRuntimeNanos = new LongAdder();
+    private final ConcurrentMap<String, RingTask> tasks = new ConcurrentHashMap<>();
+    private final Map<TaskProfile, Long> profileIntervals = new EnumMap<>(TaskProfile.class);
+    private volatile BukkitTask tickerTask;
+
+    public RingScheduler(JavaPlugin plugin, NexusLogger logger) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        profileIntervals.put(TaskProfile.HUD, 4L);
+        profileIntervals.put(TaskProfile.SCOREBOARD, 7L);
+    }
+
+    public void applyPerfSettings(NexusConfig.PerfSettings perfSettings) {
+        profileIntervals.put(TaskProfile.HUD, hzToTicks(perfSettings.hudHz()));
+        profileIntervals.put(TaskProfile.SCOREBOARD, hzToTicks(perfSettings.scoreboardHz()));
+        tasks.values().forEach(task -> {
+            if (task.id().startsWith("profile-")) {
+                TaskProfile profile = TaskProfile.valueOf(task.id().substring("profile-".length()).toUpperCase());
+                task.updateInterval(profileIntervals.getOrDefault(profile, task.intervalTicks()));
+            }
+        });
+    }
+
+    public void registerProfile(TaskProfile profile, EnumSet<GamePhase> phases, Runnable runnable) {
+        String id = "profile-" + profile.name().toLowerCase();
+        long interval = profileIntervals.getOrDefault(profile, 4L);
+        tasks.put(id, new RingTask(id, runnable, phases, interval, profile.ordinal()));
+    }
+
+    public void registerTask(String id, long intervalTicks, EnumSet<GamePhase> phases, Runnable runnable) {
+        int offset = Math.abs(id.hashCode());
+        tasks.put(id, new RingTask(id, runnable, phases, intervalTicks, offset));
+    }
+
+    public void setPhase(GamePhase phase) {
+        this.phase.set(Objects.requireNonNull(phase, "phase"));
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        if (tickerTask != null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        tickerTask = Bukkit.getScheduler().runTaskTimer(plugin, this::tick, 1L, 1L);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        if (tickerTask != null) {
+            tickerTask.cancel();
+            tickerTask = null;
+        }
+        tasks.clear();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void tick() {
+        long currentTick = tick.incrementAndGet();
+        GamePhase currentPhase = phase.get();
+        long tickStart = System.nanoTime();
+        tasks.values().forEach(task -> executeTask(task, currentTick, currentPhase));
+        long duration = System.nanoTime() - tickStart;
+        if (duration > TimeUnit.MILLISECONDS.toNanos(2)) {
+            long nanos = duration;
+            logger.debug(() -> "Tick " + currentTick + " du RingScheduler a pris " + nanos + "ns");
+        }
+    }
+
+    private void executeTask(RingTask task, long currentTick, GamePhase phase) {
+        if (!task.shouldExecute(currentTick, phase)) {
+            return;
+        }
+        long start = System.nanoTime();
+        try {
+            task.runnable().run();
+        } catch (Throwable throwable) {
+            logger.error("Erreur lors de l'exécution de la tâche " + task.id(), throwable);
+        } finally {
+            long duration = System.nanoTime() - start;
+            executedTasks.increment();
+            totalRuntimeNanos.add(duration);
+        }
+    }
+
+    private long hzToTicks(int hz) {
+        return Math.max(1L, Math.round(20.0d / Math.max(1, hz)));
+    }
+
+    public Diagnostics diagnostics() {
+        Map<String, Long> snapshot = new ConcurrentHashMap<>();
+        tasks.forEach((key, value) -> snapshot.put(key, value.intervalTicks()));
+        return new Diagnostics(
+                tick.get(),
+                executedTasks.sum(),
+                totalRuntimeNanos.sum(),
+                phase.get(),
+                Map.copyOf(snapshot));
+    }
+
+    public record Diagnostics(long ticks, long executedTasks, long totalRuntimeNanos, GamePhase phase, Map<String, Long> taskIntervals) {
+        public double averageExecutionMicros() {
+            if (executedTasks == 0L) {
+                return 0D;
+            }
+            return (totalRuntimeNanos / 1_000D) / executedTasks;
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/scheduler/RingTask.java
+++ b/src/main/java/com/heneria/nexus/scheduler/RingTask.java
@@ -1,0 +1,52 @@
+package com.heneria.nexus.scheduler;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Task executed by the ring scheduler.
+ */
+final class RingTask {
+
+    private final String id;
+    private final Runnable runnable;
+    private final EnumSet<GamePhase> phases;
+    private volatile long intervalTicks;
+    private final int offset;
+
+    RingTask(String id, Runnable runnable, EnumSet<GamePhase> phases, long intervalTicks, int offset) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.runnable = Objects.requireNonNull(runnable, "runnable");
+        this.phases = phases.isEmpty() ? EnumSet.allOf(GamePhase.class) : phases.clone();
+        this.intervalTicks = Math.max(1, intervalTicks);
+        this.offset = offset;
+    }
+
+    String id() {
+        return id;
+    }
+
+    Runnable runnable() {
+        return runnable;
+    }
+
+    Set<GamePhase> phases() {
+        return phases;
+    }
+
+    long intervalTicks() {
+        return intervalTicks;
+    }
+
+    void updateInterval(long intervalTicks) {
+        this.intervalTicks = Math.max(1, intervalTicks);
+    }
+
+    boolean shouldExecute(long tick, GamePhase phase) {
+        if (!phases.contains(phase)) {
+            return false;
+        }
+        return (tick + offset) % intervalTicks == 0;
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/ExecutorPools.java
+++ b/src/main/java/com/heneria/nexus/service/ExecutorPools.java
@@ -1,0 +1,122 @@
+package com.heneria.nexus.service;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.util.NamedThreadFactory;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the compute and IO thread pools used throughout the plugin.
+ */
+public final class ExecutorPools implements AutoCloseable {
+
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
+
+    private final NexusLogger logger;
+    private volatile NexusConfig.ThreadSettings settings;
+    private volatile ThreadPoolExecutor ioExecutor;
+    private volatile ThreadPoolExecutor computeExecutor;
+
+    public ExecutorPools(NexusLogger logger, NexusConfig.ThreadSettings settings) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.settings = Objects.requireNonNull(settings, "settings");
+        this.ioExecutor = createExecutor("IO", settings.ioPool());
+        this.computeExecutor = createExecutor("Compute", settings.computePool());
+    }
+
+    private ThreadPoolExecutor createExecutor(String name, int size) {
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                size,
+                size,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                new NamedThreadFactory("Nexus-" + name, false, logger));
+        executor.allowCoreThreadTimeOut(false);
+        return executor;
+    }
+
+    public ExecutorService ioExecutor() {
+        return ioExecutor;
+    }
+
+    public ExecutorService computeExecutor() {
+        return computeExecutor;
+    }
+
+    public synchronized void reconfigure(NexusConfig.ThreadSettings newSettings) {
+        if (this.settings.equals(newSettings)) {
+            return;
+        }
+        logger.info("Reconfiguration des pools de threads: io=%d compute=%d".formatted(newSettings.ioPool(), newSettings.computePool()));
+        ThreadPoolExecutor newIo = createExecutor("IO", newSettings.ioPool());
+        ThreadPoolExecutor newCompute = createExecutor("Compute", newSettings.computePool());
+
+        ThreadPoolExecutor oldIo = this.ioExecutor;
+        ThreadPoolExecutor oldCompute = this.computeExecutor;
+        this.ioExecutor = newIo;
+        this.computeExecutor = newCompute;
+        this.settings = newSettings;
+
+        shutdownAsync(oldIo, "IO");
+        shutdownAsync(oldCompute, "Compute");
+    }
+
+    private void shutdownAsync(ThreadPoolExecutor executor, String name) {
+        if (executor == null) {
+            return;
+        }
+        executor.shutdown();
+        CompletableFuture.runAsync(() -> awaitTermination(executor, name));
+    }
+
+    private void awaitTermination(ThreadPoolExecutor executor, String name) {
+        try {
+            if (!executor.awaitTermination(SHUTDOWN_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                logger.warn("Arrêt forcé du pool " + name);
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            logger.warn("Interruption lors de l'arrêt du pool " + name, exception);
+            executor.shutdownNow();
+        }
+    }
+
+    public Diagnostics diagnostics() {
+        return new Diagnostics(settings, snapshot(ioExecutor), snapshot(computeExecutor));
+    }
+
+    private PoolSnapshot snapshot(ThreadPoolExecutor executor) {
+        if (executor == null) {
+            return PoolSnapshot.empty();
+        }
+        return new PoolSnapshot(
+                executor.getCorePoolSize(),
+                executor.getPoolSize(),
+                executor.getActiveCount(),
+                executor.getQueue().size(),
+                executor.getCompletedTaskCount());
+    }
+
+    @Override
+    public void close() {
+        shutdownAsync(ioExecutor, "IO");
+        shutdownAsync(computeExecutor, "Compute");
+    }
+
+    public record Diagnostics(NexusConfig.ThreadSettings settings, PoolSnapshot io, PoolSnapshot compute) {
+    }
+
+    public record PoolSnapshot(int corePoolSize, int poolSize, int activeCount, int queuedTasks, long completedTasks) {
+        private static PoolSnapshot empty() {
+            return new PoolSnapshot(0, 0, 0, 0, 0L);
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/LifecycleAware.java
+++ b/src/main/java/com/heneria/nexus/service/LifecycleAware.java
@@ -1,0 +1,17 @@
+package com.heneria.nexus.service;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Marks a service that exposes lifecycle hooks.
+ */
+public interface LifecycleAware {
+
+    default CompletableFuture<Void> start() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    default CompletableFuture<Void> stop() {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/ServiceRegistry.java
+++ b/src/main/java/com/heneria/nexus/service/ServiceRegistry.java
@@ -1,0 +1,60 @@
+package com.heneria.nexus.service;
+
+import com.heneria.nexus.util.NexusLogger;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple registry able to manage service lifecycles.
+ */
+public final class ServiceRegistry {
+
+    private final Map<Class<?>, Object> services = new ConcurrentHashMap<>();
+    private final NexusLogger logger;
+
+    public ServiceRegistry(NexusLogger logger) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    public <T> void register(Class<T> type, T instance) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(instance, "instance");
+        services.put(type, instance);
+        if (instance instanceof LifecycleAware lifecycleAware) {
+            lifecycleAware.start().exceptionally(throwable -> {
+                logger.error("Erreur lors du démarrage du service " + type.getSimpleName(), throwable);
+                return null;
+            });
+        }
+    }
+
+    public <T> Optional<T> get(Class<T> type) {
+        Objects.requireNonNull(type, "type");
+        return Optional.ofNullable(type.cast(services.get(type)));
+    }
+
+    public Map<Class<?>, Object> services() {
+        return Collections.unmodifiableMap(services);
+    }
+
+    public CompletableFuture<Void> shutdown() {
+        CompletableFuture<?>[] futures = services.entrySet().stream()
+                .map(entry -> {
+                    Object instance = entry.getValue();
+                    if (instance instanceof LifecycleAware lifecycleAware) {
+                        return lifecycleAware.stop().exceptionally(throwable -> {
+                            logger.error("Erreur lors de l'arrêt du service " + entry.getKey().getSimpleName(), throwable);
+                            return null;
+                        });
+                    }
+                    return CompletableFuture.completedFuture(null);
+                })
+                .toArray(CompletableFuture[]::new);
+        services.clear();
+        return CompletableFuture.allOf(futures);
+    }
+}

--- a/src/main/java/com/heneria/nexus/util/DumpUtil.java
+++ b/src/main/java/com/heneria/nexus/util/DumpUtil.java
@@ -1,0 +1,82 @@
+package com.heneria.nexus.util;
+
+import com.heneria.nexus.config.ConfigBundle;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.scheduler.RingScheduler;
+import com.heneria.nexus.service.ExecutorPools;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Server;
+
+/**
+ * Collects runtime diagnostics for the dump command.
+ */
+public final class DumpUtil {
+
+    private DumpUtil() {
+    }
+
+    public static List<Component> createDump(Server server,
+                                             ConfigBundle bundle,
+                                             ExecutorPools executorPools,
+                                             RingScheduler scheduler,
+                                             DbProvider dbProvider) {
+        List<Component> lines = new ArrayList<>();
+        lines.add(Component.text("=== État Nexus ===", NamedTextColor.GOLD));
+        lines.add(Component.text("Serveur : " + server.getVersion(), NamedTextColor.YELLOW));
+        lines.add(Component.text("Java : " + System.getProperty("java.version"), NamedTextColor.YELLOW));
+        lines.add(Component.text("Fuseau horaire : " + bundle.config().timezone(), NamedTextColor.YELLOW));
+        lines.add(Component.text("Mode : " + bundle.config().serverMode(), NamedTextColor.YELLOW));
+
+        ExecutorPools.Diagnostics poolDiagnostics = executorPools.diagnostics();
+        lines.add(Component.empty());
+        lines.add(Component.text("-- Threads --", NamedTextColor.AQUA));
+        appendPool(lines, "IO", poolDiagnostics.io());
+        appendPool(lines, "Compute", poolDiagnostics.compute());
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        lines.add(Component.text("Threads actifs : " + threadBean.getThreadCount(), NamedTextColor.GRAY));
+        lines.add(Component.text("Pic threads : " + threadBean.getPeakThreadCount(), NamedTextColor.GRAY));
+
+        RingScheduler.Diagnostics schedulerDiagnostics = scheduler.diagnostics();
+        lines.add(Component.empty());
+        lines.add(Component.text("-- Scheduler --", NamedTextColor.AQUA));
+        lines.add(Component.text("Phase : " + schedulerDiagnostics.phase(), NamedTextColor.GRAY));
+        lines.add(Component.text("Ticks : " + schedulerDiagnostics.ticks(), NamedTextColor.GRAY));
+        lines.add(Component.text("Tâches exécutées : " + schedulerDiagnostics.executedTasks(), NamedTextColor.GRAY));
+        lines.add(Component.text("Temps moyen (µs) : " + String.format(Locale.ROOT, "%.2f", schedulerDiagnostics.averageExecutionMicros()), NamedTextColor.GRAY));
+        for (Map.Entry<String, Long> entry : schedulerDiagnostics.taskIntervals().entrySet()) {
+            lines.add(Component.text(" • " + entry.getKey() + " -> " + entry.getValue() + " ticks", NamedTextColor.DARK_GRAY));
+        }
+
+        DbProvider.Diagnostics dbDiagnostics = dbProvider.diagnostics();
+        lines.add(Component.empty());
+        lines.add(Component.text("-- Base de données --", NamedTextColor.AQUA));
+        lines.add(Component.text("Activée : " + (dbDiagnostics.settings() != null && dbDiagnostics.settings().enabled()), NamedTextColor.GRAY));
+        lines.add(Component.text("Mode dégradé : " + dbDiagnostics.degraded(), NamedTextColor.GRAY));
+        lines.add(Component.text("Connexions actives : " + dbDiagnostics.activeConnections(), NamedTextColor.GRAY));
+        lines.add(Component.text("Connexions libres : " + dbDiagnostics.idleConnections(), NamedTextColor.GRAY));
+        lines.add(Component.text("Connexions totales : " + dbDiagnostics.totalConnections(), NamedTextColor.GRAY));
+        lines.add(Component.text("Threads en attente : " + dbDiagnostics.awaitingThreads(), NamedTextColor.GRAY));
+        lines.add(Component.text("Tentatives échouées : " + dbDiagnostics.failedAttempts(), NamedTextColor.GRAY));
+
+        lines.add(Component.empty());
+        lines.add(Component.text("Chargé le : " + DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                .withZone(bundle.config().timezone())
+                .format(bundle.loadedAt()), NamedTextColor.DARK_GRAY));
+        return lines;
+    }
+
+    private static void appendPool(List<Component> lines, String name, ExecutorPools.PoolSnapshot snapshot) {
+        lines.add(Component.text(name + " -> core=" + snapshot.corePoolSize()
+                + " actifs=" + snapshot.activeCount()
+                + " file=" + snapshot.queuedTasks()
+                + " complétés=" + snapshot.completedTasks(), NamedTextColor.GRAY));
+    }
+}

--- a/src/main/java/com/heneria/nexus/util/MessageFacade.java
+++ b/src/main/java/com/heneria/nexus/util/MessageFacade.java
@@ -1,0 +1,75 @@
+package com.heneria.nexus.util;
+
+import com.heneria.nexus.config.MessageBundle;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.command.CommandSender;
+
+/**
+ * Provides MiniMessage parsing utilities with caching.
+ */
+public final class MessageFacade {
+
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final NexusLogger logger;
+    private volatile MessageBundle bundle;
+    private final Map<String, Component> cache = new ConcurrentHashMap<>();
+
+    public MessageFacade(MessageBundle bundle, NexusLogger logger) {
+        this.bundle = Objects.requireNonNull(bundle, "bundle");
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    public void update(MessageBundle bundle) {
+        this.bundle = Objects.requireNonNull(bundle, "bundle");
+        cache.clear();
+    }
+
+    public Component render(String key, TagResolver... resolvers) {
+        String template = lookup(key).orElse("<red>Message manquant: " + key + "</red>");
+        if (resolvers.length == 0) {
+            return cache.computeIfAbsent(template, this::deserialize);
+        }
+        return deserialize(template, resolvers);
+    }
+
+    public void send(CommandSender sender, String key, TagResolver... resolvers) {
+        sender.sendMessage(render(key, resolvers));
+    }
+
+    public Locale locale() {
+        return bundle.locale();
+    }
+
+    public Optional<String> lookup(String key) {
+        return bundle.message(key);
+    }
+
+    public Component raw(String rawMessage, TagResolver... resolvers) {
+        return deserialize(rawMessage, resolvers);
+    }
+
+    private Component deserialize(String template) {
+        try {
+            return miniMessage.deserialize(template);
+        } catch (Exception exception) {
+            logger.warn("MiniMessage invalide: " + template, exception);
+            return Component.text(template);
+        }
+    }
+
+    private Component deserialize(String template, TagResolver... resolvers) {
+        try {
+            return miniMessage.deserialize(template, resolvers);
+        } catch (Exception exception) {
+            logger.warn("MiniMessage invalide: " + template, exception);
+            return Component.text(template);
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/util/NamedThreadFactory.java
+++ b/src/main/java/com/heneria/nexus/util/NamedThreadFactory.java
@@ -1,0 +1,31 @@
+package com.heneria.nexus.util;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Thread factory producing clearly named threads for profiling purposes.
+ */
+public final class NamedThreadFactory implements ThreadFactory {
+
+    private final String prefix;
+    private final boolean daemon;
+    private final AtomicInteger counter = new AtomicInteger(1);
+    private final NexusLogger logger;
+
+    public NamedThreadFactory(String prefix, boolean daemon, NexusLogger logger) {
+        this.prefix = Objects.requireNonNull(prefix, "prefix");
+        this.daemon = daemon;
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        String name = prefix + "-" + counter.getAndIncrement();
+        Thread thread = Thread.ofPlatform().name(name).daemon(daemon).unstarted(runnable);
+        thread.setUncaughtExceptionHandler((t, throwable) ->
+                logger.error("Thread " + t.getName() + " terminated unexpectedly", throwable));
+        return thread;
+    }
+}

--- a/src/main/java/com/heneria/nexus/util/NexusLogger.java
+++ b/src/main/java/com/heneria/nexus/util/NexusLogger.java
@@ -1,0 +1,64 @@
+package com.heneria.nexus.util;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Simple logger wrapper adding the Nexus prefix and convenient helpers.
+ */
+public final class NexusLogger {
+
+    private final Logger delegate;
+    private final String prefix;
+
+    public NexusLogger(Logger delegate, String prefix) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.prefix = Objects.requireNonNull(prefix, "prefix");
+    }
+
+    private String format(String message) {
+        return prefix + message;
+    }
+
+    private String format(Supplier<String> supplier) {
+        return format(supplier.get());
+    }
+
+    public void info(String message) {
+        delegate.log(Level.INFO, format(message));
+    }
+
+    public void info(Supplier<String> supplier) {
+        delegate.log(Level.INFO, format(supplier));
+    }
+
+    public void warn(String message) {
+        delegate.log(Level.WARNING, format(message));
+    }
+
+    public void warn(String message, Throwable throwable) {
+        delegate.log(Level.WARNING, format(message), throwable);
+    }
+
+    public void error(String message) {
+        delegate.log(Level.SEVERE, format(message));
+    }
+
+    public void error(String message, Throwable throwable) {
+        delegate.log(Level.SEVERE, format(message), throwable);
+    }
+
+    public void debug(String message) {
+        delegate.log(Level.FINE, format(message));
+    }
+
+    public void debug(Supplier<String> supplier) {
+        delegate.log(Level.FINE, format(supplier));
+    }
+
+    public Logger unwrap() {
+        return delegate;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,62 @@
+# =============================================
+#  Configuration principale du plugin Nexus
+#  PaperMC 1.21.x — Java 21
+# =============================================
+
+server:
+  # Mode logique de ce serveur (utile pour les environnements multi-nœuds)
+  mode: "nexus"
+  # Langue des messages par défaut (BCP 47)
+  language: "fr"
+  # Fuseau horaire utilisé pour les horodatages et les dumps
+  timezone: "Europe/Paris"
+
+perf:
+  # Taux de rafraîchissement des HUD (5 Hz par défaut => toutes les 4 ticks)
+  hud_hz: 5
+  # Taux de rafraîchissement des scoreboards (3 Hz par défaut)
+  scoreboard_hz: 3
+  # Budget particules pour les effets « doux » (peut être dépassé ponctuellement)
+  particles_soft_cap: 1200
+  # Limite stricte d'émission de particules (les tâches au-delà sont coupées)
+  particles_hard_cap: 2000
+
+threads:
+  # Pool I/O pour la base de données et les accès disque. Pas d'I/O sur le main thread !
+  io_pool: 3
+  # Pool de calcul léger (préparation de données, parsings, etc.)
+  compute_pool: 1
+
+database:
+  # Active ou non la persistance MariaDB. Si désactivé, Nexus fonctionne en mode dégradé.
+  enabled: true
+  # URL JDBC MariaDB. Adapter l'hôte/port/nom de base.
+  jdbc: "jdbc:mariadb://127.0.0.1:3306/nexus"
+  # Identifiants du compte SQL dédié.
+  user: "nexus"
+  password: "change_me"
+  pool:
+    # Taille maximale du pool HikariCP (adapter à la charge attendue).
+    maxSize: 10
+    # Nombre minimal de connexions maintenues au chaud.
+    minIdle: 2
+    # Timeout de connexion en millisecondes (fail-fast conseillé < 5s).
+    connTimeoutMs: 3000
+
+# ================== PLACEHOLDERS ==================
+# Les sections suivantes seront alimentées par les tickets
+# ultérieurs (T-0xx). Elles sont laissées ici pour la lisibilité.
+
+economy:
+  # currency: "NEX"
+  # starting-balance: 1000
+  # taxes:
+  #   enabled: false
+  #   rate: 0.05
+
+maps:
+  # default-map: "vallon"
+  # rotation:
+  #   - "vallon"
+  #   - "caverne"
+  #   - "tournoi"

--- a/src/main/resources/economy.yml
+++ b/src/main/resources/economy.yml
@@ -1,0 +1,10 @@
+# =============================================
+#  Placeholder économie — sera rempli ultérieurement
+# =============================================
+
+economy:
+  # currency: "NEX"
+  # starting-balance: 1000
+  # taxes:
+  #   enabled: false
+  #   rate: 0.05

--- a/src/main/resources/maps.yml
+++ b/src/main/resources/maps.yml
@@ -1,0 +1,10 @@
+# =============================================
+#  Placeholder cartes — détails à venir
+# =============================================
+
+maps:
+  # default-map: "vallon"
+  # rotation:
+  #   - "vallon"
+  #   - "caverne"
+  #   - "tournoi"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,22 @@
+meta:
+  locale: "fr-FR"
+
+commands:
+  help:
+    header: "<gold>Commandes Nexus disponibles :</gold>"
+    help: "<gray>/nexus help</gray> <dark_gray>-</dark_gray> <yellow>Affiche cette aide.</yellow>"
+    reload: "<gray>/nexus reload</gray> <dark_gray>-</dark_gray> <yellow>Recharge les configurations et messages.</yellow>"
+    dump: "<gray>/nexus dump</gray> <dark_gray>-</dark_gray> <yellow>Affiche l'état courant (threads, DB, scheduler).</yellow>"
+  reload:
+    start: "<yellow>Rechargement en cours...</yellow>"
+    success: "<green>Configuration Nexus rechargée.</green>"
+    failure: "<red>Échec du rechargement, voir console.</red>"
+  dump:
+    header: "<gold>Dump Nexus</gold>"
+    success: "<green>Dump généré.</green>"
+  errors:
+    no-permission: "<red>Vous n'avez pas la permission requise.</red>"
+    invalid-config: "<red>La configuration contient des erreurs :</red>"
+status:
+  database:
+    degraded: "<red>Mode dégradé : persistance indisponible.</red>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,29 @@
+name: Nexus
+version: ${project.version}
+main: com.heneria.nexus.NexusPlugin
+description: Plugin noyau Nexus pour PaperMC.
+authors: [Heneria]
+api-version: '1.21'
+load: POSTWORLD
+commands:
+  nexus:
+    description: Commande principale du plugin Nexus.
+    usage: /<command> help|reload|dump
+    permission: nexus.use
+    aliases: [nx]
+permissions:
+  nexus.use:
+    description: Accéder aux commandes publiques de Nexus.
+    default: true
+  nexus.admin.reload:
+    description: Recharger la configuration Nexus.
+    default: op
+  nexus.admin.dump:
+    description: Afficher un dump d'état Nexus.
+    default: op
+  nexus.admin.*:
+    description: Accès complet aux commandes d'administration Nexus.
+    default: op
+    children:
+      nexus.admin.reload: true
+      nexus.admin.dump: true


### PR DESCRIPTION
## Summary
- bootstrap the Maven project for Paper 1.21 with shaded HikariCP and MariaDB dependencies
- add the NexusPlugin core with configuration reloads, Adventure messaging, command handling, scheduler, executors, and database provider services
- supply default YAML resources for config/messages along with utility infrastructure for dumps and service management

## Testing
- mvn -B -DskipTests package *(fails: Maven Central unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cc590629588324b40fecfe0996786f