### PR TITLE
Implement atomic multi-config manager with validation

### DIFF
--- a/src/main/java/com/heneria/nexus/config/ConfigBundle.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigBundle.java
@@ -8,22 +8,45 @@ import java.util.Objects;
  */
 public final class ConfigBundle {
 
-    private final NexusConfig config;
+    private final long version;
+    private final CoreConfig core;
     private final MessageBundle messages;
+    private final MapsCatalogConfig maps;
+    private final EconomyConfig economy;
     private final Instant loadedAt;
 
-    public ConfigBundle(NexusConfig config, MessageBundle messages, Instant loadedAt) {
-        this.config = Objects.requireNonNull(config, "config");
+    public ConfigBundle(long version,
+                        CoreConfig core,
+                        MessageBundle messages,
+                        MapsCatalogConfig maps,
+                        EconomyConfig economy,
+                        Instant loadedAt) {
+        this.version = version;
+        this.core = Objects.requireNonNull(core, "core");
         this.messages = Objects.requireNonNull(messages, "messages");
+        this.maps = Objects.requireNonNull(maps, "maps");
+        this.economy = Objects.requireNonNull(economy, "economy");
         this.loadedAt = Objects.requireNonNull(loadedAt, "loadedAt");
     }
 
-    public NexusConfig config() {
-        return config;
+    public long version() {
+        return version;
+    }
+
+    public CoreConfig core() {
+        return core;
     }
 
     public MessageBundle messages() {
         return messages;
+    }
+
+    public MapsCatalogConfig maps() {
+        return maps;
+    }
+
+    public EconomyConfig economy() {
+        return economy;
     }
 
     public Instant loadedAt() {

--- a/src/main/java/com/heneria/nexus/config/ConfigHotSwap.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigHotSwap.java
@@ -1,0 +1,43 @@
+package com.heneria.nexus.config;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Maintains the currently active configuration bundle and performs
+ * atomic swaps when a full reload succeeds.
+ */
+public final class ConfigHotSwap {
+
+    private final AtomicReference<ConfigBundle> reference = new AtomicReference<>();
+    private final AtomicLong version = new AtomicLong();
+
+    public void initialize(ConfigBundle bundle) {
+        Objects.requireNonNull(bundle, "bundle");
+        reference.set(bundle);
+        version.set(bundle.version());
+    }
+
+    public ConfigBundle current() {
+        ConfigBundle bundle = reference.get();
+        if (bundle == null) {
+            throw new IllegalStateException("Configuration not loaded yet");
+        }
+        return bundle;
+    }
+
+    public long currentVersion() {
+        return version.get();
+    }
+
+    public long nextVersion() {
+        return version.incrementAndGet();
+    }
+
+    public void commit(ConfigBundle bundle) {
+        Objects.requireNonNull(bundle, "bundle");
+        reference.set(bundle);
+        version.set(bundle.version());
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/ConfigManager.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigManager.java
@@ -1,5 +1,6 @@
 package com.heneria.nexus.config;
 
+import com.heneria.nexus.util.NamedThreadFactory;
 import com.heneria.nexus.util.NexusLogger;
 import java.io.File;
 import java.io.IOException;
@@ -9,71 +10,171 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.InvalidConfigurationException;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
- * Handles configuration files and provides atomic reloads.
+ * Handles configuration files and provides atomic reloads with validation.
  */
-public final class ConfigManager {
+public final class ConfigManager implements AutoCloseable {
 
-    private static final String DEFAULT_LANGUAGE = "fr";
-    private static final String DEFAULT_TIMEZONE = "Europe/Paris";
-    private static final String DEFAULT_JDBC = "jdbc:mariadb://127.0.0.1:3306/nexus";
-    private static final String DEFAULT_DB_USER = "nexus";
-    private static final String DEFAULT_DB_PASSWORD = "change_me";
+    private static final String CONFIG_FILE = "config.yml";
+    private static final String MESSAGES_FILE = "messages.yml";
+    private static final String MAPS_FILE = "maps.yml";
+    private static final String ECONOMY_FILE = "economy.yml";
 
     private final JavaPlugin plugin;
     private final NexusLogger logger;
     private final Path dataDirectory;
-    private final AtomicReference<ConfigBundle> bundleRef = new AtomicReference<>();
+    private final ExecutorService ioExecutor;
+    private final ConfigValidator validator = new ConfigValidator();
+    private final ConfigHotSwap hotSwap = new ConfigHotSwap();
 
     public ConfigManager(JavaPlugin plugin, NexusLogger logger) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.dataDirectory = plugin.getDataFolder().toPath();
+        this.ioExecutor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors() / 2),
+                new NamedThreadFactory("Nexus-Config", true, logger));
     }
 
-    public LoadResult initialLoad() {
+    public ReloadReport initialLoad() {
         ensureDefaults();
         try {
-            ConfigBundle bundle = loadBundle();
-            bundleRef.set(bundle);
-            return LoadResult.success(bundle);
-        } catch (ConfigLoadException exception) {
-            logger.error("Configuration invalide lors du démarrage", exception);
-            return LoadResult.failure(exception.errors());
+            LoadResult result = CompletableFuture.supplyAsync(this::loadAll, ioExecutor).join();
+            ReloadReport.Builder builder = result.report();
+            if (builder.hasErrors()) {
+                builder.version(0L);
+                return builder.buildFailure();
+            }
+            ConfigBundle bundle = new ConfigBundle(1L, result.core(), result.messages(), result.maps(), result.economy(), Instant.now());
+            hotSwap.initialize(bundle);
+            builder.version(bundle.version());
+            logger.info("Configuration initialisée (version " + bundle.version() + ")");
+            return builder.buildSuccess();
+        } catch (CompletionException exception) {
+            Throwable cause = exception.getCause() == null ? exception : exception.getCause();
+            logger.error("Impossible de charger la configuration", cause);
+            ReloadReport.Builder builder = ReloadReport.builder(Instant.now());
+            builder.error(CONFIG_FILE, "<root>", cause.getMessage() == null ? cause.toString() : cause.getMessage());
+            builder.version(0L);
+            return builder.buildFailure();
         }
     }
 
-    public LoadResult reloadFromDisk() {
-        try {
-            ConfigBundle bundle = loadBundle();
-            return LoadResult.success(bundle);
-        } catch (ConfigLoadException exception) {
-            logger.warn("Rechargement de configuration impossible", exception);
-            return LoadResult.failure(exception.errors());
-        }
+    public CompletionStage<ReloadReport> reloadAllAsync(CommandSender initiator) {
+        Objects.requireNonNull(initiator, "initiator");
+        ensureDefaults();
+        logger.info("Rechargement demandé par " + initiator.getName());
+        return CompletableFuture.supplyAsync(this::loadAll, ioExecutor)
+                .thenCompose(result -> {
+                    ReloadReport.Builder builder = result.report();
+                    if (builder.hasErrors()) {
+                        builder.version(hotSwap.currentVersion());
+                        return CompletableFuture.completedFuture(builder.buildFailure());
+                    }
+                    long version = hotSwap.currentVersion() + 1;
+                    ConfigBundle bundle = new ConfigBundle(version, result.core(), result.messages(), result.maps(), result.economy(), Instant.now());
+                    builder.version(bundle.version());
+                    return callSync(() -> {
+                        hotSwap.commit(bundle);
+                        logger.info("Configuration rechargée (version " + bundle.version() + ")");
+                        return builder.buildSuccess();
+                    });
+                })
+                .exceptionally(throwable -> {
+                    Throwable cause = throwable instanceof CompletionException && throwable.getCause() != null
+                            ? throwable.getCause()
+                            : throwable;
+                    logger.error("Erreur lors du rechargement de la configuration", cause);
+                    ReloadReport.Builder builder = ReloadReport.builder(Instant.now());
+                    builder.error(CONFIG_FILE, "<root>", cause.getMessage() == null ? cause.toString() : cause.getMessage());
+                    builder.version(hotSwap.currentVersion());
+                    return builder.buildFailure();
+                });
+    }
+
+    public CoreConfig getCore() {
+        return currentBundle().core();
+    }
+
+    public MessageBundle getMessages() {
+        return currentBundle().messages();
+    }
+
+    public MapsCatalogConfig getMaps() {
+        return currentBundle().maps();
+    }
+
+    public EconomyConfig getEconomy() {
+        return currentBundle().economy();
+    }
+
+    public long version() {
+        return hotSwap.currentVersion();
     }
 
     public ConfigBundle currentBundle() {
-        return Optional.ofNullable(bundleRef.get())
-                .orElseThrow(() -> new IllegalStateException("Configuration not loaded yet"));
+        return hotSwap.current();
     }
 
-    public void applyBundle(ConfigBundle bundle) {
-        bundleRef.set(bundle);
+    private LoadResult loadAll() {
+        ReloadReport.Builder builder = ReloadReport.builder(Instant.now());
+
+        ConfigValidator.IssueCollector coreIssues = validator.collector(CONFIG_FILE, builder);
+        YamlConfiguration coreYaml = loadYaml(CONFIG_FILE, coreIssues);
+        CoreConfig core = validator.validateCore(coreYaml, coreIssues);
+
+        ConfigValidator.IssueCollector messageIssues = validator.collector(MESSAGES_FILE, builder);
+        YamlConfiguration messageYaml = loadYaml(MESSAGES_FILE, messageIssues);
+        MessageBundle messages = validator.validateMessages(messageYaml, messageIssues);
+
+        ConfigValidator.IssueCollector mapsIssues = validator.collector(MAPS_FILE, builder);
+        YamlConfiguration mapsYaml = loadYaml(MAPS_FILE, mapsIssues);
+        MapsCatalogConfig maps = validator.validateMaps(mapsYaml, mapsIssues);
+
+        ConfigValidator.IssueCollector economyIssues = validator.collector(ECONOMY_FILE, builder);
+        YamlConfiguration economyYaml = loadYaml(ECONOMY_FILE, economyIssues);
+        EconomyConfig economy = validator.validateEconomy(economyYaml, economyIssues);
+
+        return new LoadResult(core, messages, maps, economy, builder);
+    }
+
+    private YamlConfiguration loadYaml(String resourceName, ConfigValidator.IssueCollector issues) {
+        File file = dataDirectory.resolve(resourceName).toFile();
+        YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            issues.error("<root>", "Lecture impossible: " + exception.getMessage());
+        }
+        applyDefaults(configuration, resourceName, issues);
+        return configuration;
+    }
+
+    private void applyDefaults(YamlConfiguration configuration, String resourceName, ConfigValidator.IssueCollector issues) {
+        try (InputStream inputStream = plugin.getResource(resourceName)) {
+            if (inputStream == null) {
+                issues.warn("<root>", "Ressource embarquée manquante: " + resourceName);
+                return;
+            }
+            YamlConfiguration defaults = new YamlConfiguration();
+            defaults.load(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            configuration.setDefaults(defaults);
+            configuration.options().copyDefaults(true);
+        } catch (IOException | InvalidConfigurationException exception) {
+            issues.warn("<root>", "Impossible de charger les valeurs par défaut pour " + resourceName + ": " + exception.getMessage());
+        }
     }
 
     private void ensureDefaults() {
@@ -82,13 +183,12 @@ public final class ConfigManager {
                 Files.createDirectories(dataDirectory);
             }
         } catch (IOException exception) {
-            throw new IllegalStateException("Unable to create plugin data directory", exception);
+            throw new IllegalStateException("Impossible de créer le dossier de données du plugin", exception);
         }
-
-        copyResourceIfMissing("config.yml");
-        copyResourceIfMissing("messages.yml");
-        copyResourceIfMissing("economy.yml");
-        copyResourceIfMissing("maps.yml");
+        copyResourceIfMissing(CONFIG_FILE);
+        copyResourceIfMissing(MESSAGES_FILE);
+        copyResourceIfMissing(MAPS_FILE);
+        copyResourceIfMissing(ECONOMY_FILE);
     }
 
     private void copyResourceIfMissing(String resource) {
@@ -98,246 +198,27 @@ public final class ConfigManager {
         }
     }
 
-    private ConfigBundle loadBundle() throws ConfigLoadException {
-        File configFile = dataDirectory.resolve("config.yml").toFile();
-        File messagesFile = dataDirectory.resolve("messages.yml").toFile();
-
-        YamlConfiguration configYaml = YamlConfiguration.loadConfiguration(configFile);
-        applyDefaults(configYaml, "config.yml");
-        YamlConfiguration messagesYaml = YamlConfiguration.loadConfiguration(messagesFile);
-        applyDefaults(messagesYaml, "messages.yml");
-
-        List<String> errors = new ArrayList<>();
-        NexusConfig config = parseConfig(configYaml, errors);
-        MessageBundle messages = parseMessages(messagesYaml, config.language(), errors);
-
-        if (!errors.isEmpty()) {
-            throw new ConfigLoadException(errors);
-        }
-
-        return new ConfigBundle(config, messages, Instant.now());
-    }
-
-    private void applyDefaults(YamlConfiguration configuration, String resourceName) {
-        try (InputStream inputStream = plugin.getResource(resourceName)) {
-            if (inputStream == null) {
-                return;
+    private <T> CompletionStage<T> callSync(Supplier<T> supplier) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            try {
+                future.complete(supplier.get());
+            } catch (Throwable throwable) {
+                future.completeExceptionally(throwable);
             }
-            YamlConfiguration defaults = new YamlConfiguration();
-            defaults.load(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-            configuration.setDefaults(defaults);
-            configuration.options().copyDefaults(true);
-        } catch (IOException | InvalidConfigurationException exception) {
-            logger.warn("Impossible de charger les valeurs par défaut pour " + resourceName, exception);
-        }
+        });
+        return future;
     }
 
-    private NexusConfig parseConfig(FileConfiguration yaml, List<String> errors) {
-        String serverMode = yaml.getString("server.mode", "nexus");
-        String languageTag = yaml.getString("server.language", DEFAULT_LANGUAGE);
-        Locale language = Locale.forLanguageTag(languageTag);
-        String timezoneId = yaml.getString("server.timezone", DEFAULT_TIMEZONE);
-        ZoneId timezone;
-        try {
-            timezone = ZoneId.of(timezoneId);
-        } catch (Exception exception) {
-            errors.add("server.timezone: " + exception.getMessage());
-            timezone = ZoneId.of(DEFAULT_TIMEZONE);
-        }
-
-        int hudHz = yaml.getInt("arena.hud_hz", yaml.getInt("perf.hud_hz", 5));
-        if (hudHz <= 0) {
-            errors.add("arena.hud_hz doit être > 0");
-            hudHz = 5;
-        }
-        int scoreboardHz = yaml.getInt("arena.scoreboard_hz", yaml.getInt("perf.scoreboard_hz", 3));
-        if (scoreboardHz <= 0) {
-            errors.add("arena.scoreboard_hz doit être > 0");
-            scoreboardHz = 3;
-        }
-        int particlesSoft = yaml.getInt("arena.particles.soft_cap", yaml.getInt("perf.particles_soft_cap", 1200));
-        int particlesHard = yaml.getInt("arena.particles.hard_cap", yaml.getInt("perf.particles_hard_cap", 2000));
-        if (particlesHard < particlesSoft) {
-            errors.add("arena.particles.hard_cap doit être >= arena.particles.soft_cap");
-            particlesHard = particlesSoft;
-        }
-        int maxEntities = yaml.getInt("arena.budget.max_entities", 200);
-        int maxItems = yaml.getInt("arena.budget.max_items", 128);
-        int maxProjectiles = yaml.getInt("arena.budget.max_projectiles", 64);
-        if (maxEntities < 0 || maxItems < 0 || maxProjectiles < 0) {
-            errors.add("arena.budget doit contenir des valeurs >= 0");
-            maxEntities = Math.max(0, maxEntities);
-            maxItems = Math.max(0, maxItems);
-            maxProjectiles = Math.max(0, maxProjectiles);
-        }
-
-        boolean ioVirtual = yaml.getBoolean("executors.io.virtual", false);
-        int ioMaxThreads = yaml.getInt("executors.io.maxThreads", 12);
-        if (ioMaxThreads <= 0) {
-            errors.add("executors.io.maxThreads doit être > 0");
-            ioMaxThreads = 4;
-        }
-        long ioKeepAliveMs = yaml.getLong("executors.io.keepAliveMs", 30_000L);
-        if (ioKeepAliveMs < 0L) {
-            errors.add("executors.io.keepAliveMs doit être >= 0");
-            ioKeepAliveMs = 30_000L;
-        }
-        int availableCores = Math.max(1, Runtime.getRuntime().availableProcessors());
-        int defaultComputeSize = Math.max(2, Math.min(availableCores, 4));
-        int computeSize = yaml.getInt("executors.compute.size", defaultComputeSize);
-        if (computeSize <= 0) {
-            errors.add("executors.compute.size doit être > 0");
-            computeSize = defaultComputeSize;
-        }
-        long shutdownAwait = yaml.getLong("executors.shutdown.awaitSeconds", 5L);
-        if (shutdownAwait < 0L) {
-            errors.add("executors.shutdown.awaitSeconds doit être >= 0");
-            shutdownAwait = 5L;
-        }
-        long shutdownForce = yaml.getLong("executors.shutdown.forceCancelSeconds", 3L);
-        if (shutdownForce < 0L) {
-            errors.add("executors.shutdown.forceCancelSeconds doit être >= 0");
-            shutdownForce = 3L;
-        }
-        int mainCheckInterval = yaml.getInt("executors.scheduler.main_check_interval_ticks", 1);
-        if (mainCheckInterval <= 0) {
-            errors.add("executors.scheduler.main_check_interval_ticks doit être > 0");
-            mainCheckInterval = 1;
-        }
-
-        boolean dbEnabled = yaml.getBoolean("database.enabled", true);
-        String jdbcUrl = yaml.getString("database.jdbc", DEFAULT_JDBC);
-        if (jdbcUrl == null || jdbcUrl.isBlank()) {
-            errors.add("database.jdbc manquant");
-            jdbcUrl = DEFAULT_JDBC;
-        }
-        String username = yaml.getString("database.user", DEFAULT_DB_USER);
-        if (username == null || username.isBlank()) {
-            errors.add("database.user manquant");
-            username = DEFAULT_DB_USER;
-        }
-        String password = yaml.getString("database.password", DEFAULT_DB_PASSWORD);
-        if (password == null) {
-            password = DEFAULT_DB_PASSWORD;
-        }
-        int maxSize = yaml.getInt("database.pool.maxSize", 10);
-        if (maxSize <= 0) {
-            errors.add("database.pool.maxSize doit être > 0");
-            maxSize = 10;
-        }
-        int minIdle = yaml.getInt("database.pool.minIdle", 2);
-        if (minIdle < 0) {
-            errors.add("database.pool.minIdle doit être >= 0");
-            minIdle = 0;
-        }
-        long timeoutMs = yaml.getLong("database.pool.connTimeoutMs", 3000L);
-        if (timeoutMs <= 0L) {
-            errors.add("database.pool.connTimeoutMs doit être > 0");
-            timeoutMs = 3000L;
-        }
-
-        boolean exposeServices = yaml.getBoolean("services.expose-bukkit-services", false);
-        long startTimeoutMs = yaml.getLong("timeouts.startMs", 5000L);
-        if (startTimeoutMs <= 0L) {
-            errors.add("timeouts.startMs doit être > 0");
-            startTimeoutMs = 5000L;
-        }
-        long stopTimeoutMs = yaml.getLong("timeouts.stopMs", 3000L);
-        if (stopTimeoutMs <= 0L) {
-            errors.add("timeouts.stopMs doit être > 0");
-            stopTimeoutMs = 3000L;
-        }
-        boolean degradedEnabled = yaml.getBoolean("degraded-mode.enabled", true);
-        boolean degradedBanner = yaml.getBoolean("degraded-mode.banner", true);
-        int queueTick = yaml.getInt("queue.tick_hz", 5);
-        if (queueTick <= 0) {
-            errors.add("queue.tick_hz doit être > 0");
-            queueTick = 5;
-        }
-        int vipWeight = yaml.getInt("queue.vip_weight", 0);
-        if (vipWeight < 0) {
-            errors.add("queue.vip_weight doit être >= 0");
-            vipWeight = 0;
-        }
-
-        NexusConfig.ArenaSettings arenaSettings;
-        NexusConfig.ExecutorSettings executorSettings;
-        NexusConfig.PoolSettings poolSettings;
-        try {
-            arenaSettings = new NexusConfig.ArenaSettings(hudHz, scoreboardHz, particlesSoft, particlesHard,
-                    maxEntities, maxItems, maxProjectiles);
-        } catch (IllegalArgumentException exception) {
-            errors.add("arena: " + exception.getMessage());
-            arenaSettings = new NexusConfig.ArenaSettings(5, 3, particlesSoft, particlesHard, maxEntities, maxItems, maxProjectiles);
-        }
-        NexusConfig.ExecutorSettings.IoSettings ioSettings;
-        NexusConfig.ExecutorSettings.ComputeSettings computeSettings;
-        NexusConfig.ExecutorSettings.ShutdownSettings shutdownSettings;
-        NexusConfig.ExecutorSettings.SchedulerSettings schedulerSettings;
-        try {
-            ioSettings = new NexusConfig.ExecutorSettings.IoSettings(ioVirtual, ioMaxThreads, ioKeepAliveMs);
-        } catch (IllegalArgumentException exception) {
-            errors.add("executors.io: " + exception.getMessage());
-            ioSettings = new NexusConfig.ExecutorSettings.IoSettings(false, Math.max(2, ioMaxThreads), Math.max(0L, ioKeepAliveMs));
-        }
-        try {
-            computeSettings = new NexusConfig.ExecutorSettings.ComputeSettings(computeSize);
-        } catch (IllegalArgumentException exception) {
-            errors.add("executors.compute: " + exception.getMessage());
-            computeSettings = new NexusConfig.ExecutorSettings.ComputeSettings(Math.max(1, computeSize));
-        }
-        try {
-            shutdownSettings = new NexusConfig.ExecutorSettings.ShutdownSettings(shutdownAwait, shutdownForce);
-        } catch (IllegalArgumentException exception) {
-            errors.add("executors.shutdown: " + exception.getMessage());
-            shutdownSettings = new NexusConfig.ExecutorSettings.ShutdownSettings(Math.max(0L, shutdownAwait), Math.max(0L, shutdownForce));
-        }
-        try {
-            schedulerSettings = new NexusConfig.ExecutorSettings.SchedulerSettings(mainCheckInterval);
-        } catch (IllegalArgumentException exception) {
-            errors.add("executors.scheduler: " + exception.getMessage());
-            schedulerSettings = new NexusConfig.ExecutorSettings.SchedulerSettings(Math.max(1, mainCheckInterval));
-        }
-        executorSettings = new NexusConfig.ExecutorSettings(ioSettings, computeSettings, shutdownSettings, schedulerSettings);
-        try {
-            poolSettings = new NexusConfig.PoolSettings(maxSize, minIdle, timeoutMs);
-        } catch (IllegalArgumentException exception) {
-            errors.add("database.pool: " + exception.getMessage());
-            poolSettings = new NexusConfig.PoolSettings(10, 2, 3000L);
-        }
-        NexusConfig.DatabaseSettings databaseSettings =
-                new NexusConfig.DatabaseSettings(dbEnabled, jdbcUrl, username, password, poolSettings);
-        NexusConfig.ServiceSettings serviceSettings = new NexusConfig.ServiceSettings(exposeServices);
-        NexusConfig.TimeoutSettings timeoutSettings = new NexusConfig.TimeoutSettings(startTimeoutMs, stopTimeoutMs);
-        NexusConfig.DegradedModeSettings degradedModeSettings = new NexusConfig.DegradedModeSettings(degradedEnabled, degradedBanner);
-        NexusConfig.QueueSettings queueSettings = new NexusConfig.QueueSettings(queueTick, vipWeight);
-
-        return new NexusConfig(serverMode, language, timezone, arenaSettings, executorSettings, databaseSettings,
-                serviceSettings, timeoutSettings, degradedModeSettings, queueSettings);
+    @Override
+    public void close() {
+        ioExecutor.shutdownNow();
     }
 
-    private MessageBundle parseMessages(FileConfiguration yaml, Locale locale, List<String> errors) {
-        Map<String, String> map = new LinkedHashMap<>();
-        for (String key : yaml.getKeys(true)) {
-            Object value = yaml.get(key);
-            if (value instanceof String stringValue) {
-                map.put(key, stringValue);
-            }
-        }
-        if (map.isEmpty()) {
-            errors.add("messages: aucune entrée chargée");
-        }
-        return new MessageBundle(map, locale, Instant.now());
-    }
-
-    public record LoadResult(boolean success, ConfigBundle bundle, List<String> errors) {
-
-        public static LoadResult success(ConfigBundle bundle) {
-            return new LoadResult(true, bundle, List.of());
-        }
-
-        public static LoadResult failure(List<String> errors) {
-            return new LoadResult(false, null, List.copyOf(errors));
-        }
+    private record LoadResult(CoreConfig core,
+                              MessageBundle messages,
+                              MapsCatalogConfig maps,
+                              EconomyConfig economy,
+                              ReloadReport.Builder report) {
     }
 }

--- a/src/main/java/com/heneria/nexus/config/ConfigValidator.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigValidator.java
@@ -1,0 +1,475 @@
+package com.heneria.nexus.config;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+/**
+ * Performs validation of each configuration file and materialises the
+ * immutable runtime views consumed by the rest of the plugin.
+ */
+public final class ConfigValidator {
+
+    private static final Locale DEFAULT_LOCALE = Locale.forLanguageTag("fr");
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Europe/Paris");
+    private static final String DEFAULT_SERVER_MODE = "nexus";
+    private static final Set<String> SUPPORTED_MAP_MODES = Set.of(
+            "1v1", "2v2", "3v3", "4v4", "5v5", "ffa", "rush", "casual", "competitive");
+
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+
+    public IssueCollector collector(String file, ReloadReport.Builder builder) {
+        return new IssueCollector(file, builder);
+    }
+
+    public CoreConfig validateCore(YamlConfiguration yaml, IssueCollector issues) {
+        Objects.requireNonNull(yaml, "yaml");
+        Objects.requireNonNull(issues, "issues");
+
+        String mode = readString(yaml, "server.mode", DEFAULT_SERVER_MODE, issues, false);
+        Locale locale = parseLocale(readString(yaml, "server.language", DEFAULT_LOCALE.toLanguageTag(), issues, false), issues);
+        ZoneId zone = parseZone(readString(yaml, "server.timezone", DEFAULT_ZONE.getId(), issues, false), issues);
+
+        int hudHz = boundedInt(yaml, "perf.hud_hz", 5, 1, 10, issues);
+        int scoreboardHz = boundedInt(yaml, "perf.scoreboard_hz", 3, 2, 5, issues);
+        int particlesSoft = positiveInt(yaml, "perf.particles_soft_cap", 1200, issues, true);
+        int particlesHard = positiveInt(yaml, "perf.particles_hard_cap", 2000, issues, true);
+        if (particlesHard <= particlesSoft) {
+            issues.error("perf.particles_hard_cap", "Doit être strictement supérieur à perf.particles_soft_cap");
+            particlesHard = particlesSoft + 1;
+        }
+        int maxEntities = nonNegativeInt(yaml, "perf.budget.max_entities", 200, issues);
+        int maxItems = nonNegativeInt(yaml, "perf.budget.max_items", 128, issues);
+        int maxProjectiles = nonNegativeInt(yaml, "perf.budget.max_projectiles", 64, issues);
+
+        boolean ioVirtual = yaml.getBoolean("threads.io_virtual", yaml.getBoolean("executors.io.virtual", false));
+        int ioPool = positiveInt(yaml, "threads.io_pool", yaml.getInt("executors.io.maxThreads", 3), issues, false);
+        long ioKeepAlive = positiveLong(yaml, "threads.io_keep_alive_ms", yaml.getLong("executors.io.keepAliveMs", 30_000L), issues, false);
+        int computePool = positiveInt(yaml, "threads.compute_pool", yaml.getInt("executors.compute.size", 1), issues, false);
+        long shutdownAwait = positiveLong(yaml, "threads.shutdown.await_seconds", yaml.getLong("executors.shutdown.awaitSeconds", 5L), issues, false);
+        long shutdownForce = positiveLong(yaml, "threads.shutdown.force_cancel_seconds", yaml.getLong("executors.shutdown.forceCancelSeconds", 3L), issues, false);
+        int schedulerInterval = positiveInt(yaml, "threads.scheduler.main_check_interval_ticks", yaml.getInt("executors.scheduler.main_check_interval_ticks", 1), issues, false);
+
+        boolean databaseEnabled = yaml.getBoolean("database.enabled", true);
+        String jdbc = readString(yaml, "database.jdbc", "jdbc:mariadb://127.0.0.1:3306/nexus", issues, true);
+        if (databaseEnabled && (jdbc == null || jdbc.isBlank())) {
+            issues.error("database.jdbc", "Obligatoire lorsque database.enabled=true");
+            jdbc = "jdbc:mariadb://127.0.0.1:3306/nexus";
+        }
+        String user = readString(yaml, "database.user", "nexus", issues, true);
+        if (databaseEnabled && (user == null || user.isBlank())) {
+            issues.error("database.user", "Obligatoire lorsque database.enabled=true");
+            user = "nexus";
+        }
+        String password = readString(yaml, "database.password", "change_me", issues, false);
+        int poolMax = positiveInt(yaml, "database.pool.maxSize", 10, issues, false);
+        int poolMin = nonNegativeInt(yaml, "database.pool.minIdle", 2, issues);
+        long poolTimeout = positiveLong(yaml, "database.pool.connTimeoutMs", 3000L, issues, true);
+
+        boolean exposeServices = yaml.getBoolean("services.expose-bukkit-services", false);
+        long timeoutStart = positiveLong(yaml, "timeouts.startMs", 5000L, issues, true);
+        long timeoutStop = positiveLong(yaml, "timeouts.stopMs", 3000L, issues, true);
+        boolean degradedEnabled = yaml.getBoolean("degraded-mode.enabled", true);
+        boolean degradedBanner = yaml.getBoolean("degraded-mode.banner", true);
+        int queueHz = positiveInt(yaml, "queue.tick_hz", 5, issues, true);
+        int queueVip = nonNegativeInt(yaml, "queue.vip_weight", 0, issues);
+
+        CoreConfig.ArenaSettings arenaSettings;
+        CoreConfig.ExecutorSettings executorSettings;
+        CoreConfig.PoolSettings poolSettings;
+        CoreConfig.DatabaseSettings databaseSettings;
+        CoreConfig.ServiceSettings serviceSettings = new CoreConfig.ServiceSettings(exposeServices);
+        CoreConfig.TimeoutSettings timeoutSettings;
+        CoreConfig.DegradedModeSettings degradedModeSettings = new CoreConfig.DegradedModeSettings(degradedEnabled, degradedBanner);
+        CoreConfig.QueueSettings queueSettings;
+
+        try {
+            arenaSettings = new CoreConfig.ArenaSettings(hudHz, scoreboardHz, particlesSoft, particlesHard,
+                    maxEntities, maxItems, maxProjectiles);
+        } catch (IllegalArgumentException exception) {
+            issues.error("perf", exception.getMessage());
+            arenaSettings = new CoreConfig.ArenaSettings(5, 3, 1200, 2000, 200, 128, 64);
+        }
+        CoreConfig.ExecutorSettings.IoSettings ioSettings;
+        try {
+            ioSettings = new CoreConfig.ExecutorSettings.IoSettings(ioVirtual, Math.max(1, ioPool), Math.max(0L, ioKeepAlive));
+        } catch (IllegalArgumentException exception) {
+            issues.error("threads.io_pool", exception.getMessage());
+            ioSettings = new CoreConfig.ExecutorSettings.IoSettings(false, 3, 30_000L);
+        }
+        CoreConfig.ExecutorSettings.ComputeSettings computeSettings;
+        try {
+            computeSettings = new CoreConfig.ExecutorSettings.ComputeSettings(Math.max(1, computePool));
+        } catch (IllegalArgumentException exception) {
+            issues.error("threads.compute_pool", exception.getMessage());
+            computeSettings = new CoreConfig.ExecutorSettings.ComputeSettings(1);
+        }
+        CoreConfig.ExecutorSettings.ShutdownSettings shutdownSettings;
+        try {
+            shutdownSettings = new CoreConfig.ExecutorSettings.ShutdownSettings(Math.max(0L, shutdownAwait), Math.max(0L, shutdownForce));
+        } catch (IllegalArgumentException exception) {
+            issues.error("threads.shutdown", exception.getMessage());
+            shutdownSettings = new CoreConfig.ExecutorSettings.ShutdownSettings(5L, 3L);
+        }
+        CoreConfig.ExecutorSettings.SchedulerSettings schedulerSettings;
+        try {
+            schedulerSettings = new CoreConfig.ExecutorSettings.SchedulerSettings(Math.max(1, schedulerInterval));
+        } catch (IllegalArgumentException exception) {
+            issues.error("threads.scheduler.main_check_interval_ticks", exception.getMessage());
+            schedulerSettings = new CoreConfig.ExecutorSettings.SchedulerSettings(1);
+        }
+        executorSettings = new CoreConfig.ExecutorSettings(ioSettings, computeSettings, shutdownSettings, schedulerSettings);
+
+        try {
+            poolSettings = new CoreConfig.PoolSettings(poolMax, poolMin, poolTimeout);
+        } catch (IllegalArgumentException exception) {
+            issues.error("database.pool", exception.getMessage());
+            poolSettings = new CoreConfig.PoolSettings(10, 2, 3000L);
+        }
+        databaseSettings = new CoreConfig.DatabaseSettings(databaseEnabled, jdbc, user, password, poolSettings);
+
+        try {
+            timeoutSettings = new CoreConfig.TimeoutSettings(timeoutStart, timeoutStop);
+        } catch (IllegalArgumentException exception) {
+            issues.error("timeouts", exception.getMessage());
+            timeoutSettings = new CoreConfig.TimeoutSettings(5000L, 3000L);
+        }
+        try {
+            queueSettings = new CoreConfig.QueueSettings(queueHz, queueVip);
+        } catch (IllegalArgumentException exception) {
+            issues.error("queue", exception.getMessage());
+            queueSettings = new CoreConfig.QueueSettings(5, 0);
+        }
+
+        return new CoreConfig(mode, locale, zone, arenaSettings, executorSettings, databaseSettings,
+                serviceSettings, timeoutSettings, degradedModeSettings, queueSettings);
+    }
+
+    public MessageBundle validateMessages(YamlConfiguration yaml, IssueCollector issues) {
+        Objects.requireNonNull(yaml, "yaml");
+        Objects.requireNonNull(issues, "issues");
+
+        Locale locale = parseLocale(readString(yaml, "meta.locale", DEFAULT_LOCALE.toLanguageTag(), issues, false), issues);
+        MessageBundle.Builder builder = MessageBundle.builder(locale, Instant.now());
+
+        if (yaml.contains("prefix")) {
+            String rawPrefix = yaml.getString("prefix");
+            if (rawPrefix != null) {
+                parseComponent(rawPrefix, "prefix", issues).ifPresent(component -> builder.prefix(rawPrefix, component));
+            }
+        }
+
+        ConfigurationSection root = yaml;
+        for (String key : root.getKeys(false)) {
+            if (key.equals("meta") || key.equals("prefix")) {
+                continue;
+            }
+            Object value = root.get(key);
+            consumeValue(builder, key, value, issues);
+        }
+
+        if (builder.isEmpty()) {
+            issues.error("messages", "Aucune entrée valide dans messages.yml");
+        }
+
+        return builder.build();
+    }
+
+    private void consumeValue(MessageBundle.Builder builder, String path, Object value, IssueCollector issues) {
+        if (value instanceof ConfigurationSection section) {
+            for (String child : section.getKeys(false)) {
+                consumeValue(builder, path + "." + child, section.get(child), issues);
+            }
+            return;
+        }
+        if (value instanceof String string) {
+            parseComponent(string, path, issues).ifPresent(component -> builder.add(path, string, component));
+            return;
+        }
+        if (value instanceof List<?> list) {
+            List<Component> components = new ArrayList<>();
+            List<String> raws = new ArrayList<>();
+            int index = 0;
+            for (Object element : list) {
+                if (!(element instanceof String entry)) {
+                    issues.warn(path, "Entrée de liste non textuelle ignorée (index=" + index + ")");
+                    index++;
+                    continue;
+                }
+                Optional<Component> parsed = parseComponent(entry, path + "[" + index + "]", issues);
+                parsed.ifPresent(component -> {
+                    raws.add(entry);
+                    components.add(component);
+                });
+                index++;
+            }
+            if (!components.isEmpty()) {
+                builder.addList(path, raws, components);
+            }
+            return;
+        }
+        issues.warn(path, "Type non supporté: " + (value == null ? "null" : value.getClass().getSimpleName()));
+    }
+
+    private Optional<Component> parseComponent(String raw, String path, IssueCollector issues) {
+        try {
+            return Optional.of(miniMessage.deserialize(raw));
+        } catch (Exception exception) {
+            issues.error(path, "MiniMessage invalide: " + exception.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public MapsCatalogConfig validateMaps(YamlConfiguration yaml, IssueCollector issues) {
+        Objects.requireNonNull(yaml, "yaml");
+        Objects.requireNonNull(issues, "issues");
+
+        ConfigurationSection rotationSection = yaml.getConfigurationSection("rotation");
+        boolean rotationEnabled = rotationSection != null && rotationSection.getBoolean("enabled", true);
+        boolean weightedPick = rotationSection != null && rotationSection.getBoolean("weighted_pick", true);
+        boolean vetoVote = rotationSection != null && rotationSection.getBoolean("veto_vote", true);
+        int minVotes = rotationSection != null ? nonNegativeInt(rotationSection, "min_votes_to_pick", 0, issues) : 0;
+        MapsCatalogConfig.RotationSettings rotation = new MapsCatalogConfig.RotationSettings(rotationEnabled, weightedPick, vetoVote, minVotes);
+
+        List<MapsCatalogConfig.MapEntry> entries = new ArrayList<>();
+        Set<String> ids = new HashSet<>();
+        List<?> mapsList = yaml.getList("maps");
+        if (mapsList == null || mapsList.isEmpty()) {
+            issues.warn("maps", "Aucune map définie dans maps.yml");
+        } else {
+            int index = 0;
+            for (Object element : mapsList) {
+                if (!(element instanceof java.util.Map<?, ?> map)) {
+                    issues.error("maps", "Entrée maps[" + index + "] invalide");
+                    index++;
+                    continue;
+                }
+                String id = Optional.ofNullable(map.get("id")).map(Object::toString).orElse(null);
+                if (id == null || id.isBlank()) {
+                    issues.error("maps", "maps[" + index + "].id manquant");
+                    index++;
+                    continue;
+                }
+                String normalized = id.toLowerCase(Locale.ROOT);
+                if (!ids.add(normalized)) {
+                    issues.error("maps", "maps[" + index + "] id dupliqué: " + id);
+                    index++;
+                    continue;
+                }
+                String display = Optional.ofNullable(map.get("display")).map(Object::toString).orElse(id);
+                int weight = parseInt(map.get("weight"), 1);
+                if (weight <= 0) {
+                    issues.error("maps", "maps[" + index + "].weight doit être >= 1");
+                    weight = 1;
+                }
+                Object modesRaw = map.get("modes");
+                List<String> modes = new ArrayList<>();
+                if (modesRaw instanceof List<?> list) {
+                    for (Object mode : list) {
+                        if (mode == null) {
+                            continue;
+                        }
+                        String value = mode.toString().trim();
+                        if (value.isEmpty()) {
+                            continue;
+                        }
+                        String normalizedMode = value.toLowerCase(Locale.ROOT);
+                        if (!SUPPORTED_MAP_MODES.contains(normalizedMode)) {
+                            issues.error("maps", "Mode inconnu " + value + " pour " + id);
+                        } else {
+                            modes.add(value);
+                        }
+                    }
+                }
+                if (modes.isEmpty()) {
+                    issues.warn("maps", "maps[" + index + "] sans modes valides");
+                }
+                try {
+                    entries.add(new MapsCatalogConfig.MapEntry(id, display, weight, List.copyOf(modes)));
+                } catch (IllegalArgumentException exception) {
+                    issues.error("maps", "maps[" + index + "]: " + exception.getMessage());
+                }
+                index++;
+            }
+        }
+        return new MapsCatalogConfig(rotation, List.copyOf(entries));
+    }
+
+    public EconomyConfig validateEconomy(YamlConfiguration yaml, IssueCollector issues) {
+        Objects.requireNonNull(yaml, "yaml");
+        Objects.requireNonNull(issues, "issues");
+
+        int winCoins = nonNegativeInt(yaml, "coins.win_per_match", 20, issues);
+        int loseCoins = nonNegativeInt(yaml, "coins.lose_per_match", 5, issues);
+        int firstWin = nonNegativeInt(yaml, "coins.first_win_bonus", 50, issues);
+        if (winCoins < loseCoins) {
+            issues.error("coins.win_per_match", "Doit être >= coins.lose_per_match");
+            winCoins = loseCoins;
+        }
+        EconomyConfig.CoinsSettings coinsSettings = new EconomyConfig.CoinsSettings(winCoins, loseCoins, firstWin);
+
+        int seasonDays = positiveInt(yaml, "battlepass.season_days", 90, issues, true);
+        int tiers = positiveInt(yaml, "battlepass.tiers", 65, issues, true);
+        int xpWin = nonNegativeInt(yaml, "battlepass.xp_per_match.win", 120, issues);
+        int xpLose = nonNegativeInt(yaml, "battlepass.xp_per_match.lose", 60, issues);
+        if (xpWin < xpLose) {
+            issues.error("battlepass.xp_per_match.win", "Doit être >= battlepass.xp_per_match.lose");
+            xpWin = xpLose;
+        }
+        EconomyConfig.XpPerMatch xpPerMatch = new EconomyConfig.XpPerMatch(xpWin, xpLose);
+        EconomyConfig.BattlePassSettings battlePassSettings = new EconomyConfig.BattlePassSettings(seasonDays, tiers, xpPerMatch);
+
+        return new EconomyConfig(coinsSettings, battlePassSettings);
+    }
+
+    private Locale parseLocale(String tag, IssueCollector issues) {
+        try {
+            Locale locale = Locale.forLanguageTag(tag == null ? DEFAULT_LOCALE.toLanguageTag() : tag);
+            if (locale == null || locale.toLanguageTag().isBlank()) {
+                throw new IllegalArgumentException("Locale vide");
+            }
+            return locale;
+        } catch (Exception exception) {
+            issues.warn("server.language", "Locale invalide, utilisation de fr" + " (" + exception.getMessage() + ")");
+            return DEFAULT_LOCALE;
+        }
+    }
+
+    private ZoneId parseZone(String id, IssueCollector issues) {
+        try {
+            return ZoneId.of(id == null ? DEFAULT_ZONE.getId() : id);
+        } catch (Exception exception) {
+            issues.warn("server.timezone", "Fuseau horaire invalide, utilisation de " + DEFAULT_ZONE.getId());
+            return DEFAULT_ZONE;
+        }
+    }
+
+    private String readString(YamlConfiguration yaml, String path, String def, IssueCollector issues, boolean required) {
+        if (!yaml.isSet(path)) {
+            if (required) {
+                issues.warn(path, "Valeur manquante, utilisation de " + def);
+            }
+            return def;
+        }
+        String value = yaml.getString(path);
+        if (value == null) {
+            if (required) {
+                issues.error(path, "Valeur manquante");
+            }
+            return def;
+        }
+        return value;
+    }
+
+    private int boundedInt(YamlConfiguration yaml, String path, int def, int min, int max, IssueCollector issues) {
+        int value = yaml.getInt(path, def);
+        if (!yaml.isSet(path)) {
+            issues.warn(path, "Valeur manquante, utilisation de " + def);
+            return value;
+        }
+        if (value < min || value > max) {
+            issues.error(path, "Doit être compris entre " + min + " et " + max + ");");
+            return Math.max(min, Math.min(max, value));
+        }
+        return value;
+    }
+
+    private int positiveInt(YamlConfiguration yaml, String path, int def, IssueCollector issues, boolean warnOnMissing) {
+        int value = yaml.getInt(path, def);
+        if (!yaml.isSet(path) && warnOnMissing) {
+            issues.warn(path, "Valeur manquante, utilisation de " + def);
+        }
+        if (value <= 0) {
+            issues.error(path, "Doit être > 0");
+            return Math.max(1, value);
+        }
+        return value;
+    }
+
+    private long positiveLong(YamlConfiguration yaml, String path, long def, IssueCollector issues, boolean warnOnMissing) {
+        long value = yaml.getLong(path, def);
+        if (!yaml.isSet(path) && warnOnMissing) {
+            issues.warn(path, "Valeur manquante, utilisation de " + def);
+        }
+        if (value <= 0L) {
+            issues.error(path, "Doit être > 0");
+            return Math.max(1L, value);
+        }
+        return value;
+    }
+
+    private int nonNegativeInt(YamlConfiguration yaml, String path, int def, IssueCollector issues) {
+        int value = yaml.getInt(path, def);
+        if (!yaml.isSet(path)) {
+            issues.warn(path, "Valeur manquante, utilisation de " + def);
+            return value;
+        }
+        if (value < 0) {
+            issues.error(path, "Doit être >= 0");
+            return Math.max(0, value);
+        }
+        return value;
+    }
+
+    private int nonNegativeInt(ConfigurationSection section, String path, int def, IssueCollector issues) {
+        if (!section.isSet(path)) {
+            issues.warn(path, "Valeur manquante, utilisation de " + def);
+            return def;
+        }
+        int value = section.getInt(path, def);
+        if (value < 0) {
+            issues.error(path, "Doit être >= 0");
+            return Math.max(0, value);
+        }
+        return value;
+    }
+
+    private int parseInt(Object value, int def) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Integer.parseInt(string.trim());
+            } catch (NumberFormatException ignored) {
+                return def;
+            }
+        }
+        return def;
+    }
+
+    public static final class IssueCollector {
+
+        private final String file;
+        private final ReloadReport.Builder builder;
+        private boolean hasErrors;
+
+        private IssueCollector(String file, ReloadReport.Builder builder) {
+            this.file = Objects.requireNonNull(file, "file");
+            this.builder = Objects.requireNonNull(builder, "builder");
+        }
+
+        public void warn(String path, String message) {
+            builder.warn(file, path, message);
+        }
+
+        public void error(String path, String message) {
+            hasErrors = true;
+            builder.error(file, path, message);
+        }
+
+        public boolean hasErrors() {
+            return hasErrors;
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * Immutable view over the main nexus configuration.
  */
-public final class NexusConfig {
+public final class CoreConfig {
 
     private final String serverMode;
     private final Locale language;
@@ -20,16 +20,16 @@ public final class NexusConfig {
     private final DegradedModeSettings degradedModeSettings;
     private final QueueSettings queueSettings;
 
-    public NexusConfig(String serverMode,
-                       Locale language,
-                       ZoneId timezone,
-                       ArenaSettings arenaSettings,
-                       ExecutorSettings executorSettings,
-                       DatabaseSettings databaseSettings,
-                       ServiceSettings serviceSettings,
-                       TimeoutSettings timeoutSettings,
-                       DegradedModeSettings degradedModeSettings,
-                       QueueSettings queueSettings) {
+    public CoreConfig(String serverMode,
+                      Locale language,
+                      ZoneId timezone,
+                      ArenaSettings arenaSettings,
+                      ExecutorSettings executorSettings,
+                      DatabaseSettings databaseSettings,
+                      ServiceSettings serviceSettings,
+                      TimeoutSettings timeoutSettings,
+                      DegradedModeSettings degradedModeSettings,
+                      QueueSettings queueSettings) {
         this.serverMode = Objects.requireNonNull(serverMode, "serverMode");
         this.language = Objects.requireNonNull(language, "language");
         this.timezone = Objects.requireNonNull(timezone, "timezone");

--- a/src/main/java/com/heneria/nexus/config/EconomyConfig.java
+++ b/src/main/java/com/heneria/nexus/config/EconomyConfig.java
@@ -1,0 +1,59 @@
+package com.heneria.nexus.config;
+
+import java.util.Objects;
+
+/**
+ * Immutable snapshot of the base economy configuration.
+ */
+public final class EconomyConfig {
+
+    private final CoinsSettings coins;
+    private final BattlePassSettings battlePass;
+
+    public EconomyConfig(CoinsSettings coins, BattlePassSettings battlePass) {
+        this.coins = Objects.requireNonNull(coins, "coins");
+        this.battlePass = Objects.requireNonNull(battlePass, "battlePass");
+    }
+
+    public CoinsSettings coins() {
+        return coins;
+    }
+
+    public BattlePassSettings battlePass() {
+        return battlePass;
+    }
+
+    public record CoinsSettings(int winPerMatch, int losePerMatch, int firstWinBonus) {
+        public CoinsSettings {
+            if (winPerMatch < 0 || losePerMatch < 0 || firstWinBonus < 0) {
+                throw new IllegalArgumentException("Economy rewards must be >= 0");
+            }
+            if (winPerMatch < losePerMatch) {
+                throw new IllegalArgumentException("winPerMatch must be >= losePerMatch");
+            }
+        }
+    }
+
+    public record BattlePassSettings(int seasonDays, int tiers, XpPerMatch xpPerMatch) {
+        public BattlePassSettings {
+            if (seasonDays <= 0) {
+                throw new IllegalArgumentException("seasonDays must be > 0");
+            }
+            if (tiers <= 0) {
+                throw new IllegalArgumentException("tiers must be > 0");
+            }
+            Objects.requireNonNull(xpPerMatch, "xpPerMatch");
+        }
+    }
+
+    public record XpPerMatch(int win, int lose) {
+        public XpPerMatch {
+            if (win < 0 || lose < 0) {
+                throw new IllegalArgumentException("XP rewards must be >= 0");
+            }
+            if (win < lose) {
+                throw new IllegalArgumentException("win XP must be >= lose XP");
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/MapsCatalogConfig.java
+++ b/src/main/java/com/heneria/nexus/config/MapsCatalogConfig.java
@@ -1,0 +1,56 @@
+package com.heneria.nexus.config;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Immutable view over the maps catalogue configuration.
+ */
+public final class MapsCatalogConfig {
+
+    private final RotationSettings rotation;
+    private final List<MapEntry> maps;
+
+    public MapsCatalogConfig(RotationSettings rotation, List<MapEntry> maps) {
+        this.rotation = Objects.requireNonNull(rotation, "rotation");
+        this.maps = List.copyOf(Objects.requireNonNull(maps, "maps"));
+    }
+
+    public RotationSettings rotation() {
+        return rotation;
+    }
+
+    public List<MapEntry> maps() {
+        return maps;
+    }
+
+    public record RotationSettings(boolean enabled,
+                                   boolean weightedPick,
+                                   boolean vetoVote,
+                                   int minVotesToPick) {
+        public RotationSettings {
+            if (minVotesToPick < 0) {
+                throw new IllegalArgumentException("minVotesToPick must be >= 0");
+            }
+        }
+    }
+
+    public record MapEntry(String id, String displayName, int weight, List<String> modes) {
+        public MapEntry {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(displayName, "displayName");
+            Objects.requireNonNull(modes, "modes");
+            if (!id.matches("[a-zA-Z0-9_]+")) {
+                throw new IllegalArgumentException("id must be alphanumeric with optional underscore");
+            }
+            if (weight <= 0) {
+                throw new IllegalArgumentException("weight must be > 0");
+            }
+        }
+
+        public String normalizedId() {
+            return id.toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/MessageBundle.java
+++ b/src/main/java/com/heneria/nexus/config/MessageBundle.java
@@ -2,32 +2,70 @@ package com.heneria.nexus.config;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import net.kyori.adventure.text.Component;
 
 /**
  * Immutable snapshot of the MiniMessage templates loaded from disk.
  */
 public final class MessageBundle {
 
-    private final Map<String, String> messages;
+    private final Map<String, MessageEntry> messages;
+    private final Map<String, List<MessageEntry>> listMessages;
     private final Locale locale;
     private final Instant loadedAt;
+    private final MessageEntry prefix;
 
-    public MessageBundle(Map<String, String> messages, Locale locale, Instant loadedAt) {
-        this.messages = Collections.unmodifiableMap(messages);
+    private MessageBundle(Map<String, MessageEntry> messages,
+                          Map<String, List<MessageEntry>> listMessages,
+                          MessageEntry prefix,
+                          Locale locale,
+                          Instant loadedAt) {
+        this.messages = Collections.unmodifiableMap(new LinkedHashMap<>(messages));
+        this.listMessages = Collections.unmodifiableMap(new LinkedHashMap<>(listMessages));
+        this.prefix = prefix;
         this.locale = Objects.requireNonNull(locale, "locale");
         this.loadedAt = Objects.requireNonNull(loadedAt, "loadedAt");
     }
 
-    public Optional<String> message(String key) {
+    public Optional<Component> message(String key) {
+        return Optional.ofNullable(messages.get(key)).map(MessageEntry::component);
+    }
+
+    public Optional<String> raw(String key) {
+        return Optional.ofNullable(messages.get(key)).map(MessageEntry::raw);
+    }
+
+    public Optional<MessageEntry> entry(String key) {
         return Optional.ofNullable(messages.get(key));
     }
 
-    public Map<String, String> messages() {
-        return messages;
+    public Optional<List<Component>> messageList(String key) {
+        return Optional.ofNullable(listMessages.get(key))
+                .map(entries -> entries.stream().map(MessageEntry::component).toList());
+    }
+
+    public Optional<List<String>> rawList(String key) {
+        return Optional.ofNullable(listMessages.get(key))
+                .map(entries -> entries.stream().map(MessageEntry::raw).toList());
+    }
+
+    public Optional<List<MessageEntry>> entryList(String key) {
+        return Optional.ofNullable(listMessages.get(key))
+                .map(List::copyOf);
+    }
+
+    public Optional<Component> prefix() {
+        return Optional.ofNullable(prefix).map(MessageEntry::component);
+    }
+
+    public Optional<String> rawPrefix() {
+        return Optional.ofNullable(prefix).map(MessageEntry::raw);
     }
 
     public Locale locale() {
@@ -36,5 +74,58 @@ public final class MessageBundle {
 
     public Instant loadedAt() {
         return loadedAt;
+    }
+
+    public static Builder builder(Locale locale, Instant loadedAt) {
+        return new Builder(locale, loadedAt);
+    }
+
+    public record MessageEntry(String key, String raw, Component component) {
+        public MessageEntry {
+            Objects.requireNonNull(key, "key");
+            Objects.requireNonNull(raw, "raw");
+            Objects.requireNonNull(component, "component");
+        }
+    }
+
+    public static final class Builder {
+
+        private final Locale locale;
+        private final Instant loadedAt;
+        private final Map<String, MessageEntry> singles = new LinkedHashMap<>();
+        private final Map<String, List<MessageEntry>> lists = new LinkedHashMap<>();
+        private MessageEntry prefix;
+
+        private Builder(Locale locale, Instant loadedAt) {
+            this.locale = Objects.requireNonNull(locale, "locale");
+            this.loadedAt = Objects.requireNonNull(loadedAt, "loadedAt");
+        }
+
+        public void add(String key, String raw, Component component) {
+            singles.put(key, new MessageEntry(key, raw, component));
+        }
+
+        public void addList(String key, List<String> raws, List<Component> components) {
+            if (raws.size() != components.size()) {
+                throw new IllegalArgumentException("raws and components size mismatch");
+            }
+            List<MessageEntry> entries = new java.util.ArrayList<>(raws.size());
+            for (int i = 0; i < raws.size(); i++) {
+                entries.add(new MessageEntry(key + "[" + i + "]", raws.get(i), components.get(i)));
+            }
+            lists.put(key, List.copyOf(entries));
+        }
+
+        public void prefix(String raw, Component component) {
+            this.prefix = new MessageEntry("prefix", raw, component);
+        }
+
+        public boolean isEmpty() {
+            return singles.isEmpty() && lists.isEmpty();
+        }
+
+        public MessageBundle build() {
+            return new MessageBundle(singles, lists, prefix, locale, loadedAt);
+        }
     }
 }

--- a/src/main/java/com/heneria/nexus/config/ReloadReport.java
+++ b/src/main/java/com/heneria/nexus/config/ReloadReport.java
@@ -1,0 +1,121 @@
+package com.heneria.nexus.config;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detailed report emitted after a configuration reload attempt.
+ */
+public final class ReloadReport {
+
+    private final boolean success;
+    private final long version;
+    private final Instant startedAt;
+    private final Instant completedAt;
+    private final Duration duration;
+    private final List<ValidationMessage> warnings;
+    private final List<ValidationMessage> errors;
+
+    private ReloadReport(boolean success,
+                         long version,
+                         Instant startedAt,
+                         Instant completedAt,
+                         Duration duration,
+                         List<ValidationMessage> warnings,
+                         List<ValidationMessage> errors) {
+        this.success = success;
+        this.version = version;
+        this.startedAt = Objects.requireNonNull(startedAt, "startedAt");
+        this.completedAt = Objects.requireNonNull(completedAt, "completedAt");
+        this.duration = Objects.requireNonNull(duration, "duration");
+        this.warnings = List.copyOf(warnings);
+        this.errors = List.copyOf(errors);
+    }
+
+    public boolean success() {
+        return success;
+    }
+
+    public long version() {
+        return version;
+    }
+
+    public Instant startedAt() {
+        return startedAt;
+    }
+
+    public Instant completedAt() {
+        return completedAt;
+    }
+
+    public Duration duration() {
+        return duration;
+    }
+
+    public List<ValidationMessage> warnings() {
+        return warnings;
+    }
+
+    public List<ValidationMessage> errors() {
+        return errors;
+    }
+
+    public static Builder builder(Instant startedAt) {
+        return new Builder(startedAt);
+    }
+
+    /**
+     * Helper used to accumulate warnings and errors while keeping
+     * track of the reload timings.
+     */
+    public static final class Builder {
+
+        private final Instant startedAt;
+        private final List<ValidationMessage> warnings = new ArrayList<>();
+        private final List<ValidationMessage> errors = new ArrayList<>();
+        private long version;
+
+        private Builder(Instant startedAt) {
+            this.startedAt = Objects.requireNonNull(startedAt, "startedAt");
+        }
+
+        public void warn(String file, String path, String message) {
+            warnings.add(new ValidationMessage(file, path, message));
+        }
+
+        public void error(String file, String path, String message) {
+            errors.add(new ValidationMessage(file, path, message));
+        }
+
+        public boolean hasErrors() {
+            return !errors.isEmpty();
+        }
+
+        public void version(long version) {
+            this.version = version;
+        }
+
+        public ReloadReport buildSuccess() {
+            Instant completed = Instant.now();
+            return new ReloadReport(true, version, startedAt, completed,
+                    Duration.between(startedAt, completed), warnings, errors);
+        }
+
+        public ReloadReport buildFailure() {
+            Instant completed = Instant.now();
+            return new ReloadReport(false, version, startedAt, completed,
+                    Duration.between(startedAt, completed), warnings, errors);
+        }
+    }
+
+    public record ValidationMessage(String file, String path, String message) {
+        public ValidationMessage {
+            Objects.requireNonNull(file, "file");
+            Objects.requireNonNull(path, "path");
+            Objects.requireNonNull(message, "message");
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/db/DbProvider.java
+++ b/src/main/java/com/heneria/nexus/db/DbProvider.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.db;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.service.LifecycleAware;
 import com.heneria.nexus.util.NexusLogger;
 import com.zaxxer.hikari.HikariConfig;
@@ -27,7 +27,7 @@ public final class DbProvider implements LifecycleAware {
 
     private final NexusLogger logger;
     private final AtomicReference<HikariDataSource> dataSourceRef = new AtomicReference<>();
-    private final AtomicReference<NexusConfig.DatabaseSettings> settingsRef = new AtomicReference<>();
+    private final AtomicReference<CoreConfig.DatabaseSettings> settingsRef = new AtomicReference<>();
     private final AtomicLong failedAttempts = new AtomicLong();
     private volatile boolean degraded;
 
@@ -35,7 +35,7 @@ public final class DbProvider implements LifecycleAware {
         this.logger = Objects.requireNonNull(logger, "logger");
     }
 
-    public CompletableFuture<Boolean> applyConfiguration(NexusConfig.DatabaseSettings settings, Executor executor) {
+    public CompletableFuture<Boolean> applyConfiguration(CoreConfig.DatabaseSettings settings, Executor executor) {
         settingsRef.set(settings);
         if (!settings.enabled()) {
             logger.info("Persistance désactivée, fonctionnement en mémoire");
@@ -78,7 +78,7 @@ public final class DbProvider implements LifecycleAware {
         }
     }
 
-    private HikariConfig toHikariConfig(NexusConfig.DatabaseSettings settings) {
+    private HikariConfig toHikariConfig(CoreConfig.DatabaseSettings settings) {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(settings.jdbcUrl());
         config.setUsername(settings.username());
@@ -115,7 +115,7 @@ public final class DbProvider implements LifecycleAware {
     public Diagnostics diagnostics() {
         HikariDataSource dataSource = dataSourceRef.get();
         HikariPoolMXBean pool = dataSource != null ? dataSource.getHikariPoolMXBean() : null;
-        NexusConfig.DatabaseSettings settings = settingsRef.get();
+        CoreConfig.DatabaseSettings settings = settingsRef.get();
         return new Diagnostics(
                 settings,
                 degraded,
@@ -152,7 +152,7 @@ public final class DbProvider implements LifecycleAware {
         T apply(Connection connection) throws SQLException;
     }
 
-    public record Diagnostics(NexusConfig.DatabaseSettings settings,
+    public record Diagnostics(CoreConfig.DatabaseSettings settings,
                               boolean degraded,
                               int activeConnections,
                               int idleConnections,

--- a/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
+++ b/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.scheduler;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.service.LifecycleAware;
 import com.heneria.nexus.util.NexusLogger;
 import java.util.EnumMap;
@@ -50,7 +50,7 @@ public final class RingScheduler implements LifecycleAware {
         profileIntervals.put(TaskProfile.SCOREBOARD, 7L);
     }
 
-    public void applyPerfSettings(NexusConfig.ArenaSettings arenaSettings) {
+    public void applyPerfSettings(CoreConfig.ArenaSettings arenaSettings) {
         profileIntervals.put(TaskProfile.HUD, hzToTicks(arenaSettings.hudHz()));
         profileIntervals.put(TaskProfile.SCOREBOARD, hzToTicks(arenaSettings.scoreboardHz()));
         tasks.values().forEach(task -> {

--- a/src/main/java/com/heneria/nexus/service/api/ArenaService.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaService.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.api;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.service.LifecycleAware;
 import java.util.Collection;
 import java.util.Optional;
@@ -58,7 +58,7 @@ public interface ArenaService extends LifecycleAware {
      * Applies new arena related settings. Called when the configuration is
      * reloaded.
      */
-    void applyArenaSettings(NexusConfig.ArenaSettings settings);
+    void applyArenaSettings(CoreConfig.ArenaSettings settings);
 
     interface ArenaListener {
         void onPhaseChange(ArenaHandle handle, ArenaPhase previous, ArenaPhase next);

--- a/src/main/java/com/heneria/nexus/service/api/EconomyService.java
+++ b/src/main/java/com/heneria/nexus/service/api/EconomyService.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.api;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.service.LifecycleAware;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -20,7 +20,7 @@ public interface EconomyService extends LifecycleAware {
 
     EconomyTransaction beginTransaction();
 
-    void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings);
+    void applyDegradedModeSettings(CoreConfig.DegradedModeSettings settings);
 
     boolean isDegraded();
 }

--- a/src/main/java/com/heneria/nexus/service/api/ProfileService.java
+++ b/src/main/java/com/heneria/nexus/service/api/ProfileService.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.api;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.service.LifecycleAware;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -16,7 +16,7 @@ public interface ProfileService extends LifecycleAware {
 
     void invalidate(UUID playerId);
 
-    void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings);
+    void applyDegradedModeSettings(CoreConfig.DegradedModeSettings settings);
 
     boolean isDegraded();
 }

--- a/src/main/java/com/heneria/nexus/service/api/QueueService.java
+++ b/src/main/java/com/heneria/nexus/service/api/QueueService.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.api;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.service.LifecycleAware;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,5 +38,5 @@ public interface QueueService extends LifecycleAware {
     /**
      * Applies configuration updates impacting the queue tick rate.
      */
-    void applySettings(NexusConfig.QueueSettings settings);
+    void applySettings(CoreConfig.QueueSettings settings);
 }

--- a/src/main/java/com/heneria/nexus/service/core/ArenaServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/ArenaServiceImpl.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.service.api.ArenaBudget;
 import com.heneria.nexus.service.api.ArenaCreationException;
@@ -40,7 +40,7 @@ public final class ArenaServiceImpl implements ArenaService {
     private final ExecutorManager executorManager;
     private final ConcurrentHashMap<UUID, ArenaHandle> arenas = new ConcurrentHashMap<>();
     private final CopyOnWriteArrayList<ArenaListener> listeners = new CopyOnWriteArrayList<>();
-    private final AtomicReference<NexusConfig.ArenaSettings> settingsRef;
+    private final AtomicReference<CoreConfig.ArenaSettings> settingsRef;
 
     public ArenaServiceImpl(JavaPlugin plugin,
                             NexusLogger logger,
@@ -49,7 +49,7 @@ public final class ArenaServiceImpl implements ArenaService {
                             Optional<ProfileService> profileService,
                             EconomyService economyService,
                             ExecutorManager executorManager,
-                            NexusConfig config) {
+                            CoreConfig config) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.mapService = Objects.requireNonNull(mapService, "mapService");
@@ -129,7 +129,7 @@ public final class ArenaServiceImpl implements ArenaService {
 
     @Override
     public ArenaBudget budget(ArenaHandle handle) {
-        NexusConfig.ArenaSettings settings = settingsRef.get();
+        CoreConfig.ArenaSettings settings = settingsRef.get();
         return new ArenaBudget(settings.maxEntities(), settings.maxItems(), settings.maxProjectiles());
     }
 
@@ -144,7 +144,7 @@ public final class ArenaServiceImpl implements ArenaService {
     }
 
     @Override
-    public void applyArenaSettings(NexusConfig.ArenaSettings settings) {
+    public void applyArenaSettings(CoreConfig.ArenaSettings settings) {
         settingsRef.set(Objects.requireNonNull(settings, "settings"));
         logger.info("Paramètres d'arène mis à jour: hud=" + settings.hudHz() + " scoreboard=" + settings.scoreboardHz());
     }

--- a/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.db.DbProvider;
 import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.service.api.EconomyException;
@@ -28,9 +28,9 @@ public final class EconomyServiceImpl implements EconomyService {
     private final ExecutorManager executorManager;
     private final ConcurrentHashMap<UUID, BalanceEntry> balances = new ConcurrentHashMap<>();
     private final AtomicBoolean degraded = new AtomicBoolean();
-    private final AtomicReference<NexusConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
+    private final AtomicReference<CoreConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
 
-    public EconomyServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorManager executorManager, NexusConfig config) {
+    public EconomyServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorManager executorManager, CoreConfig config) {
         this.logger = Objects.requireNonNull(logger, "logger");
         this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
         this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
@@ -139,7 +139,7 @@ public final class EconomyServiceImpl implements EconomyService {
     }
 
     @Override
-    public void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings) {
+    public void applyDegradedModeSettings(CoreConfig.DegradedModeSettings settings) {
         degradedSettings.set(Objects.requireNonNull(settings, "settings"));
     }
 
@@ -152,7 +152,7 @@ public final class EconomyServiceImpl implements EconomyService {
         boolean fallback = dbProvider.isDegraded();
         boolean previous = degraded.getAndSet(fallback);
         if (fallback && !previous) {
-            NexusConfig.DegradedModeSettings settings = degradedSettings.get();
+            CoreConfig.DegradedModeSettings settings = degradedSettings.get();
             if (settings.banner()) {
                 logger.warn("Mode dégradé activé pour l'EconomyService : stockage en mémoire");
             }

--- a/src/main/java/com/heneria/nexus/service/core/ProfileServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/ProfileServiceImpl.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.db.DbProvider;
 import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.service.api.PlayerProfile;
@@ -29,9 +29,9 @@ public final class ProfileServiceImpl implements ProfileService {
     private final ConcurrentHashMap<UUID, CacheEntry> cache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, PlayerProfile> persistentStore = new ConcurrentHashMap<>();
     private final AtomicBoolean degraded = new AtomicBoolean();
-    private final AtomicReference<NexusConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
+    private final AtomicReference<CoreConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
 
-    public ProfileServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorManager executorManager, NexusConfig config) {
+    public ProfileServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorManager executorManager, CoreConfig config) {
         this.logger = Objects.requireNonNull(logger, "logger");
         this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
         this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
@@ -81,7 +81,7 @@ public final class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public void applyDegradedModeSettings(NexusConfig.DegradedModeSettings settings) {
+    public void applyDegradedModeSettings(CoreConfig.DegradedModeSettings settings) {
         degradedSettings.set(Objects.requireNonNull(settings, "settings"));
     }
 
@@ -94,7 +94,7 @@ public final class ProfileServiceImpl implements ProfileService {
         boolean fallback = dbProvider.isDegraded();
         boolean previous = degraded.getAndSet(fallback);
         if (fallback && !previous) {
-            NexusConfig.DegradedModeSettings settings = degradedSettings.get();
+            CoreConfig.DegradedModeSettings settings = degradedSettings.get();
             if (settings.banner()) {
                 logger.warn("Mode dégradé activé pour le ProfileService : stockage en mémoire");
             }

--- a/src/main/java/com/heneria/nexus/service/core/QueueServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/QueueServiceImpl.java
@@ -1,6 +1,6 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.config.NexusConfig;
+import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.service.api.ArenaMode;
 import com.heneria.nexus.service.api.MatchPlan;
@@ -42,7 +42,7 @@ public final class QueueServiceImpl implements QueueService {
     private final Map<ArenaMode, ConcurrentLinkedQueue<QueueTicket>> queues = new EnumMap<>(ArenaMode.class);
     private final ConcurrentHashMap<UUID, QueueTicket> ticketsByPlayer = new ConcurrentHashMap<>();
     private final AtomicLong matchesFormed = new AtomicLong();
-    private final AtomicReference<NexusConfig.QueueSettings> settingsRef;
+    private final AtomicReference<CoreConfig.QueueSettings> settingsRef;
     private final AtomicReference<QueueStats> stats = new AtomicReference<>(new QueueStats(0, 0, 0L, 0L));
     private volatile BukkitTask tickerTask;
 
@@ -50,7 +50,7 @@ public final class QueueServiceImpl implements QueueService {
                             NexusLogger logger,
                             ExecutorManager executorManager,
                             ProfileService profileService,
-                            NexusConfig config) {
+                            CoreConfig config) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
@@ -157,7 +157,7 @@ public final class QueueServiceImpl implements QueueService {
     }
 
     @Override
-    public void applySettings(NexusConfig.QueueSettings settings) {
+    public void applySettings(CoreConfig.QueueSettings settings) {
         Objects.requireNonNull(settings, "settings");
         settingsRef.set(settings);
         scheduleTicker();

--- a/src/main/java/com/heneria/nexus/util/DumpUtil.java
+++ b/src/main/java/com/heneria/nexus/util/DumpUtil.java
@@ -34,8 +34,8 @@ public final class DumpUtil {
         lines.add(Component.text("=== État Nexus ===", NamedTextColor.GOLD));
         lines.add(Component.text("Serveur : " + server.getVersion(), NamedTextColor.YELLOW));
         lines.add(Component.text("Java : " + System.getProperty("java.version"), NamedTextColor.YELLOW));
-        lines.add(Component.text("Fuseau horaire : " + bundle.config().timezone(), NamedTextColor.YELLOW));
-        lines.add(Component.text("Mode : " + bundle.config().serverMode(), NamedTextColor.YELLOW));
+        lines.add(Component.text("Fuseau horaire : " + bundle.core().timezone(), NamedTextColor.YELLOW));
+        lines.add(Component.text("Mode : " + bundle.core().serverMode(), NamedTextColor.YELLOW));
 
         ExecutorManager.PoolStats poolDiagnostics = executorManager.stats();
         lines.add(Component.empty());
@@ -89,7 +89,7 @@ public final class DumpUtil {
 
         lines.add(Component.empty());
         lines.add(Component.text("Chargé le : " + DateTimeFormatter.ISO_LOCAL_DATE_TIME
-                .withZone(bundle.config().timezone())
+                .withZone(bundle.core().timezone())
                 .format(bundle.loadedAt()), NamedTextColor.DARK_GRAY));
         return lines;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,127 +4,52 @@
 # =============================================
 
 server:
-  # Mode logique de ce serveur (utile pour les environnements multi-nœuds)
   mode: "nexus"
-  # Langue des messages par défaut (BCP 47)
   language: "fr"
-  # Fuseau horaire utilisé pour les horodatages et les dumps
   timezone: "Europe/Paris"
 
-services:
-  # Expose les services clés via le ServicesManager de Bukkit pour les autres plugins
-  expose-bukkit-services: false
-
-timeouts:
-  # Timeout global pour le démarrage des services (ms)
-  startMs: 5000
-  # Timeout global pour l'arrêt des services (ms)
-  stopMs: 3000
-
-degraded-mode:
-  # Active les mécanismes de repli (économie/profils en mémoire) si la DB ne répond pas
-  enabled: true
-  # Affiche une bannière opérateur lorsque le mode dégradé est actif
-  banner: true
-
-queue:
-  # Fréquence d'exécution du matchmaking (Hz)
-  tick_hz: 5
-  # Bonus de poids pour les joueurs VIP (0..3 conseillé)
-  vip_weight: 1
-
-arena:
-  # Taux de rafraîchissement des HUD (5 Hz par défaut => toutes les 4 ticks)
+perf:
   hud_hz: 5
-  # Taux de rafraîchissement des scoreboards (3 Hz par défaut)
   scoreboard_hz: 3
-  particles:
-    # Budget particules pour les effets « doux » (peut être dépassé ponctuellement)
-    soft_cap: 1200
-    # Limite stricte d'émission de particules (les tâches au-delà sont coupées)
-    hard_cap: 2000
+  particles_soft_cap: 1200
+  particles_hard_cap: 2000
   budget:
-    # Nombre maximum d'entités actives par arène
     max_entities: 200
-    # Nombre maximum d'items au sol
     max_items: 128
-    # Nombre maximum de projectiles simultanés
     max_projectiles: 64
 
-ring:
-  defaults:
-    HUD: "5hz"
-    SCOREBOARD: "4hz"
-    PARTICLES: "5hz"
-    GENERATOR: "2hz"
-    EVENTS: "2hz"
-    QUEUE: "2hz"
-    MISC: "5hz"
-  profiles:
-    RESET:
-      enableCosmetics: false
-      enableQueue: false
-    END:
-      hudHz: "2hz"
-      scoreboardHz: "2hz"
-  degrade:
-    soft:
-      mspt: 30
-      scale: 0.6
-    hard:
-      mspt: 45
-      pauseCosmetics: true
-
-executors:
-  io:
-    # Active les threads virtuels (Java 21+) pour les tâches fortement bloquantes.
-    virtual: false
-    # Taille maximale du pool I/O si les threads virtuels sont désactivés.
-    maxThreads: 12
-    # Temps d'inactivité avant recyclage des threads I/O (ms).
-    keepAliveMs: 30000
-  compute:
-    # Taille du pool CPU-bound (matchmaking, validations). Conseillé: max(2, min(cœurs, 4)).
-    size: 4
+threads:
+  io_virtual: false
+  io_pool: 12
+  io_keep_alive_ms: 30000
+  compute_pool: 4
   shutdown:
-    # Délai d'attente (secondes) pour terminer les tâches en cours lors du /stop.
-    awaitSeconds: 5
-    # Délai supplémentaire avant annulation forcée.
-    forceCancelSeconds: 3
+    await_seconds: 5
+    force_cancel_seconds: 3
   scheduler:
-    # Intervalle de drainage des callbacks main thread (ticks).
     main_check_interval_ticks: 1
 
 database:
-  # Active ou non la persistance MariaDB. Si désactivé, Nexus fonctionne en mode dégradé.
   enabled: true
-  # URL JDBC MariaDB. Adapter l'hôte/port/nom de base.
   jdbc: "jdbc:mariadb://127.0.0.1:3306/nexus"
-  # Identifiants du compte SQL dédié.
   user: "nexus"
   password: "change_me"
   pool:
-    # Taille maximale du pool HikariCP (adapter à la charge attendue).
     maxSize: 10
-    # Nombre minimal de connexions maintenues au chaud.
     minIdle: 2
-    # Timeout de connexion en millisecondes (fail-fast conseillé < 5s).
     connTimeoutMs: 3000
 
-# ================== PLACEHOLDERS ==================
-# Les sections suivantes seront alimentées par les tickets
-# ultérieurs (T-0xx). Elles sont laissées ici pour la lisibilité.
+services:
+  expose-bukkit-services: false
 
-economy:
-  # currency: "NEX"
-  # starting-balance: 1000
-  # taxes:
-  #   enabled: false
-  #   rate: 0.05
+timeouts:
+  startMs: 5000
+  stopMs: 3000
 
-maps:
-  # default-map: "vallon"
-  # rotation:
-  #   - "vallon"
-  #   - "caverne"
-  #   - "tournoi"
+degraded-mode:
+  enabled: true
+  banner: true
+
+queue:
+  tick_hz: 5
+  vip_weight: 1

--- a/src/main/resources/economy.yml
+++ b/src/main/resources/economy.yml
@@ -1,10 +1,15 @@
 # =============================================
-#  Placeholder économie — sera rempli ultérieurement
+#  Configuration économie Nexus
 # =============================================
 
-economy:
-  # currency: "NEX"
-  # starting-balance: 1000
-  # taxes:
-  #   enabled: false
-  #   rate: 0.05
+coins:
+  win_per_match: 20
+  lose_per_match: 5
+  first_win_bonus: 50
+
+battlepass:
+  season_days: 90
+  tiers: 65
+  xp_per_match:
+    win: 120
+    lose: 60

--- a/src/main/resources/maps.yml
+++ b/src/main/resources/maps.yml
@@ -1,10 +1,19 @@
 # =============================================
-#  Placeholder cartes — détails à venir
+#  Catalogue des maps Nexus
 # =============================================
 
+rotation:
+  enabled: true
+  weighted_pick: true
+  veto_vote: true
+  min_votes_to_pick: 1
+
 maps:
-  # default-map: "vallon"
-  # rotation:
-  #   - "vallon"
-  #   - "caverne"
-  #   - "tournoi"
+  - id: "temple_ancien"
+    display: "Temple Ancien"
+    weight: 3
+    modes: ["2v2", "4v4"]
+  - id: "caverne_glacee"
+    display: "Caverne Glacée"
+    weight: 2
+    modes: ["2v2"]

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,22 +1,24 @@
 meta:
   locale: "fr-FR"
 
-commands:
-  help:
-    header: "<gold>Commandes Nexus disponibles :</gold>"
-    help: "<gray>/nexus help</gray> <dark_gray>-</dark_gray> <yellow>Affiche cette aide.</yellow>"
+prefix: "<gray>[<light_purple>NEXUS</light_purple>]</gray> "
+
+help:
+  header: "<gold>Commandes Nexus disponibles :</gold>"
+  lines:
+    - "<gray>/nexus help</gray> <dark_gray>-</dark_gray> <yellow>Affiche cette aide.</yellow>"
+  admin:
     reload: "<gray>/nexus reload</gray> <dark_gray>-</dark_gray> <yellow>Recharge les configurations et messages.</yellow>"
     dump: "<gray>/nexus dump</gray> <dark_gray>-</dark_gray> <yellow>Affiche l'état courant (threads, DB, scheduler).</yellow>"
+
+errors:
+  no_permission: "<red>Vous n'avez pas la permission requise.</red>"
+
+admin:
   reload:
     start: "<yellow>Rechargement en cours...</yellow>"
-    success: "<green>Configuration Nexus rechargée.</green>"
-    failure: "<red>Échec du rechargement, voir console.</red>"
+    ok: "<green>Configuration Nexus rechargée.</green>"
+    fail: "<red>Échec du rechargement, voir console.</red>"
   dump:
     header: "<gold>Dump Nexus</gold>"
     success: "<green>Dump généré.</green>"
-  errors:
-    no-permission: "<red>Vous n'avez pas la permission requise.</red>"
-    invalid-config: "<red>La configuration contient des erreurs :</red>"
-status:
-  database:
-    degraded: "<red>Mode dégradé : persistance indisponible.</red>"


### PR DESCRIPTION
## Summary
- replace the legacy ConfigManager with an asynchronous loader that validates config.yml, messages.yml, maps.yml and economy.yml, hot-swapping them atomically
- introduce CoreConfig, MapsCatalogConfig, EconomyConfig and ReloadReport to expose immutable runtime views and detailed reload diagnostics
- update plugin services, message handling and defaults to the new configuration structure with MiniMessage parsing at load time

## Testing
- `mvn -q -DskipTests package` *(fails: maven-resources-plugin dependency could not be downloaded because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce79c68b548324b20b2364b5f916e8