### PR TITLE
feat: introduce managed service registry and core services

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -3,24 +3,39 @@ package com.heneria.nexus;
 import com.heneria.nexus.command.NexusCommand;
 import com.heneria.nexus.config.ConfigBundle;
 import com.heneria.nexus.config.ConfigManager;
+import com.heneria.nexus.config.NexusConfig;
 import com.heneria.nexus.db.DbProvider;
 import com.heneria.nexus.scheduler.GamePhase;
 import com.heneria.nexus.scheduler.RingScheduler;
 import com.heneria.nexus.scheduler.RingScheduler.TaskProfile;
 import com.heneria.nexus.service.ExecutorPools;
 import com.heneria.nexus.service.ServiceRegistry;
+import com.heneria.nexus.service.api.ArenaService;
+import com.heneria.nexus.service.api.EconomyService;
+import com.heneria.nexus.service.api.MapService;
+import com.heneria.nexus.service.api.ProfileService;
+import com.heneria.nexus.service.api.QueueService;
+import com.heneria.nexus.service.core.ArenaServiceImpl;
+import com.heneria.nexus.service.core.EconomyServiceImpl;
+import com.heneria.nexus.service.core.MapServiceImpl;
+import com.heneria.nexus.service.core.ProfileServiceImpl;
+import com.heneria.nexus.service.core.QueueServiceImpl;
 import com.heneria.nexus.util.DumpUtil;
 import com.heneria.nexus.util.MessageFacade;
 import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.ServicePriority;
+import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -38,50 +53,73 @@ public final class NexusPlugin extends JavaPlugin {
     private ExecutorPools executorPools;
     private RingScheduler ringScheduler;
     private DbProvider dbProvider;
+    private boolean bootstrapFailed;
+    private boolean servicesExposed;
 
     @Override
     public void onLoad() {
-        this.logger = new NexusLogger(getLogger(), LOG_PREFIX);
-        this.serviceRegistry = new ServiceRegistry(logger);
-    }
-
-    @Override
-    public void onEnable() {
         this.logger = new NexusLogger(getLogger(), LOG_PREFIX);
         this.configManager = new ConfigManager(this, logger);
         ConfigManager.LoadResult loadResult = configManager.initialLoad();
         if (!loadResult.success()) {
             loadResult.errors().forEach(error -> logger.error("Erreur de configuration: " + error));
-            getServer().getPluginManager().disablePlugin(this);
+            bootstrapFailed = true;
             return;
         }
         this.bundle = loadResult.bundle();
         this.messageFacade = new MessageFacade(bundle.messages(), logger);
         this.executorPools = new ExecutorPools(logger, bundle.config().threadSettings());
-        this.ringScheduler = new RingScheduler(this, logger);
-        this.ringScheduler.applyPerfSettings(bundle.config().perfSettings());
-        this.ringScheduler.registerProfile(TaskProfile.HUD,
-                EnumSet.of(GamePhase.LOBBY, GamePhase.STARTING, GamePhase.PLAYING),
-                () -> {
-                });
-        this.ringScheduler.registerProfile(TaskProfile.SCOREBOARD,
-                EnumSet.of(GamePhase.STARTING, GamePhase.PLAYING, GamePhase.RESET),
-                () -> {
-                });
-        this.dbProvider = new DbProvider(logger);
+        this.serviceRegistry = new ServiceRegistry(logger);
+        registerSingletons();
+        registerServices();
+        try {
+            serviceRegistry.wire(Duration.ofMillis(bundle.config().timeoutSettings().startMs()));
+            this.ringScheduler = serviceRegistry.get(RingScheduler.class);
+            this.dbProvider = serviceRegistry.get(DbProvider.class);
+            ringScheduler.applyPerfSettings(bundle.config().arenaSettings());
+        } catch (Exception exception) {
+            logger.error("Impossible d'initialiser le registre de services", exception);
+            bootstrapFailed = true;
+        }
+    }
 
-        serviceRegistry.register(RingScheduler.class, ringScheduler);
-        serviceRegistry.register(DbProvider.class, dbProvider);
-
+    @Override
+    public void onEnable() {
+        if (bootstrapFailed) {
+            logger.error("Initialisation de Nexus impossible, désactivation");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        this.logger = new NexusLogger(getLogger(), LOG_PREFIX);
+        this.messageFacade.update(bundle.messages());
         registerCommands();
         logEnvironment();
         configureDatabase(bundle.config().databaseSettings());
+        try {
+            serviceRegistry.startAll(Duration.ofMillis(bundle.config().timeoutSettings().startMs()));
+            ringScheduler.registerProfile(TaskProfile.HUD,
+                    EnumSet.of(GamePhase.LOBBY, GamePhase.STARTING, GamePhase.PLAYING),
+                    () -> {
+                    });
+            ringScheduler.registerProfile(TaskProfile.SCOREBOARD,
+                    EnumSet.of(GamePhase.STARTING, GamePhase.PLAYING, GamePhase.RESET),
+                    () -> {
+                    });
+            maybeExposeServices();
+        } catch (Exception exception) {
+            logger.error("Démarrage des services impossible", exception);
+            getServer().getPluginManager().disablePlugin(this);
+        }
     }
 
     @Override
     public void onDisable() {
+        if (servicesExposed) {
+            getServer().getServicesManager().unregisterAll(this);
+            servicesExposed = false;
+        }
         if (serviceRegistry != null) {
-            serviceRegistry.shutdown().join();
+            serviceRegistry.stopAll(Duration.ofMillis(bundle != null ? bundle.config().timeoutSettings().stopMs() : 3000L));
         }
         if (executorPools != null) {
             executorPools.close();
@@ -89,14 +127,17 @@ public final class NexusPlugin extends JavaPlugin {
         logger.info("Nexus désactivé proprement");
     }
 
-    private void configureDatabase(com.heneria.nexus.config.NexusConfig.DatabaseSettings settings) {
+    private void configureDatabase(NexusConfig.DatabaseSettings settings) {
         ExecutorService ioExecutor = executorPools.ioExecutor();
         CompletableFuture<Boolean> future = dbProvider.applyConfiguration(settings, ioExecutor);
-        future.thenAccept(success -> {
-            if (!success) {
+        try {
+            boolean success = future.orTimeout(bundle.config().timeoutSettings().startMs(), TimeUnit.MILLISECONDS).join();
+            if (!success && bundle.config().degradedModeSettings().enabled()) {
                 logger.warn("Mode dégradé activé : MariaDB indisponible");
             }
-        });
+        } catch (Exception exception) {
+            logger.warn("Configuration MariaDB impossible", exception);
+        }
     }
 
     private void registerCommands() {
@@ -112,8 +153,9 @@ public final class NexusPlugin extends JavaPlugin {
         logger.info("Paper: %s".formatted(getServer().getVersion()));
         logger.info("Fuseau horaire: %s".formatted(bundle.config().timezone()));
         logger.info("HUD: %d Hz, scoreboard: %d Hz".formatted(
-                bundle.config().perfSettings().hudHz(),
-                bundle.config().perfSettings().scoreboardHz()));
+                bundle.config().arenaSettings().hudHz(),
+                bundle.config().arenaSettings().scoreboardHz()));
+        logger.info("Matchmaking: %d Hz".formatted(bundle.config().queueSettings().tickHz()));
         logger.info("Threads: io=%d compute=%d".formatted(
                 bundle.config().threadSettings().ioPool(),
                 bundle.config().threadSettings().computePool()));
@@ -156,11 +198,23 @@ public final class NexusPlugin extends JavaPlugin {
 
     private synchronized void applyBundle(ConfigBundle newBundle) {
         executorPools.reconfigure(newBundle.config().threadSettings());
-        ringScheduler.applyPerfSettings(newBundle.config().perfSettings());
+        ringScheduler.applyPerfSettings(newBundle.config().arenaSettings());
         messageFacade.update(newBundle.messages());
         this.bundle = newBundle;
         configManager.applyBundle(newBundle);
+        serviceRegistry.updateSingleton(ConfigBundle.class, newBundle);
+        serviceRegistry.updateSingleton(NexusConfig.class, newBundle.config());
         configureDatabase(newBundle.config().databaseSettings());
+        serviceRegistry.get(QueueService.class).applySettings(newBundle.config().queueSettings());
+        serviceRegistry.get(ArenaService.class).applyArenaSettings(newBundle.config().arenaSettings());
+        serviceRegistry.get(ProfileService.class).applyDegradedModeSettings(newBundle.config().degradedModeSettings());
+        serviceRegistry.get(EconomyService.class).applyDegradedModeSettings(newBundle.config().degradedModeSettings());
+        if (servicesExposed && !newBundle.config().serviceSettings().exposeBukkitServices()) {
+            getServer().getServicesManager().unregisterAll(this);
+            servicesExposed = false;
+        } else if (!servicesExposed && newBundle.config().serviceSettings().exposeBukkitServices()) {
+            maybeExposeServices();
+        }
     }
 
     public void handleDump(CommandSender sender) {
@@ -169,7 +223,7 @@ public final class NexusPlugin extends JavaPlugin {
             return;
         }
         messageFacade.send(sender, "commands.dump.header");
-        List<Component> lines = DumpUtil.createDump(getServer(), bundle, executorPools, ringScheduler, dbProvider);
+        List<Component> lines = DumpUtil.createDump(getServer(), bundle, executorPools, ringScheduler, dbProvider, serviceRegistry);
         lines.forEach(sender::sendMessage);
         messageFacade.send(sender, "commands.dump.success");
     }
@@ -180,5 +234,38 @@ public final class NexusPlugin extends JavaPlugin {
 
     public ConfigBundle bundle() {
         return bundle;
+    }
+
+    private void registerSingletons() {
+        serviceRegistry.registerSingleton(JavaPlugin.class, this);
+        serviceRegistry.registerSingleton(NexusPlugin.class, this);
+        serviceRegistry.registerSingleton(NexusLogger.class, logger);
+        serviceRegistry.registerSingleton(ConfigManager.class, configManager);
+        serviceRegistry.registerSingleton(ConfigBundle.class, bundle);
+        serviceRegistry.registerSingleton(NexusConfig.class, bundle.config());
+        serviceRegistry.registerSingleton(ExecutorPools.class, executorPools);
+    }
+
+    private void registerServices() {
+        serviceRegistry.registerService(DbProvider.class, DbProvider.class);
+        serviceRegistry.registerService(RingScheduler.class, RingScheduler.class);
+        serviceRegistry.registerService(MapService.class, MapServiceImpl.class);
+        serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
+        serviceRegistry.registerService(EconomyService.class, EconomyServiceImpl.class);
+        serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);
+        serviceRegistry.registerService(ArenaService.class, ArenaServiceImpl.class);
+    }
+
+    private void maybeExposeServices() {
+        if (!bundle.config().serviceSettings().exposeBukkitServices()) {
+            return;
+        }
+        ServicesManager servicesManager = getServer().getServicesManager();
+        servicesManager.register(ArenaService.class, serviceRegistry.get(ArenaService.class), this, ServicePriority.Normal);
+        servicesManager.register(MapService.class, serviceRegistry.get(MapService.class), this, ServicePriority.Normal);
+        servicesManager.register(QueueService.class, serviceRegistry.get(QueueService.class), this, ServicePriority.Normal);
+        servicesManager.register(EconomyService.class, serviceRegistry.get(EconomyService.class), this, ServicePriority.Normal);
+        servicesManager.register(ProfileService.class, serviceRegistry.get(ProfileService.class), this, ServicePriority.Normal);
+        servicesExposed = true;
     }
 }

--- a/src/main/java/com/heneria/nexus/config/NexusConfig.java
+++ b/src/main/java/com/heneria/nexus/config/NexusConfig.java
@@ -12,22 +12,34 @@ public final class NexusConfig {
     private final String serverMode;
     private final Locale language;
     private final ZoneId timezone;
-    private final PerfSettings perfSettings;
+    private final ArenaSettings arenaSettings;
     private final ThreadSettings threadSettings;
     private final DatabaseSettings databaseSettings;
+    private final ServiceSettings serviceSettings;
+    private final TimeoutSettings timeoutSettings;
+    private final DegradedModeSettings degradedModeSettings;
+    private final QueueSettings queueSettings;
 
     public NexusConfig(String serverMode,
                        Locale language,
                        ZoneId timezone,
-                       PerfSettings perfSettings,
+                       ArenaSettings arenaSettings,
                        ThreadSettings threadSettings,
-                       DatabaseSettings databaseSettings) {
+                       DatabaseSettings databaseSettings,
+                       ServiceSettings serviceSettings,
+                       TimeoutSettings timeoutSettings,
+                       DegradedModeSettings degradedModeSettings,
+                       QueueSettings queueSettings) {
         this.serverMode = Objects.requireNonNull(serverMode, "serverMode");
         this.language = Objects.requireNonNull(language, "language");
         this.timezone = Objects.requireNonNull(timezone, "timezone");
-        this.perfSettings = Objects.requireNonNull(perfSettings, "perfSettings");
+        this.arenaSettings = Objects.requireNonNull(arenaSettings, "arenaSettings");
         this.threadSettings = Objects.requireNonNull(threadSettings, "threadSettings");
         this.databaseSettings = Objects.requireNonNull(databaseSettings, "databaseSettings");
+        this.serviceSettings = Objects.requireNonNull(serviceSettings, "serviceSettings");
+        this.timeoutSettings = Objects.requireNonNull(timeoutSettings, "timeoutSettings");
+        this.degradedModeSettings = Objects.requireNonNull(degradedModeSettings, "degradedModeSettings");
+        this.queueSettings = Objects.requireNonNull(queueSettings, "queueSettings");
     }
 
     public String serverMode() {
@@ -42,8 +54,8 @@ public final class NexusConfig {
         return timezone;
     }
 
-    public PerfSettings perfSettings() {
-        return perfSettings;
+    public ArenaSettings arenaSettings() {
+        return arenaSettings;
     }
 
     public ThreadSettings threadSettings() {
@@ -54,8 +66,25 @@ public final class NexusConfig {
         return databaseSettings;
     }
 
-    public record PerfSettings(int hudHz, int scoreboardHz, int particlesSoftCap, int particlesHardCap) {
-        public PerfSettings {
+    public ServiceSettings serviceSettings() {
+        return serviceSettings;
+    }
+
+    public TimeoutSettings timeoutSettings() {
+        return timeoutSettings;
+    }
+
+    public DegradedModeSettings degradedModeSettings() {
+        return degradedModeSettings;
+    }
+
+    public QueueSettings queueSettings() {
+        return queueSettings;
+    }
+
+    public record ArenaSettings(int hudHz, int scoreboardHz, int particlesSoftCap, int particlesHardCap,
+                                int maxEntities, int maxItems, int maxProjectiles) {
+        public ArenaSettings {
             if (hudHz <= 0) {
                 throw new IllegalArgumentException("hudHz must be positive");
             }
@@ -67,6 +96,9 @@ public final class NexusConfig {
             }
             if (particlesHardCap < particlesSoftCap) {
                 throw new IllegalArgumentException("particlesHardCap must be >= particlesSoftCap");
+            }
+            if (maxEntities < 0 || maxItems < 0 || maxProjectiles < 0) {
+                throw new IllegalArgumentException("budgets must be >= 0");
             }
         }
     }
@@ -101,6 +133,34 @@ public final class NexusConfig {
             }
             if (connectionTimeoutMs <= 0) {
                 throw new IllegalArgumentException("connectionTimeoutMs must be positive");
+            }
+        }
+    }
+
+    public record ServiceSettings(boolean exposeBukkitServices) {
+    }
+
+    public record TimeoutSettings(long startMs, long stopMs) {
+        public TimeoutSettings {
+            if (startMs <= 0L) {
+                throw new IllegalArgumentException("startMs must be positive");
+            }
+            if (stopMs <= 0L) {
+                throw new IllegalArgumentException("stopMs must be positive");
+            }
+        }
+    }
+
+    public record DegradedModeSettings(boolean enabled, boolean banner) {
+    }
+
+    public record QueueSettings(int tickHz, int vipWeight) {
+        public QueueSettings {
+            if (tickHz <= 0) {
+                throw new IllegalArgumentException("tickHz must be > 0");
+            }
+            if (vipWeight < 0) {
+                throw new IllegalArgumentException("vipWeight must be >= 0");
             }
         }
     }

--- a/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
+++ b/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
@@ -50,9 +50,9 @@ public final class RingScheduler implements LifecycleAware {
         profileIntervals.put(TaskProfile.SCOREBOARD, 7L);
     }
 
-    public void applyPerfSettings(NexusConfig.PerfSettings perfSettings) {
-        profileIntervals.put(TaskProfile.HUD, hzToTicks(perfSettings.hudHz()));
-        profileIntervals.put(TaskProfile.SCOREBOARD, hzToTicks(perfSettings.scoreboardHz()));
+    public void applyPerfSettings(NexusConfig.ArenaSettings arenaSettings) {
+        profileIntervals.put(TaskProfile.HUD, hzToTicks(arenaSettings.hudHz()));
+        profileIntervals.put(TaskProfile.SCOREBOARD, hzToTicks(arenaSettings.scoreboardHz()));
         tasks.values().forEach(task -> {
             if (task.id().startsWith("profile-")) {
                 TaskProfile profile = TaskProfile.valueOf(task.id().substring("profile-".length()).toUpperCase());

--- a/src/main/java/com/heneria/nexus/service/LifecycleAware.java
+++ b/src/main/java/com/heneria/nexus/service/LifecycleAware.java
@@ -1,5 +1,6 @@
 package com.heneria.nexus.service;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -7,11 +8,23 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface LifecycleAware {
 
+    default CompletableFuture<Void> initialize() {
+        return CompletableFuture.completedFuture(null);
+    }
+
     default CompletableFuture<Void> start() {
         return CompletableFuture.completedFuture(null);
     }
 
     default CompletableFuture<Void> stop() {
         return CompletableFuture.completedFuture(null);
+    }
+
+    default boolean isHealthy() {
+        return lastError().isEmpty();
+    }
+
+    default Optional<Throwable> lastError() {
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/heneria/nexus/service/ServiceLifecycle.java
+++ b/src/main/java/com/heneria/nexus/service/ServiceLifecycle.java
@@ -1,0 +1,15 @@
+package com.heneria.nexus.service;
+
+/**
+ * Lifecycle states exposed for diagnostics.
+ */
+public enum ServiceLifecycle {
+    NEW,
+    INITIALIZING,
+    INITIALIZED,
+    STARTING,
+    STARTED,
+    STOPPING,
+    STOPPED,
+    FAILED
+}

--- a/src/main/java/com/heneria/nexus/service/ServiceRegistry.java
+++ b/src/main/java/com/heneria/nexus/service/ServiceRegistry.java
@@ -1,60 +1,586 @@
 package com.heneria.nexus.service;
 
 import com.heneria.nexus.util.NexusLogger;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Simple registry able to manage service lifecycles.
+ * Lightweight service registry used to bootstrap the plugin without relying on
+ * external dependency injection frameworks.
  */
 public final class ServiceRegistry {
 
-    private final Map<Class<?>, Object> services = new ConcurrentHashMap<>();
     private final NexusLogger logger;
+    private final Map<Class<?>, Object> singletons = new ConcurrentHashMap<>();
+    private final Map<Class<?>, ServiceDefinition<?>> definitions = new LinkedHashMap<>();
+    private final Map<Class<?>, ServiceHolder<?>> holders = new LinkedHashMap<>();
+    private List<ServiceHolder<?>> startOrder = List.of();
+    private boolean wired;
+    private boolean started;
 
     public ServiceRegistry(NexusLogger logger) {
         this.logger = Objects.requireNonNull(logger, "logger");
     }
 
-    public <T> void register(Class<T> type, T instance) {
+    /**
+     * Registers an already constructed singleton object to the registry.
+     *
+     * <p>Singletons are available for constructor injection and lookups but are
+     * not managed by the service lifecycle.</p>
+     */
+    public synchronized <T> void registerSingleton(Class<T> type, T instance) {
         Objects.requireNonNull(type, "type");
         Objects.requireNonNull(instance, "instance");
-        services.put(type, instance);
-        if (instance instanceof LifecycleAware lifecycleAware) {
-            lifecycleAware.start().exceptionally(throwable -> {
-                logger.error("Erreur lors du démarrage du service " + type.getSimpleName(), throwable);
-                return null;
-            });
+        ensureNotRegistered(type);
+        singletons.put(type, instance);
+    }
+
+    /**
+     * Replaces a singleton value previously registered.
+     */
+    public synchronized <T> void updateSingleton(Class<T> type, T instance) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(instance, "instance");
+        if (!singletons.containsKey(type)) {
+            throw new IllegalStateException("No singleton registered for " + type.getName());
+        }
+        singletons.put(type, instance);
+    }
+
+    /**
+     * Registers a service implementation. The registry will use constructor
+     * injection to resolve dependencies and will manage the lifecycle hooks of
+     * the created instance.
+     */
+    public synchronized <T> void registerService(Class<T> serviceType, Class<? extends T> implementationType) {
+        Objects.requireNonNull(serviceType, "serviceType");
+        Objects.requireNonNull(implementationType, "implementationType");
+        if (!serviceType.isAssignableFrom(implementationType)) {
+            throw new IllegalArgumentException(implementationType.getName()
+                    + " n'implémente pas " + serviceType.getName());
+        }
+        ensureNotRegistered(serviceType);
+        ServiceDefinition<T> definition = ServiceDefinition.create(serviceType, implementationType);
+        definitions.put(serviceType, definition);
+        holders.put(serviceType, new ServiceHolder<>(definition));
+    }
+
+    private void ensureNotRegistered(Class<?> type) {
+        if (singletons.containsKey(type) || definitions.containsKey(type)) {
+            throw new IllegalStateException("A provider is already registered for " + type.getName());
         }
     }
 
-    public <T> Optional<T> get(Class<T> type) {
+    /**
+     * Wires the registry by resolving the dependency graph and invoking the
+     * {@link LifecycleAware#initialize()} hook on each managed service.
+     */
+    public synchronized void wire(Duration initializationTimeout) {
+        Objects.requireNonNull(initializationTimeout, "initializationTimeout");
+        if (wired) {
+            return;
+        }
+        detectMissingDependencies();
+        List<ServiceHolder<?>> order = computeTopologicalOrder();
+        Deque<Class<?>> stack = new ArrayDeque<>();
+        for (ServiceHolder<?> holder : order) {
+            holder.ensureInitialized(this, stack, initializationTimeout);
+        }
+        this.startOrder = List.copyOf(order);
+        this.wired = true;
+        logInitializationReport();
+    }
+
+    /**
+     * Starts all managed services in topological order.
+     */
+    public synchronized void startAll(Duration timeout) {
+        Objects.requireNonNull(timeout, "timeout");
+        if (!wired) {
+            throw new IllegalStateException("Registry not wired yet");
+        }
+        if (started) {
+            return;
+        }
+        List<ServiceHolder<?>> startedHolders = new ArrayList<>();
+        for (ServiceHolder<?> holder : startOrder) {
+            try {
+                holder.start(timeout);
+                startedHolders.add(holder);
+            } catch (ServiceRegistryException exception) {
+                Throwable cause = exception.getCause() != null ? exception.getCause() : exception;
+                logger.error("Échec du démarrage du service " + holder.definition.serviceType().getSimpleName(), cause);
+                holder.markFailed(cause);
+                startedHolders.reversed().forEach(other -> safeStop(other, timeout));
+                throw exception;
+            }
+        }
+        this.started = true;
+    }
+
+    /**
+     * Stops all managed services in reverse topological order.
+     */
+    public synchronized void stopAll(Duration timeout) {
+        Objects.requireNonNull(timeout, "timeout");
+        if (!wired) {
+            return;
+        }
+        startOrder.reversed().forEach(holder -> safeStop(holder, timeout));
+        started = false;
+    }
+
+    private void safeStop(ServiceHolder<?> holder, Duration timeout) {
+        try {
+            holder.stop(timeout);
+        } catch (ServiceRegistryException exception) {
+            Throwable cause = exception.getCause() != null ? exception.getCause() : exception;
+            logger.error("Erreur lors de l'arrêt du service " + holder.definition.serviceType().getSimpleName(), cause);
+        }
+    }
+
+    /**
+     * Retrieves a managed service or singleton registered for the given type.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(Class<T> type) {
         Objects.requireNonNull(type, "type");
-        return Optional.ofNullable(type.cast(services.get(type)));
+        Object singleton = singletons.get(type);
+        if (singleton != null) {
+            return (T) singleton;
+        }
+        ServiceHolder<?> holder = holders.get(type);
+        if (holder == null) {
+            throw new IllegalStateException("No service registered for " + type.getName());
+        }
+        return (T) holder.instance;
     }
 
-    public Map<Class<?>, Object> services() {
-        return Collections.unmodifiableMap(services);
+    /**
+     * Returns an optional view over a managed service or singleton.
+     */
+    public <T> Optional<T> find(Class<T> type) {
+        Objects.requireNonNull(type, "type");
+        if (singletons.containsKey(type)) {
+            return Optional.of(type.cast(singletons.get(type)));
+        }
+        ServiceHolder<?> holder = holders.get(type);
+        if (holder == null || holder.instance == null) {
+            return Optional.empty();
+        }
+        return Optional.of(type.cast(holder.instance));
     }
 
-    public CompletableFuture<Void> shutdown() {
-        CompletableFuture<?>[] futures = services.entrySet().stream()
-                .map(entry -> {
-                    Object instance = entry.getValue();
-                    if (instance instanceof LifecycleAware lifecycleAware) {
-                        return lifecycleAware.stop().exceptionally(throwable -> {
-                            logger.error("Erreur lors de l'arrêt du service " + entry.getKey().getSimpleName(), throwable);
-                            return null;
-                        });
+    /**
+     * Returns immutable diagnostics for every registered service.
+     */
+    public Collection<ServiceStateSnapshot> snapshot() {
+        List<ServiceStateSnapshot> states = new ArrayList<>();
+        holders.values().forEach(holder -> states.add(holder.snapshot()));
+        return Collections.unmodifiableList(states);
+    }
+
+    private void detectMissingDependencies() {
+        for (ServiceDefinition<?> definition : definitions.values()) {
+            for (Dependency dependency : definition.dependencies()) {
+                if (dependency.type() == ServiceRegistry.class) {
+                    continue;
+                }
+                if (dependency.optional()) {
+                    continue;
+                }
+                if (!definitions.containsKey(dependency.type()) && !singletons.containsKey(dependency.type())) {
+                    throw new IllegalStateException("Unsatisfied dependency " + dependency.type().getName()
+                            + " for service " + definition.serviceType().getName());
+                }
+            }
+        }
+    }
+
+    private List<ServiceHolder<?>> computeTopologicalOrder() {
+        Map<Class<?>, VisitState> visitStates = new LinkedHashMap<>();
+        List<ServiceHolder<?>> order = new ArrayList<>();
+        for (Class<?> type : definitions.keySet()) {
+            dfs(type, visitStates, order, new ArrayDeque<>());
+        }
+        return order;
+    }
+
+    private void dfs(Class<?> type,
+                     Map<Class<?>, VisitState> visitStates,
+                     List<ServiceHolder<?>> order,
+                     Deque<Class<?>> stack) {
+        VisitState state = visitStates.get(type);
+        if (state == VisitState.PERMANENT) {
+            return;
+        }
+        if (state == VisitState.TEMPORARY) {
+            stack.addLast(type);
+            throw new ServiceRegistryException("Cycle détecté: " + cycleToString(stack));
+        }
+        visitStates.put(type, VisitState.TEMPORARY);
+        stack.addLast(type);
+        ServiceDefinition<?> definition = definitions.get(type);
+        for (Dependency dependency : definition.dependencies()) {
+            Class<?> dependencyType = dependency.type();
+            if (!definitions.containsKey(dependencyType)) {
+                continue;
+            }
+            dfs(dependencyType, visitStates, order, stack);
+        }
+        stack.removeLast();
+        visitStates.put(type, VisitState.PERMANENT);
+        order.add(holders.get(type));
+    }
+
+    private String cycleToString(Deque<Class<?>> stack) {
+        return stack.stream().map(Class::getSimpleName).reduce((left, right) -> left + " -> " + right).orElse("<cycle>");
+    }
+
+    private void logInitializationReport() {
+        logger.info("=== Services enregistrés ===");
+        String header = String.format(Locale.ROOT, "%-22s | %-30s | Dépendances", "Service", "Implémentation");
+        logger.info(header);
+        logger.info("-".repeat(header.length()));
+        for (ServiceHolder<?> holder : startOrder) {
+            ServiceDefinition<?> definition = holder.definition;
+            String deps = definition.dependencies().isEmpty()
+                    ? "—"
+                    : definition.dependencies().stream()
+                            .filter(dep -> dep.type() != ServiceRegistry.class)
+                            .map(dep -> dep.type().getSimpleName() + (dep.optional() ? "?" : ""))
+                            .reduce((left, right) -> left + ", " + right)
+                            .orElse("—");
+            logger.info(String.format(Locale.ROOT,
+                    "%-22s | %-30s | %s",
+                    definition.serviceType().getSimpleName(),
+                    definition.implementationType().getSimpleName(),
+                    deps));
+        }
+    }
+
+    private Object resolveDependency(Dependency dependency, Deque<Class<?>> stack, Duration timeout) {
+        Class<?> type = dependency.type();
+        if (type == ServiceRegistry.class) {
+            return this;
+        }
+        if (singletons.containsKey(type)) {
+            return singletons.get(type);
+        }
+        ServiceHolder<?> holder = holders.get(type);
+        if (holder != null) {
+            if (stack.contains(type)) {
+                stack.addLast(type);
+                throw new ServiceRegistryException("Cycle détecté: " + cycleToString(stack));
+            }
+            stack.addLast(type);
+            Object value = holder.ensureInitialized(this, stack, timeout);
+            stack.removeLast();
+            return value;
+        }
+        if (dependency.optional()) {
+            return null;
+        }
+        throw new ServiceRegistryException("Aucun fournisseur disponible pour " + type.getName());
+    }
+
+    private enum VisitState {
+        TEMPORARY,
+        PERMANENT
+    }
+
+    private static final class ServiceDefinition<T> {
+
+        private final Class<T> serviceType;
+        private final Class<? extends T> implementationType;
+        private final Constructor<? extends T> constructor;
+        private final List<Dependency> dependencies;
+
+        private ServiceDefinition(Class<T> serviceType,
+                                  Class<? extends T> implementationType,
+                                  Constructor<? extends T> constructor,
+                                  List<Dependency> dependencies) {
+            this.serviceType = serviceType;
+            this.implementationType = implementationType;
+            this.constructor = constructor;
+            this.dependencies = dependencies;
+        }
+
+        static <T> ServiceDefinition<T> create(Class<T> serviceType, Class<? extends T> implementationType) {
+            Constructor<? extends T> constructor = selectConstructor(implementationType);
+            List<Dependency> dependencies = analyseDependencies(constructor);
+            return new ServiceDefinition<>(serviceType, implementationType, constructor, dependencies);
+        }
+
+        private static <T> Constructor<? extends T> selectConstructor(Class<? extends T> implementation) {
+            Constructor<?>[] constructors = implementation.getDeclaredConstructors();
+            if (constructors.length != 1) {
+                throw new IllegalArgumentException("Implementation " + implementation.getName()
+                        + " must declare exactly one constructor for injection");
+            }
+            Constructor<? extends T> constructor = (Constructor<? extends T>) constructors[0];
+            if (!constructor.canAccess(null)) {
+                constructor.setAccessible(true);
+            }
+            return constructor;
+        }
+
+        private static List<Dependency> analyseDependencies(Constructor<?> constructor) {
+            List<Dependency> dependencies = new ArrayList<>();
+            for (Parameter parameter : constructor.getParameters()) {
+                dependencies.add(toDependency(parameter));
+            }
+            return dependencies;
+        }
+
+        private static Dependency toDependency(Parameter parameter) {
+            Class<?> rawType = parameter.getType();
+            if (Optional.class.equals(rawType)) {
+                Type parameterized = parameter.getParameterizedType();
+                if (!(parameterized instanceof ParameterizedType parameterizedType)) {
+                    throw new IllegalArgumentException("Optional dependency without type information for "
+                            + parameter.getDeclaringExecutable());
+                }
+                Type actualType = parameterizedType.getActualTypeArguments()[0];
+                if (!(actualType instanceof Class<?> dependencyType)) {
+                    throw new IllegalArgumentException("Unsupported optional dependency type " + actualType);
+                }
+                return new Dependency(dependencyType, true);
+            }
+            return new Dependency(rawType, false);
+        }
+
+        Class<T> serviceType() {
+            return serviceType;
+        }
+
+        Class<? extends T> implementationType() {
+            return implementationType;
+        }
+
+        Constructor<? extends T> constructor() {
+            return constructor;
+        }
+
+        List<Dependency> dependencies() {
+            return dependencies;
+        }
+    }
+
+    private static final class Dependency {
+        private final Class<?> type;
+        private final boolean optional;
+
+        private Dependency(Class<?> type, boolean optional) {
+            this.type = type;
+            this.optional = optional;
+        }
+
+        Class<?> type() {
+            return type;
+        }
+
+        boolean optional() {
+            return optional;
+        }
+    }
+
+    private final class ServiceHolder<T> {
+
+        private final ServiceDefinition<T> definition;
+        private volatile T instance;
+        private volatile ServiceLifecycle lifecycle = ServiceLifecycle.NEW;
+        private volatile Throwable lastError;
+        private volatile boolean healthy = true;
+        private Duration initializationDuration = Duration.ZERO;
+        private Duration startDuration = Duration.ZERO;
+        private Duration stopDuration = Duration.ZERO;
+
+        private ServiceHolder(ServiceDefinition<T> definition) {
+            this.definition = definition;
+        }
+
+        T ensureInitialized(ServiceRegistry registry, Deque<Class<?>> stack, Duration timeout) {
+            if (instance != null) {
+                return instance;
+            }
+            synchronized (this) {
+                if (instance != null) {
+                    return instance;
+                }
+                if (lifecycle == ServiceLifecycle.INITIALIZING) {
+                    stack.addLast(definition.serviceType());
+                    throw new ServiceRegistryException("Cycle détecté: " + cycleToString(stack));
+                }
+                lifecycle = ServiceLifecycle.INITIALIZING;
+                long startTime = System.nanoTime();
+                try {
+                    Object[] args = new Object[definition.dependencies().size()];
+                    for (int index = 0; index < definition.dependencies().size(); index++) {
+                        Dependency dependency = definition.dependencies().get(index);
+                        Object resolved = resolveDependency(dependency, stack, timeout);
+                        args[index] = dependency.optional() ? Optional.ofNullable(resolved) : Objects.requireNonNull(resolved);
                     }
-                    return CompletableFuture.completedFuture(null);
-                })
-                .toArray(CompletableFuture[]::new);
-        services.clear();
-        return CompletableFuture.allOf(futures);
+                    T created = instantiate(args);
+                    instance = created;
+                    invokeInitialize(timeout);
+                    initializationDuration = Duration.ofNanos(System.nanoTime() - startTime);
+                    lifecycle = ServiceLifecycle.INITIALIZED;
+                    updateHealth();
+                    return created;
+                } catch (ServiceRegistryException exception) {
+                    lifecycle = ServiceLifecycle.FAILED;
+                    lastError = exception.getCause();
+                    throw exception;
+                } catch (Throwable throwable) {
+                    lifecycle = ServiceLifecycle.FAILED;
+                    lastError = throwable;
+                    throw new ServiceRegistryException("Impossible d'initialiser " + definition.serviceType().getSimpleName(), throwable);
+                }
+            }
+        }
+
+        private T instantiate(Object[] args) throws ReflectiveOperationException {
+            Constructor<? extends T> constructor = definition.constructor();
+            return constructor.newInstance(args);
+        }
+
+        private void invokeInitialize(Duration timeout) {
+            if (!(instance instanceof LifecycleAware lifecycleAware)) {
+                return;
+            }
+            CompletableFuture<Void> future = lifecycleAware.initialize();
+            await("initialize", timeout, future);
+        }
+
+        void start(Duration timeout) {
+            ensureInitialized(ServiceRegistry.this, new ArrayDeque<>(), timeout);
+            if (!(instance instanceof LifecycleAware lifecycleAware)) {
+                lifecycle = ServiceLifecycle.STARTED;
+                return;
+            }
+            synchronized (this) {
+                if (lifecycle == ServiceLifecycle.STARTED) {
+                    return;
+                }
+                lifecycle = ServiceLifecycle.STARTING;
+                long startTime = System.nanoTime();
+                try {
+                    CompletableFuture<Void> future = lifecycleAware.start();
+                    await("start", timeout, future);
+                    startDuration = Duration.ofNanos(System.nanoTime() - startTime);
+                    lifecycle = ServiceLifecycle.STARTED;
+                    updateHealth();
+                } catch (ServiceRegistryException exception) {
+                    lifecycle = ServiceLifecycle.FAILED;
+                    lastError = exception.getCause();
+                    throw exception;
+                } catch (Throwable throwable) {
+                    lifecycle = ServiceLifecycle.FAILED;
+                    lastError = throwable;
+                    throw new ServiceRegistryException("Erreur lors du démarrage de "
+                            + definition.serviceType().getSimpleName(), throwable);
+                }
+            }
+        }
+
+        void stop(Duration timeout) {
+            if (!(instance instanceof LifecycleAware lifecycleAware)) {
+                lifecycle = ServiceLifecycle.STOPPED;
+                return;
+            }
+            synchronized (this) {
+                if (lifecycle == ServiceLifecycle.STOPPED || lifecycle == ServiceLifecycle.NEW) {
+                    return;
+                }
+                lifecycle = ServiceLifecycle.STOPPING;
+                long startTime = System.nanoTime();
+                try {
+                    CompletableFuture<Void> future = lifecycleAware.stop();
+                    await("stop", timeout, future);
+                    stopDuration = Duration.ofNanos(System.nanoTime() - startTime);
+                    lifecycle = ServiceLifecycle.STOPPED;
+                } catch (ServiceRegistryException exception) {
+                    lifecycle = ServiceLifecycle.FAILED;
+                    lastError = exception.getCause();
+                    throw exception;
+                } catch (Throwable throwable) {
+                    lifecycle = ServiceLifecycle.FAILED;
+                    lastError = throwable;
+                    throw new ServiceRegistryException("Erreur lors de l'arrêt de "
+                            + definition.serviceType().getSimpleName(), throwable);
+                }
+            }
+        }
+
+        void markFailed(Throwable throwable) {
+            this.lifecycle = ServiceLifecycle.FAILED;
+            this.lastError = throwable;
+            this.healthy = false;
+        }
+
+        private void await(String phase, Duration timeout, CompletableFuture<Void> future) {
+            Objects.requireNonNull(timeout, "timeout");
+            try {
+                if (!timeout.isZero() && !timeout.isNegative()) {
+                    future.orTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS).join();
+                } else {
+                    future.join();
+                }
+            } catch (Exception exception) {
+                Throwable cause = unwrap(exception);
+                throw new ServiceRegistryException("Phase " + phase + " en échec pour "
+                        + definition.serviceType().getSimpleName(), cause);
+            }
+        }
+
+        private Throwable unwrap(Throwable throwable) {
+            if (throwable instanceof ServiceRegistryException registryException) {
+                return registryException.getCause();
+            }
+            Throwable cause = throwable.getCause();
+            return cause != null ? cause : throwable;
+        }
+
+        private void updateHealth() {
+            if (instance instanceof LifecycleAware lifecycleAware) {
+                healthy = lifecycleAware.isHealthy();
+                lastError = lifecycleAware.lastError().orElse(lastError);
+            }
+        }
+
+        ServiceStateSnapshot snapshot() {
+            return new ServiceStateSnapshot(
+                    definition.serviceType(),
+                    lifecycle,
+                    healthy,
+                    Optional.ofNullable(lastError),
+                    initializationDuration,
+                    startDuration,
+                    stopDuration,
+                    definition.dependencies().stream()
+                            .filter(dependency -> dependency.type() != ServiceRegistry.class)
+                            .map(Dependency::type)
+                            .toList());
+        }
     }
 }
+
+*** End Patch

--- a/src/main/java/com/heneria/nexus/service/ServiceRegistryException.java
+++ b/src/main/java/com/heneria/nexus/service/ServiceRegistryException.java
@@ -1,0 +1,15 @@
+package com.heneria.nexus.service;
+
+/**
+ * Exception thrown when the service registry cannot complete an operation.
+ */
+public final class ServiceRegistryException extends RuntimeException {
+
+    public ServiceRegistryException(String message) {
+        super(message);
+    }
+
+    public ServiceRegistryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/ServiceStateSnapshot.java
+++ b/src/main/java/com/heneria/nexus/service/ServiceStateSnapshot.java
@@ -1,0 +1,18 @@
+package com.heneria.nexus.service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Immutable diagnostics snapshot for a managed service.
+ */
+public record ServiceStateSnapshot(Class<?> serviceType,
+                                   ServiceLifecycle lifecycle,
+                                   boolean healthy,
+                                   Optional<Throwable> lastError,
+                                   Duration initializationDuration,
+                                   Duration startDuration,
+                                   Duration stopDuration,
+                                   List<Class<?>> dependencies) {
+}

--- a/src/main/java/com/heneria/nexus/service/api/ArenaBudget.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaBudget.java
@@ -1,0 +1,7 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Describes the runtime budgets allocated to an arena instance.
+ */
+public record ArenaBudget(int maxEntities, int maxItems, int maxProjectiles) {
+}

--- a/src/main/java/com/heneria/nexus/service/api/ArenaCreationException.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaCreationException.java
@@ -1,0 +1,15 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Exception raised when an arena instance cannot be created.
+ */
+public final class ArenaCreationException extends Exception {
+
+    public ArenaCreationException(String message) {
+        super(message);
+    }
+
+    public ArenaCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/ArenaHandle.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaHandle.java
@@ -1,0 +1,50 @@
+package com.heneria.nexus.service.api;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Mutable view over an arena instance managed by {@link ArenaService}.
+ */
+public final class ArenaHandle {
+
+    private final UUID id;
+    private final String mapId;
+    private final ArenaMode mode;
+    private final AtomicReference<ArenaPhase> phase;
+    private final Instant createdAt = Instant.now();
+
+    public ArenaHandle(UUID id, String mapId, ArenaMode mode, ArenaPhase initialPhase) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.mapId = Objects.requireNonNull(mapId, "mapId");
+        this.mode = Objects.requireNonNull(mode, "mode");
+        this.phase = new AtomicReference<>(Objects.requireNonNull(initialPhase, "initialPhase"));
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public String mapId() {
+        return mapId;
+    }
+
+    public ArenaMode mode() {
+        return mode;
+    }
+
+    public ArenaPhase phase() {
+        return phase.get();
+    }
+
+    public ArenaPhase setPhase(ArenaPhase next) {
+        Objects.requireNonNull(next, "next");
+        return phase.getAndSet(next);
+    }
+
+    public Instant createdAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/ArenaMode.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaMode.java
@@ -1,0 +1,9 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * High level description of the gameplay mode used by an arena.
+ */
+public enum ArenaMode {
+    CASUAL,
+    COMPETITIVE
+}

--- a/src/main/java/com/heneria/nexus/service/api/ArenaPhase.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaPhase.java
@@ -1,0 +1,13 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Enumeration describing the lifecycle of an arena instance.
+ */
+public enum ArenaPhase {
+    LOBBY,
+    STARTING,
+    PLAYING,
+    SCORED,
+    RESET,
+    END
+}

--- a/src/main/java/com/heneria/nexus/service/api/ArenaService.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaService.java
@@ -1,0 +1,70 @@
+package com.heneria.nexus.service.api;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+
+/**
+ * Core gameplay service managing arena instances and their lifecycle.
+ */
+public interface ArenaService extends LifecycleAware {
+
+    /**
+     * Creates a new arena instance bound to the provided map identifier.
+     *
+     * @param mapId identifier of the map to load
+     * @param mode gameplay mode requested by the queue
+     * @param seed optional deterministic seed for world generation related tasks
+     * @return handle representing the created arena
+     * @throws ArenaCreationException if the map cannot be loaded or the arena budget is exceeded
+     */
+    ArenaHandle createInstance(String mapId, ArenaMode mode, OptionalLong seed) throws ArenaCreationException;
+
+    /**
+     * Returns the arena instance associated with the provided identifier.
+     */
+    Optional<ArenaHandle> getInstance(UUID arenaId);
+
+    /**
+     * Returns an immutable snapshot of the currently active arenas.
+     */
+    Collection<ArenaHandle> instances();
+
+    /**
+     * Requests a phase transition for the given arena. This method must be
+     * invoked from the main server thread and should not block.
+     */
+    void transition(ArenaHandle handle, ArenaPhase nextPhase);
+
+    /**
+     * Retrieves the performance budget applied to the arena.
+     */
+    ArenaBudget budget(ArenaHandle handle);
+
+    /**
+     * Registers a listener receiving internal arena signals.
+     */
+    void registerListener(ArenaListener listener);
+
+    /**
+     * Unregisters a previously registered listener.
+     */
+    void unregisterListener(ArenaListener listener);
+
+    /**
+     * Applies new arena related settings. Called when the configuration is
+     * reloaded.
+     */
+    void applyArenaSettings(NexusConfig.ArenaSettings settings);
+
+    interface ArenaListener {
+        void onPhaseChange(ArenaHandle handle, ArenaPhase previous, ArenaPhase next);
+
+        void onResetStart(ArenaHandle handle);
+
+        void onResetEnd(ArenaHandle handle);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/EconomyException.java
+++ b/src/main/java/com/heneria/nexus/service/api/EconomyException.java
@@ -1,0 +1,15 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Domain level exception for economy operations.
+ */
+public final class EconomyException extends Exception {
+
+    public EconomyException(String message) {
+        super(message);
+    }
+
+    public EconomyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/EconomyService.java
+++ b/src/main/java/com/heneria/nexus/service/api/EconomyService.java
@@ -1,0 +1,26 @@
+package com.heneria.nexus.service.api;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Persistent currency management for the Nexus network.
+ */
+public interface EconomyService extends LifecycleAware {
+
+    CompletionStage<Long> getBalance(UUID accountId);
+
+    CompletionStage<Long> credit(UUID accountId, long amount, String reason);
+
+    CompletionStage<Long> debit(UUID accountId, long amount, String reason) throws EconomyException;
+
+    CompletionStage<EconomyTransferResult> transfer(UUID from, UUID to, long amount, String reason) throws EconomyException;
+
+    EconomyTransaction beginTransaction();
+
+    void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings);
+
+    boolean isDegraded();
+}

--- a/src/main/java/com/heneria/nexus/service/api/EconomyTransaction.java
+++ b/src/main/java/com/heneria/nexus/service/api/EconomyTransaction.java
@@ -1,0 +1,23 @@
+package com.heneria.nexus.service.api;
+
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Represents a transactional batch of economy operations.
+ */
+public interface EconomyTransaction extends AutoCloseable {
+
+    void credit(UUID account, long amount, String reason);
+
+    void debit(UUID account, long amount, String reason) throws EconomyException;
+
+    CompletionStage<Void> commit();
+
+    void rollback();
+
+    @Override
+    default void close() {
+        rollback();
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/EconomyTransferResult.java
+++ b/src/main/java/com/heneria/nexus/service/api/EconomyTransferResult.java
@@ -1,0 +1,7 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Result of a transfer operation.
+ */
+public record EconomyTransferResult(long fromBalance, long toBalance) {
+}

--- a/src/main/java/com/heneria/nexus/service/api/MapDefinition.java
+++ b/src/main/java/com/heneria/nexus/service/api/MapDefinition.java
@@ -1,0 +1,18 @@
+package com.heneria.nexus.service.api;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents an entry of the map catalog.
+ */
+public record MapDefinition(String id, String displayName, Path folder, Map<String, Object> metadata) {
+
+    public MapDefinition {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(displayName, "displayName");
+        Objects.requireNonNull(folder, "folder");
+        Objects.requireNonNull(metadata, "metadata");
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/MapLoadException.java
+++ b/src/main/java/com/heneria/nexus/service/api/MapLoadException.java
@@ -1,0 +1,15 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Exception thrown when the catalog cannot be loaded.
+ */
+public final class MapLoadException extends Exception {
+
+    public MapLoadException(String message) {
+        super(message);
+    }
+
+    public MapLoadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/MapQuery.java
+++ b/src/main/java/com/heneria/nexus/service/api/MapQuery.java
@@ -1,0 +1,18 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Optional;
+
+/**
+ * Simple filter used to list maps.
+ */
+public record MapQuery(Optional<ArenaMode> mode, Optional<String> regionTag) {
+
+    public MapQuery {
+        mode = mode == null ? Optional.empty() : mode;
+        regionTag = regionTag == null ? Optional.empty() : regionTag;
+    }
+
+    public static MapQuery any() {
+        return new MapQuery(Optional.empty(), Optional.empty());
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/MapService.java
+++ b/src/main/java/com/heneria/nexus/service/api/MapService.java
@@ -1,0 +1,37 @@
+package com.heneria.nexus.service.api;
+
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Catalog of available arenas.
+ */
+public interface MapService extends LifecycleAware {
+
+    /**
+     * Loads the map catalog. Called during the {@code initialize} phase.
+     */
+    void loadCatalog() throws MapLoadException;
+
+    /**
+     * Reloads the map catalog atomically from disk.
+     */
+    void reload() throws MapLoadException;
+
+    /**
+     * Retrieves a map definition by identifier.
+     */
+    Optional<MapDefinition> getMap(String id);
+
+    /**
+     * Lists map definitions matching the provided query.
+     */
+    Collection<MapDefinition> list(MapQuery query);
+
+    /**
+     * Performs expensive validations on the provided map identifier. Should be
+     * invoked from the compute executor.
+     */
+    ValidationReport validate(String mapId);
+}

--- a/src/main/java/com/heneria/nexus/service/api/MatchPlan.java
+++ b/src/main/java/com/heneria/nexus/service/api/MatchPlan.java
@@ -1,0 +1,16 @@
+package com.heneria.nexus.service.api;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Result of a matchmaking iteration.
+ */
+public record MatchPlan(UUID matchId, ArenaMode mode, List<UUID> players, Optional<String> mapCandidate) {
+
+    public MatchPlan {
+        players = List.copyOf(players);
+        mapCandidate = mapCandidate == null ? Optional.empty() : mapCandidate;
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/PlayerProfile.java
+++ b/src/main/java/com/heneria/nexus/service/api/PlayerProfile.java
@@ -1,0 +1,55 @@
+package com.heneria.nexus.service.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Mutable view representing a player profile.
+ */
+public final class PlayerProfile {
+
+    private final UUID playerId;
+    private final Map<String, Long> statistics;
+    private final Map<String, String> preferences;
+    private final List<String> cosmetics;
+    private Instant lastUpdate;
+
+    public PlayerProfile(UUID playerId,
+                         Map<String, Long> statistics,
+                         Map<String, String> preferences,
+                         List<String> cosmetics,
+                         Instant lastUpdate) {
+        this.playerId = Objects.requireNonNull(playerId, "playerId");
+        this.statistics = Objects.requireNonNull(statistics, "statistics");
+        this.preferences = Objects.requireNonNull(preferences, "preferences");
+        this.cosmetics = Objects.requireNonNull(cosmetics, "cosmetics");
+        this.lastUpdate = Objects.requireNonNullElse(lastUpdate, Instant.now());
+    }
+
+    public UUID playerId() {
+        return playerId;
+    }
+
+    public Map<String, Long> statistics() {
+        return statistics;
+    }
+
+    public Map<String, String> preferences() {
+        return preferences;
+    }
+
+    public List<String> cosmetics() {
+        return cosmetics;
+    }
+
+    public Instant lastUpdate() {
+        return lastUpdate;
+    }
+
+    public void touch() {
+        this.lastUpdate = Instant.now();
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/ProfileService.java
+++ b/src/main/java/com/heneria/nexus/service/api/ProfileService.java
@@ -1,0 +1,22 @@
+package com.heneria.nexus.service.api;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Provides access to player profiles with caching and degraded fallbacks.
+ */
+public interface ProfileService extends LifecycleAware {
+
+    CompletionStage<PlayerProfile> load(UUID playerId);
+
+    CompletionStage<Void> saveAsync(PlayerProfile profile);
+
+    void invalidate(UUID playerId);
+
+    void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings);
+
+    boolean isDegraded();
+}

--- a/src/main/java/com/heneria/nexus/service/api/QueueOptions.java
+++ b/src/main/java/com/heneria/nexus/service/api/QueueOptions.java
@@ -1,0 +1,17 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Additional parameters used when enqueuing a player.
+ */
+public record QueueOptions(boolean vip, int weight) {
+
+    public QueueOptions {
+        if (weight < 0) {
+            throw new IllegalArgumentException("weight must be >= 0");
+        }
+    }
+
+    public static QueueOptions standard() {
+        return new QueueOptions(false, 0);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/QueueService.java
+++ b/src/main/java/com/heneria/nexus/service/api/QueueService.java
@@ -1,0 +1,42 @@
+package com.heneria.nexus.service.api;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Provides matchmaking capabilities for players.
+ */
+public interface QueueService extends LifecycleAware {
+
+    /**
+     * Adds a player to the queue.
+     */
+    QueueTicket enqueue(UUID playerId, ArenaMode mode, QueueOptions options);
+
+    /**
+     * Removes a player from the queue.
+     */
+    void leave(UUID playerId);
+
+    /**
+     * Returns a lightweight snapshot of the queue for diagnostics.
+     */
+    QueueSnapshot snapshot();
+
+    /**
+     * Returns aggregated queue metrics.
+     */
+    QueueStats stats();
+
+    /**
+     * Attempts to form a match for the given mode. Invoked on the compute executor.
+     */
+    Optional<MatchPlan> tryMatch(ArenaMode mode);
+
+    /**
+     * Applies configuration updates impacting the queue tick rate.
+     */
+    void applySettings(NexusConfig.QueueSettings settings);
+}

--- a/src/main/java/com/heneria/nexus/service/api/QueueSnapshot.java
+++ b/src/main/java/com/heneria/nexus/service/api/QueueSnapshot.java
@@ -1,0 +1,13 @@
+package com.heneria.nexus.service.api;
+
+import java.util.List;
+
+/**
+ * Immutable snapshot of the queue state.
+ */
+public record QueueSnapshot(List<QueueTicket> tickets) {
+
+    public QueueSnapshot {
+        tickets = List.copyOf(tickets);
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/QueueStats.java
+++ b/src/main/java/com/heneria/nexus/service/api/QueueStats.java
@@ -1,0 +1,7 @@
+package com.heneria.nexus.service.api;
+
+/**
+ * Aggregated metrics about the matchmaking queues.
+ */
+public record QueueStats(int totalPlayers, int vipPlayers, long averageWaitSeconds, long matchesFormed) {
+}

--- a/src/main/java/com/heneria/nexus/service/api/QueueTicket.java
+++ b/src/main/java/com/heneria/nexus/service/api/QueueTicket.java
@@ -1,0 +1,18 @@
+package com.heneria.nexus.service.api;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Entry representing a player waiting in the queue.
+ */
+public record QueueTicket(UUID playerId, ArenaMode mode, QueueOptions options, Instant enqueuedAt) {
+
+    public QueueTicket {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(mode, "mode");
+        options = options == null ? QueueOptions.standard() : options;
+        enqueuedAt = enqueuedAt == null ? Instant.now() : enqueuedAt;
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/ValidationReport.java
+++ b/src/main/java/com/heneria/nexus/service/api/ValidationReport.java
@@ -1,0 +1,23 @@
+package com.heneria.nexus.service.api;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Result of a map validation process.
+ */
+public record ValidationReport(boolean valid, List<String> warnings, List<String> errors) {
+
+    public static ValidationReport success(List<String> warnings) {
+        return new ValidationReport(true, List.copyOf(warnings), List.of());
+    }
+
+    public static ValidationReport failure(List<String> warnings, List<String> errors) {
+        return new ValidationReport(false, List.copyOf(warnings), List.copyOf(errors));
+    }
+
+    public ValidationReport {
+        Objects.requireNonNull(warnings, "warnings");
+        Objects.requireNonNull(errors, "errors");
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/ArenaServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/ArenaServiceImpl.java
@@ -1,0 +1,152 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.ExecutorPools;
+import com.heneria.nexus.service.api.ArenaBudget;
+import com.heneria.nexus.service.api.ArenaCreationException;
+import com.heneria.nexus.service.api.ArenaHandle;
+import com.heneria.nexus.service.api.ArenaMode;
+import com.heneria.nexus.service.api.ArenaPhase;
+import com.heneria.nexus.service.api.ArenaService;
+import com.heneria.nexus.service.api.EconomyService;
+import com.heneria.nexus.service.api.MapService;
+import com.heneria.nexus.service.api.ProfileService;
+import com.heneria.nexus.service.api.QueueService;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Default arena orchestration service.
+ */
+public final class ArenaServiceImpl implements ArenaService {
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final MapService mapService;
+    private final QueueService queueService;
+    private final Optional<ProfileService> profileService;
+    private final EconomyService economyService;
+    private final ExecutorService computeExecutor;
+    private final ConcurrentHashMap<UUID, ArenaHandle> arenas = new ConcurrentHashMap<>();
+    private final CopyOnWriteArrayList<ArenaListener> listeners = new CopyOnWriteArrayList<>();
+    private final AtomicReference<NexusConfig.ArenaSettings> settingsRef;
+
+    public ArenaServiceImpl(JavaPlugin plugin,
+                            NexusLogger logger,
+                            MapService mapService,
+                            QueueService queueService,
+                            Optional<ProfileService> profileService,
+                            EconomyService economyService,
+                            ExecutorPools executorPools,
+                            NexusConfig config) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.mapService = Objects.requireNonNull(mapService, "mapService");
+        this.queueService = Objects.requireNonNull(queueService, "queueService");
+        this.profileService = Objects.requireNonNull(profileService, "profileService");
+        this.economyService = Objects.requireNonNull(economyService, "economyService");
+        this.computeExecutor = Objects.requireNonNull(executorPools, "executorPools").computeExecutor();
+        this.settingsRef = new AtomicReference<>(config.arenaSettings());
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public ArenaHandle createInstance(String mapId, ArenaMode mode, OptionalLong seed) throws ArenaCreationException {
+        Objects.requireNonNull(mapId, "mapId");
+        Objects.requireNonNull(mode, "mode");
+        if (mapService.getMap(mapId).isEmpty()) {
+            throw new ArenaCreationException("Map inconnue: " + mapId);
+        }
+        ArenaHandle handle = new ArenaHandle(UUID.randomUUID(), mapId, mode, ArenaPhase.LOBBY);
+        arenas.put(handle.id(), handle);
+        logger.info("Nouvelle arène " + handle.id() + " sur map " + mapId + " mode " + mode);
+        seed.ifPresent(value -> logger.debug(() -> "Seed déterministe appliqué à " + handle.id() + " -> " + value));
+        return handle;
+    }
+
+    @Override
+    public Optional<ArenaHandle> getInstance(UUID arenaId) {
+        return Optional.ofNullable(arenas.get(arenaId));
+    }
+
+    @Override
+    public Collection<ArenaHandle> instances() {
+        return List.copyOf(arenas.values());
+    }
+
+    @Override
+    public void transition(ArenaHandle handle, ArenaPhase nextPhase) {
+        Objects.requireNonNull(handle, "handle");
+        Objects.requireNonNull(nextPhase, "nextPhase");
+        if (!plugin.getServer().isPrimaryThread()) {
+            throw new IllegalStateException("Les transitions d'arène doivent être réalisées sur le main thread");
+        }
+        ArenaPhase previous = handle.setPhase(nextPhase);
+        listeners.forEach(listener -> safe(() -> listener.onPhaseChange(handle, previous, nextPhase)));
+        if (nextPhase == ArenaPhase.RESET) {
+            listeners.forEach(listener -> safe(() -> listener.onResetStart(handle)));
+            computeExecutor.execute(() -> logger.debug(() -> "Préparation du reset pour " + handle.id()));
+        } else if (previous == ArenaPhase.RESET && nextPhase != ArenaPhase.RESET) {
+            listeners.forEach(listener -> safe(() -> listener.onResetEnd(handle)));
+        } else if (nextPhase == ArenaPhase.SCORED) {
+            if (economyService.isDegraded()) {
+                logger.warn("Économie en mode dégradé lors du score pour " + handle.id());
+            }
+        } else if (nextPhase == ArenaPhase.END) {
+            arenas.remove(handle.id());
+            computeExecutor.execute(() -> queueService.tryMatch(handle.mode()).ifPresent(plan ->
+                    logger.info("Match prêt après fin d'arène " + handle.id() + " -> " + plan.matchId())));
+            profileService.ifPresent(service -> {
+                if (service.isDegraded()) {
+                    logger.warn("Profil en mode dégradé détecté lors de la fermeture de " + handle.id());
+                }
+            });
+        }
+    }
+
+    private void safe(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable throwable) {
+            logger.error("Listener d'arène en échec", throwable);
+        }
+    }
+
+    @Override
+    public ArenaBudget budget(ArenaHandle handle) {
+        NexusConfig.ArenaSettings settings = settingsRef.get();
+        return new ArenaBudget(settings.maxEntities(), settings.maxItems(), settings.maxProjectiles());
+    }
+
+    @Override
+    public void registerListener(ArenaListener listener) {
+        listeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    @Override
+    public void unregisterListener(ArenaListener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void applyArenaSettings(NexusConfig.ArenaSettings settings) {
+        settingsRef.set(Objects.requireNonNull(settings, "settings"));
+        logger.info("Paramètres d'arène mis à jour: hud=" + settings.hudHz() + " scoreboard=" + settings.scoreboardHz());
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/MapServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/MapServiceImpl.java
@@ -1,0 +1,152 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.service.ExecutorPools;
+import com.heneria.nexus.service.api.MapDefinition;
+import com.heneria.nexus.service.api.MapLoadException;
+import com.heneria.nexus.service.api.MapQuery;
+import com.heneria.nexus.service.api.MapService;
+import com.heneria.nexus.service.api.ValidationReport;
+import com.heneria.nexus.util.NexusLogger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Default in-memory implementation of {@link MapService}.
+ */
+public final class MapServiceImpl implements MapService {
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final ExecutorService computeExecutor;
+    private final AtomicReference<Map<String, MapDefinition>> catalog = new AtomicReference<>(Map.of());
+    private final AtomicReference<ValidationReport> lastValidation = new AtomicReference<>();
+
+    public MapServiceImpl(JavaPlugin plugin, NexusLogger logger, ExecutorPools executorPools) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.computeExecutor = Objects.requireNonNull(executorPools, "executorPools").computeExecutor();
+    }
+
+    @Override
+    public CompletableFuture<Void> initialize() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                loadCatalog();
+            } catch (MapLoadException exception) {
+                throw new RuntimeException(exception);
+            }
+        }, computeExecutor);
+    }
+
+    @Override
+    public void loadCatalog() throws MapLoadException {
+        Path dataFolder = plugin.getDataFolder().toPath();
+        Path mapsFile = dataFolder.resolve("maps.yml");
+        FileConfiguration configuration = YamlConfiguration.loadConfiguration(mapsFile.toFile());
+        ConfigurationSection root = configuration.getConfigurationSection("maps");
+        Map<String, MapDefinition> newCatalog = new ConcurrentHashMap<>();
+        if (root != null) {
+            for (String key : root.getKeys(false)) {
+                ConfigurationSection section = root.getConfigurationSection(key);
+                if (section == null) {
+                    continue;
+                }
+                String displayName = section.getString("display", key);
+                Path mapFolder = dataFolder.resolve("maps").resolve(key);
+                Map<String, Object> metadata = new HashMap<>();
+                section.getValues(false).forEach(metadata::put);
+                newCatalog.put(key.toLowerCase(Locale.ROOT), new MapDefinition(key, displayName, mapFolder, Map.copyOf(metadata)));
+            }
+        }
+        catalog.set(Collections.unmodifiableMap(newCatalog));
+        logger.info("Catalogue des maps chargé (%d entrées)".formatted(newCatalog.size()));
+    }
+
+    @Override
+    public void reload() throws MapLoadException {
+        loadCatalog();
+    }
+
+    @Override
+    public Optional<MapDefinition> getMap(String id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(catalog.get().get(id.toLowerCase(Locale.ROOT)));
+    }
+
+    @Override
+    public Collection<MapDefinition> list(MapQuery query) {
+        MapQuery effectiveQuery = query == null ? MapQuery.any() : query;
+        return catalog.get().values().stream()
+                .filter(definition -> filterByMode(definition, effectiveQuery))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private boolean filterByMode(MapDefinition definition, MapQuery query) {
+        if (query.mode().isEmpty()) {
+            return true;
+        }
+        Object modes = definition.metadata().get("modes");
+        if (modes instanceof List<?> list) {
+            return list.stream()
+                    .map(Object::toString)
+                    .map(value -> value.toUpperCase(Locale.ROOT))
+                    .anyMatch(value -> value.equals(query.mode().get().name()));
+        }
+        return true;
+    }
+
+    @Override
+    public ValidationReport validate(String mapId) {
+        MapDefinition definition = getMap(mapId).orElse(null);
+        List<String> warnings = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+        if (definition == null) {
+            errors.add("Map inconnue : " + mapId);
+            ValidationReport report = ValidationReport.failure(warnings, errors);
+            lastValidation.set(report);
+            return report;
+        }
+        Path folder = definition.folder();
+        if (!Files.exists(folder)) {
+            errors.add("Dossier introuvable : " + folder);
+        } else {
+            Path layout = folder.resolve("map.yml");
+            if (!Files.exists(layout)) {
+                warnings.add("map.yml manquant pour " + definition.id());
+            }
+            Path schematic = folder.resolve("world.schem");
+            if (!Files.exists(schematic)) {
+                warnings.add("world.schem absent pour " + definition.id());
+            }
+        }
+        ValidationReport report = errors.isEmpty()
+                ? ValidationReport.success(warnings)
+                : ValidationReport.failure(warnings, errors);
+        lastValidation.set(report);
+        return report;
+    }
+
+    public Optional<ValidationReport> lastValidation() {
+        return Optional.ofNullable(lastValidation.get());
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/ProfileServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/ProfileServiceImpl.java
@@ -1,0 +1,127 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.service.ExecutorPools;
+import com.heneria.nexus.service.api.PlayerProfile;
+import com.heneria.nexus.service.api.ProfileService;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Default profile service relying on the database provider with in-memory fallback.
+ */
+public final class ProfileServiceImpl implements ProfileService {
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+
+    private final NexusLogger logger;
+    private final DbProvider dbProvider;
+    private final ExecutorService ioExecutor;
+    private final ConcurrentHashMap<UUID, CacheEntry> cache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, PlayerProfile> persistentStore = new ConcurrentHashMap<>();
+    private final AtomicBoolean degraded = new AtomicBoolean();
+    private final AtomicReference<NexusConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
+
+    public ProfileServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorPools executorPools, NexusConfig config) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorPools, "executorPools").ioExecutor();
+        this.degradedSettings.set(config.degradedModeSettings());
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        return CompletableFuture.runAsync(this::refreshDegradedState, ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<PlayerProfile> load(UUID playerId) {
+        Objects.requireNonNull(playerId, "playerId");
+        CacheEntry cached = cache.get(playerId);
+        if (cached != null && !cached.isExpired()) {
+            return CompletableFuture.completedFuture(copyProfile(cached.profile()));
+        }
+        return CompletableFuture.supplyAsync(() -> {
+            boolean fallback = refreshDegradedState();
+            if (fallback) {
+                return cache.compute(playerId, (id, entry) -> {
+                    PlayerProfile profile = entry != null ? entry.profile() : defaultProfile(playerId);
+                    return new CacheEntry(copyProfile(profile), Instant.now());
+                }).profile();
+            }
+            PlayerProfile stored = persistentStore.computeIfAbsent(playerId, this::defaultProfile);
+            CacheEntry entry = new CacheEntry(copyProfile(stored), Instant.now());
+            cache.put(playerId, entry);
+            return copyProfile(entry.profile());
+        }, ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<Void> saveAsync(PlayerProfile profile) {
+        Objects.requireNonNull(profile, "profile");
+        PlayerProfile copy = copyProfile(profile);
+        return CompletableFuture.runAsync(() -> {
+            persistentStore.put(profile.playerId(), copyProfile(copy));
+            cache.put(profile.playerId(), new CacheEntry(copyProfile(copy), Instant.now()));
+        }, ioExecutor);
+    }
+
+    @Override
+    public void invalidate(UUID playerId) {
+        cache.remove(playerId);
+    }
+
+    @Override
+    public void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings) {
+        degradedSettings.set(Objects.requireNonNull(settings, "settings"));
+    }
+
+    @Override
+    public boolean isDegraded() {
+        return degraded.get();
+    }
+
+    private boolean refreshDegradedState() {
+        boolean fallback = dbProvider.isDegraded();
+        boolean previous = degraded.getAndSet(fallback);
+        if (fallback && !previous) {
+            NexusConfig.DegradedModeSettings settings = degradedSettings.get();
+            if (settings.banner()) {
+                logger.warn("Mode dégradé activé pour le ProfileService : stockage en mémoire");
+            }
+        }
+        if (!fallback && previous) {
+            logger.info("ProfileService repassé en mode persistant");
+        }
+        return fallback;
+    }
+
+    private PlayerProfile defaultProfile(UUID playerId) {
+        return new PlayerProfile(playerId, new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), List.of(), Instant.now());
+    }
+
+    private PlayerProfile copyProfile(PlayerProfile profile) {
+        return new PlayerProfile(
+                profile.playerId(),
+                new ConcurrentHashMap<>(profile.statistics()),
+                new ConcurrentHashMap<>(profile.preferences()),
+                List.copyOf(profile.cosmetics()),
+                profile.lastUpdate());
+    }
+
+    private record CacheEntry(PlayerProfile profile, Instant loadedAt) {
+        boolean isExpired() {
+            return loadedAt.plus(CACHE_TTL).isBefore(Instant.now());
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/QueueServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/QueueServiceImpl.java
@@ -1,0 +1,181 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.service.ExecutorPools;
+import com.heneria.nexus.service.api.ArenaMode;
+import com.heneria.nexus.service.api.MatchPlan;
+import com.heneria.nexus.service.api.QueueOptions;
+import com.heneria.nexus.service.api.QueueService;
+import com.heneria.nexus.service.api.QueueSnapshot;
+import com.heneria.nexus.service.api.QueueStats;
+import com.heneria.nexus.service.api.QueueTicket;
+import com.heneria.nexus.service.api.ProfileService;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Default matchmaking service using in-memory queues.
+ */
+public final class QueueServiceImpl implements QueueService {
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final ExecutorService computeExecutor;
+    private final ProfileService profileService;
+    private final Map<ArenaMode, ConcurrentLinkedQueue<QueueTicket>> queues = new EnumMap<>(ArenaMode.class);
+    private final ConcurrentHashMap<UUID, QueueTicket> ticketsByPlayer = new ConcurrentHashMap<>();
+    private final AtomicLong matchesFormed = new AtomicLong();
+    private final AtomicReference<NexusConfig.QueueSettings> settingsRef;
+    private final AtomicReference<QueueStats> stats = new AtomicReference<>(new QueueStats(0, 0, 0L, 0L));
+    private volatile BukkitTask tickerTask;
+
+    public QueueServiceImpl(JavaPlugin plugin,
+                            NexusLogger logger,
+                            ExecutorPools executorPools,
+                            ProfileService profileService,
+                            NexusConfig config) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.computeExecutor = Objects.requireNonNull(executorPools, "executorPools").computeExecutor();
+        this.profileService = Objects.requireNonNull(profileService, "profileService");
+        this.settingsRef = new AtomicReference<>(config.queueSettings());
+        for (ArenaMode mode : ArenaMode.values()) {
+            queues.put(mode, new ConcurrentLinkedQueue<>());
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        return CompletableFuture.runAsync(this::scheduleTicker, computeExecutor);
+    }
+
+    private void scheduleTicker() {
+        cancelTicker();
+        long period = Math.max(1L, Math.round(20.0d / Math.max(1, settingsRef.get().tickHz())));
+        tickerTask = plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, () ->
+                computeExecutor.execute(this::matchAllModes), period, period);
+        logger.info("QueueService démarré (période=" + period + " ticks)");
+    }
+
+    private void cancelTicker() {
+        if (tickerTask != null) {
+            tickerTask.cancel();
+            tickerTask = null;
+        }
+    }
+
+    private void matchAllModes() {
+        for (ArenaMode mode : ArenaMode.values()) {
+            tryMatch(mode).ifPresent(plan -> matchesFormed.incrementAndGet());
+        }
+        updateStats();
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        return CompletableFuture.runAsync(this::cancelTicker, computeExecutor);
+    }
+
+    @Override
+    public QueueTicket enqueue(UUID playerId, ArenaMode mode, QueueOptions options) {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(mode, "mode");
+        QueueOptions effectiveOptions = options == null ? QueueOptions.standard() : options;
+        QueueTicket ticket = new QueueTicket(playerId, mode, effectiveOptions, Instant.now());
+        ticketsByPlayer.put(playerId, ticket);
+        queues.get(mode).add(ticket);
+        profileService.load(playerId).exceptionally(throwable -> {
+            logger.debug(() -> "Préchargement du profil impossible pour " + playerId + ": " + throwable.getMessage());
+            return null;
+        });
+        updateStats();
+        return ticket;
+    }
+
+    @Override
+    public void leave(UUID playerId) {
+        QueueTicket ticket = ticketsByPlayer.remove(playerId);
+        if (ticket != null) {
+            queues.get(ticket.mode()).remove(ticket);
+            updateStats();
+        }
+    }
+
+    @Override
+    public QueueSnapshot snapshot() {
+        Collection<QueueTicket> tickets = ticketsByPlayer.values();
+        return new QueueSnapshot(tickets.stream().sorted(Comparator.comparing(QueueTicket::enqueuedAt)).toList());
+    }
+
+    @Override
+    public QueueStats stats() {
+        return stats.get();
+    }
+
+    @Override
+    public Optional<MatchPlan> tryMatch(ArenaMode mode) {
+        ConcurrentLinkedQueue<QueueTicket> queue = queues.get(mode);
+        if (queue == null) {
+            return Optional.empty();
+        }
+        List<QueueTicket> candidates = new ArrayList<>(queue);
+        if (candidates.size() < 2) {
+            return Optional.empty();
+        }
+        candidates.sort(Comparator.comparingInt(this::weightForTicket).reversed()
+                .thenComparing(QueueTicket::enqueuedAt));
+        List<QueueTicket> selected = candidates.stream().limit(2).toList();
+        List<UUID> players = selected.stream().map(QueueTicket::playerId).toList();
+        if (players.stream().anyMatch(id -> !ticketsByPlayer.containsKey(id))) {
+            selected.forEach(queue::remove);
+            return Optional.empty();
+        }
+        selected.forEach(ticket -> {
+            ticketsByPlayer.remove(ticket.playerId());
+            queue.remove(ticket);
+        });
+        updateStats();
+        MatchPlan plan = new MatchPlan(UUID.randomUUID(), mode, players, Optional.empty());
+        return Optional.of(plan);
+    }
+
+    @Override
+    public void applySettings(NexusConfig.QueueSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        settingsRef.set(settings);
+        scheduleTicker();
+    }
+
+    private int weightForTicket(QueueTicket ticket) {
+        int vipBonus = ticket.options().vip() ? settingsRef.get().vipWeight() : 0;
+        return vipBonus + ticket.options().weight();
+    }
+
+    private void updateStats() {
+        Collection<QueueTicket> tickets = ticketsByPlayer.values();
+        long vip = tickets.stream().filter(ticket -> ticket.options().vip()).count();
+        long totalWait = tickets.stream()
+                .mapToLong(ticket -> Duration.between(ticket.enqueuedAt(), Instant.now()).getSeconds())
+                .sum();
+        long averageWait = tickets.isEmpty() ? 0L : totalWait / tickets.size();
+        stats.set(new QueueStats(tickets.size(), (int) vip, averageWait, matchesFormed.get()));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,15 +11,45 @@ server:
   # Fuseau horaire utilisé pour les horodatages et les dumps
   timezone: "Europe/Paris"
 
-perf:
+services:
+  # Expose les services clés via le ServicesManager de Bukkit pour les autres plugins
+  expose-bukkit-services: false
+
+timeouts:
+  # Timeout global pour le démarrage des services (ms)
+  startMs: 5000
+  # Timeout global pour l'arrêt des services (ms)
+  stopMs: 3000
+
+degraded-mode:
+  # Active les mécanismes de repli (économie/profils en mémoire) si la DB ne répond pas
+  enabled: true
+  # Affiche une bannière opérateur lorsque le mode dégradé est actif
+  banner: true
+
+queue:
+  # Fréquence d'exécution du matchmaking (Hz)
+  tick_hz: 5
+  # Bonus de poids pour les joueurs VIP (0..3 conseillé)
+  vip_weight: 1
+
+arena:
   # Taux de rafraîchissement des HUD (5 Hz par défaut => toutes les 4 ticks)
   hud_hz: 5
   # Taux de rafraîchissement des scoreboards (3 Hz par défaut)
   scoreboard_hz: 3
-  # Budget particules pour les effets « doux » (peut être dépassé ponctuellement)
-  particles_soft_cap: 1200
-  # Limite stricte d'émission de particules (les tâches au-delà sont coupées)
-  particles_hard_cap: 2000
+  particles:
+    # Budget particules pour les effets « doux » (peut être dépassé ponctuellement)
+    soft_cap: 1200
+    # Limite stricte d'émission de particules (les tâches au-delà sont coupées)
+    hard_cap: 2000
+  budget:
+    # Nombre maximum d'entités actives par arène
+    max_entities: 200
+    # Nombre maximum d'items au sol
+    max_items: 128
+    # Nombre maximum de projectiles simultanés
+    max_projectiles: 64
 
 threads:
   # Pool I/O pour la base de données et les accès disque. Pas d'I/O sur le main thread !


### PR DESCRIPTION
## Summary
- implement a constructor-injected ServiceRegistry with lifecycle tracking, health snapshots, and dependency cycle detection
- define service contracts for arena, map, queue, economy, and profile domains alongside baseline implementations with degraded-mode handling
- integrate the registry into the plugin lifecycle, expand configuration for service exposure and timeouts, and enhance diagnostics/dump output

## Testing
- `mvn -B -DskipTests package` *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc20365a88324b117040ce8855a34