### PR TITLE
Add MiniMessage facade contracts and UI configuration

### DIFF
--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -2,7 +2,10 @@ package com.heneria.nexus.config;
 
 import java.time.ZoneId;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import net.kyori.adventure.bossbar.BossBar;
 
 /**
  * Immutable view over the main nexus configuration.
@@ -19,6 +22,7 @@ public final class CoreConfig {
     private final TimeoutSettings timeoutSettings;
     private final DegradedModeSettings degradedModeSettings;
     private final QueueSettings queueSettings;
+    private final UiSettings uiSettings;
 
     public CoreConfig(String serverMode,
                       Locale language,
@@ -29,7 +33,8 @@ public final class CoreConfig {
                       ServiceSettings serviceSettings,
                       TimeoutSettings timeoutSettings,
                       DegradedModeSettings degradedModeSettings,
-                      QueueSettings queueSettings) {
+                      QueueSettings queueSettings,
+                      UiSettings uiSettings) {
         this.serverMode = Objects.requireNonNull(serverMode, "serverMode");
         this.language = Objects.requireNonNull(language, "language");
         this.timezone = Objects.requireNonNull(timezone, "timezone");
@@ -40,6 +45,7 @@ public final class CoreConfig {
         this.timeoutSettings = Objects.requireNonNull(timeoutSettings, "timeoutSettings");
         this.degradedModeSettings = Objects.requireNonNull(degradedModeSettings, "degradedModeSettings");
         this.queueSettings = Objects.requireNonNull(queueSettings, "queueSettings");
+        this.uiSettings = Objects.requireNonNull(uiSettings, "uiSettings");
     }
 
     public String serverMode() {
@@ -80,6 +86,10 @@ public final class CoreConfig {
 
     public QueueSettings queueSettings() {
         return queueSettings;
+    }
+
+    public UiSettings uiSettings() {
+        return uiSettings;
     }
 
     public record ArenaSettings(int hudHz, int scoreboardHz, int particlesSoftCap, int particlesHardCap,
@@ -200,6 +210,45 @@ public final class CoreConfig {
             }
             if (vipWeight < 0) {
                 throw new IllegalArgumentException("vipWeight must be >= 0");
+            }
+        }
+    }
+
+    public record UiSettings(boolean strictMiniMessage,
+                             Map<String, TitleTimesProfile> titleProfiles,
+                             BossBarDefaults bossBarDefaults) {
+        public UiSettings {
+            Objects.requireNonNull(titleProfiles, "titleProfiles");
+            this.titleProfiles = Map.copyOf(titleProfiles);
+            Objects.requireNonNull(bossBarDefaults, "bossBarDefaults");
+        }
+    }
+
+    public record TitleTimesProfile(int fadeInTicks, int stayTicks, int fadeOutTicks) {
+        public TitleTimesProfile {
+            if (fadeInTicks < 0) {
+                throw new IllegalArgumentException("fadeInTicks must be >= 0");
+            }
+            if (stayTicks <= 0) {
+                throw new IllegalArgumentException("stayTicks must be > 0");
+            }
+            if (fadeOutTicks < 0) {
+                throw new IllegalArgumentException("fadeOutTicks must be >= 0");
+            }
+        }
+    }
+
+    public record BossBarDefaults(BossBar.Color color,
+                                  BossBar.Overlay overlay,
+                                  Set<BossBar.Flag> flags,
+                                  int updateEveryTicks) {
+        public BossBarDefaults {
+            Objects.requireNonNull(color, "color");
+            Objects.requireNonNull(overlay, "overlay");
+            Objects.requireNonNull(flags, "flags");
+            this.flags = flags.isEmpty() ? Set.of() : Set.copyOf(flags);
+            if (updateEveryTicks <= 0) {
+                throw new IllegalArgumentException("updateEveryTicks must be > 0");
             }
         }
     }

--- a/src/main/java/com/heneria/nexus/service/api/ArenaContext.java
+++ b/src/main/java/com/heneria/nexus/service/api/ArenaContext.java
@@ -1,0 +1,23 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Map;
+import java.util.OptionalLong;
+
+/**
+ * Lightweight context exposed to UI resolvers when rendering arena bound
+ * messages.
+ */
+public interface ArenaContext {
+
+    /** Returns the handle of the arena emitting the message. */
+    ArenaHandle arena();
+
+    /** Returns the current gameplay phase. */
+    ArenaPhase phase();
+
+    /** Returns the remaining time in milliseconds if relevant. */
+    OptionalLong remainingTimeMs();
+
+    /** Additional key/value attributes describing the arena state. */
+    Map<String, Object> attributes();
+}

--- a/src/main/java/com/heneria/nexus/service/api/AudienceGateway.java
+++ b/src/main/java/com/heneria/nexus/service/api/AudienceGateway.java
@@ -1,0 +1,34 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Optional;
+import java.util.UUID;
+import net.kyori.adventure.audience.Audience;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+/**
+ * Gateway returning Adventure audiences backed by Paper's audience provider.
+ */
+public interface AudienceGateway {
+
+    /** Returns the adventure audience associated with the provided player. */
+    Optional<Audience> player(Player player);
+
+    /** Returns the adventure audience associated with a player UUID. */
+    Optional<Audience> player(UUID playerId);
+
+    /** Returns the adventure audience representing a scoreboard team. */
+    Optional<Audience> team(String teamName);
+
+    /** Returns the adventure audience representing the entire server. */
+    Audience server();
+
+    /** Returns the console audience. */
+    Audience console();
+
+    /** Returns the adventure audience for a given world. */
+    Optional<Audience> world(World world);
+
+    /** Returns an aggregated audience from the provided audiences. */
+    Audience of(Iterable<? extends Audience> audiences);
+}

--- a/src/main/java/com/heneria/nexus/service/api/BossBarHandle.java
+++ b/src/main/java/com/heneria/nexus/service/api/BossBarHandle.java
@@ -1,0 +1,38 @@
+package com.heneria.nexus.service.api;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Handle representing an attached boss bar instance.
+ */
+public interface BossBarHandle {
+
+    /** Returns the underlying Adventure boss bar instance. */
+    BossBar bossBar();
+
+    /** Returns the audience currently targeted by the bar. */
+    Audience audience();
+
+    /** Returns the profile driving this bar. */
+    BossBarProfile profile();
+
+    /** Updates the textual component displayed by the bar. */
+    void updateName(Component name);
+
+    /** Updates the progress between {@code 0.0} and {@code 1.0}. */
+    void updateProgress(float progress);
+
+    /** Shows the bar to its audience if hidden. */
+    void show();
+
+    /** Hides the bar from its audience. */
+    void hide();
+
+    /** Detaches and cleans up the bar. Further updates become no-ops. */
+    void detach();
+
+    /** Returns whether the handle has been detached. */
+    boolean detached();
+}

--- a/src/main/java/com/heneria/nexus/service/api/BossBarProfile.java
+++ b/src/main/java/com/heneria/nexus/service/api/BossBarProfile.java
@@ -1,0 +1,42 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Set;
+import net.kyori.adventure.bossbar.BossBar;
+
+/**
+ * Configuration backing a boss bar instance. Profiles are sourced from the
+ * configuration and reused across arenas and players.
+ */
+public interface BossBarProfile {
+
+    /** Identifier of the profile. */
+    String id();
+
+    /** Returns the Adventure colour applied to the bar. */
+    BossBar.Color color();
+
+    /** Returns the Adventure overlay applied to the bar. */
+    BossBar.Overlay overlay();
+
+    /** Returns the static flags that must be enabled on the bar. */
+    Set<BossBar.Flag> flags();
+
+    /**
+     * Returns the recommended update cadence in ticks for dynamic bars.
+     */
+    int updateEveryTicks();
+
+    /**
+     * Defines how bar instances are cloned when attached to audiences.
+     */
+    ClonePolicy clonePolicy();
+
+    enum ClonePolicy {
+        /** Shared instance for all audiences. */
+        GLOBAL,
+        /** Dedicated instance per connected player. */
+        PER_PLAYER,
+        /** Dedicated instance per arena or logical group. */
+        PER_ARENA
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/BossBarPrototype.java
+++ b/src/main/java/com/heneria/nexus/service/api/BossBarPrototype.java
@@ -1,0 +1,36 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Set;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
+/**
+ * Immutable description of a boss bar resolved from configuration.
+ */
+public interface BossBarPrototype {
+
+    /** Unique message key associated with the bar name. */
+    String key();
+
+    /** Returns the MiniMessage template for the bar name. */
+    MiniMessageTemplate nameTemplate();
+
+    /** Returns the colour to use when instantiating the bar. */
+    BossBar.Color color();
+
+    /** Returns the overlay to use when instantiating the bar. */
+    BossBar.Overlay overlay();
+
+    /** Returns the static flags applied to the bar. */
+    Set<BossBar.Flag> flags();
+
+    /** Returns the cloning policy derived from the profile. */
+    BossBarProfile.ClonePolicy clonePolicy();
+
+    /**
+     * Creates a fresh Adventure boss bar instance based on the prototype.
+     * Implementations must clone state rather than returning shared instances
+     * when the clone policy requires isolation.
+     */
+    BossBar instantiate(TagResolver... resolvers);
+}

--- a/src/main/java/com/heneria/nexus/service/api/BossBarPrototypeRegistry.java
+++ b/src/main/java/com/heneria/nexus/service/api/BossBarPrototypeRegistry.java
@@ -1,0 +1,19 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Registry exposing boss bar prototypes resolved from configuration.
+ */
+public interface BossBarPrototypeRegistry {
+
+    /** Returns the prototype matching the provided key if present. */
+    Optional<BossBarPrototype> find(String key);
+
+    /** Returns the prototype matching the provided key or throws when absent. */
+    BossBarPrototype require(String key);
+
+    /** Returns all known prototypes. */
+    Collection<BossBarPrototype> prototypes();
+}

--- a/src/main/java/com/heneria/nexus/service/api/ComponentTemplateCache.java
+++ b/src/main/java/com/heneria/nexus/service/api/ComponentTemplateCache.java
@@ -1,0 +1,32 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Immutable cache of MiniMessage templates resolved at load time.
+ */
+public interface ComponentTemplateCache {
+
+    /**
+     * Returns the prefix template shared across all messages.
+     */
+    MiniMessageTemplate prefix();
+
+    /**
+     * Returns the template associated with the provided key if present.
+     */
+    Optional<MiniMessageTemplate> find(String key);
+
+    /**
+     * Returns the template associated with the provided key or throws if
+     * missing. Implementations should surface the key in the thrown exception
+     * to ease troubleshooting missing translations.
+     */
+    MiniMessageTemplate require(String key);
+
+    /**
+     * Returns an immutable snapshot of the cached templates.
+     */
+    Map<String, MiniMessageTemplate> templates();
+}

--- a/src/main/java/com/heneria/nexus/service/api/MiniMessageFacade.java
+++ b/src/main/java/com/heneria/nexus/service/api/MiniMessageFacade.java
@@ -1,0 +1,52 @@
+package com.heneria.nexus.service.api;
+
+import com.heneria.nexus.service.LifecycleAware;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
+/**
+ * High level facade encapsulating all MiniMessage rendering logic.
+ */
+public interface MiniMessageFacade extends LifecycleAware {
+
+    /** Returns the cached prefix component. */
+    Component prefix();
+
+    /** Returns a rendered component for the provided key. */
+    Component msg(String key, TagResolver... resolvers);
+
+    /** Sends a rendered component directly to the provided audience. */
+    void send(Audience target, String key, TagResolver... resolvers);
+
+    /**
+     * Sends a rendered component to multiple audiences. Implementations must
+     * operate on the main server thread.
+     */
+    void broadcast(Iterable<? extends Audience> targets, String key, TagResolver... resolvers);
+
+    /** Sends an action bar message. */
+    void actionBar(Audience target, String key, TagResolver... resolvers);
+
+    /**
+     * Sends a title using the provided MiniMessage keys and timing profile.
+     */
+    void title(Audience target, String keyTitle, String keySubtitle, TimesProfile times, TagResolver... resolvers);
+
+    /**
+     * Attaches a boss bar to the target and returns a handle to control it.
+     */
+    BossBarHandle bossbar(Audience target, String barKey, BossBarProfile profile, TagResolver... resolvers);
+
+    /** Returns the cache holding component templates. */
+    ComponentTemplateCache componentTemplates();
+
+    /** Returns the cache holding title templates. */
+    TitleTemplateCache titleTemplates();
+
+    /** Returns the registry of boss bar prototypes. */
+    BossBarPrototypeRegistry bossBarPrototypes();
+
+    /** Returns the resolver factory used to compose tag resolvers. */
+    TagResolverFactory resolvers();
+}

--- a/src/main/java/com/heneria/nexus/service/api/MiniMessageTemplate.java
+++ b/src/main/java/com/heneria/nexus/service/api/MiniMessageTemplate.java
@@ -1,0 +1,34 @@
+package com.heneria.nexus.service.api;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
+/**
+ * Represents a pre-parsed MiniMessage template that can render lightweight
+ * components without re-parsing the underlying string at runtime.
+ */
+public interface MiniMessageTemplate {
+
+    /**
+     * Returns the unique message key associated with this template.
+     */
+    String key();
+
+    /**
+     * Renders the template using the provided tag resolvers.
+     * Implementations must not perform a MiniMessage parse on the hot path.
+     */
+    Component render(TagResolver... resolvers);
+
+    /**
+     * Returns the pre-parsed component associated with the template without
+     * applying additional resolvers.
+     */
+    Component component();
+
+    /**
+     * Returns the raw MiniMessage source string, useful for logging and
+     * debugging reload issues.
+     */
+    String source();
+}

--- a/src/main/java/com/heneria/nexus/service/api/TagResolverFactory.java
+++ b/src/main/java/com/heneria/nexus/service/api/TagResolverFactory.java
@@ -1,0 +1,43 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.entity.Player;
+
+/**
+ * Factory responsible for building MiniMessage {@link TagResolver} instances
+ * used by the {@link MiniMessageFacade}.
+ */
+public interface TagResolverFactory {
+
+    /**
+     * Returns a resolver backed by static key/value entries typically coming
+     * from the server configuration.
+     */
+    TagResolver resolverStatic(Map<String, String> entries);
+
+    /** Builds a resolver exposing player related placeholders. */
+    TagResolver resolverPlayer(Player player);
+
+    /** Builds a resolver exposing arena related placeholders. */
+    TagResolver resolverArena(ArenaContext context);
+
+    /** Returns a new builder for composing resolvers. */
+    Builder builder();
+
+    interface Builder {
+
+        /** Adds an already built resolver to the composite. */
+        Builder add(TagResolver resolver);
+
+        /**
+         * Adds a resolver supplier whose value will be cached for the duration
+         * of the rendering pass to avoid repeated heavy computations.
+         */
+        Builder caching(Supplier<TagResolver> resolverSupplier);
+
+        /** Builds the composite resolver. */
+        TagResolver build();
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/api/TimesProfile.java
+++ b/src/main/java/com/heneria/nexus/service/api/TimesProfile.java
@@ -1,0 +1,19 @@
+package com.heneria.nexus.service.api;
+
+import net.kyori.adventure.title.Title;
+
+/**
+ * Represents a named timing profile used when building Adventure titles.
+ */
+public interface TimesProfile {
+
+    /**
+     * Identifier of the profile as configured in {@code config.yml}.
+     */
+    String id();
+
+    /**
+     * Returns the Adventure times instance associated with the profile.
+     */
+    Title.Times times();
+}

--- a/src/main/java/com/heneria/nexus/service/api/TitleTemplate.java
+++ b/src/main/java/com/heneria/nexus/service/api/TitleTemplate.java
@@ -1,0 +1,38 @@
+package com.heneria.nexus.service.api;
+
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.title.Title;
+
+/**
+ * Represents a pre-built title template coupled to a timing profile.
+ */
+public interface TitleTemplate {
+
+    /**
+     * Returns the message key used for the title component.
+     */
+    String titleKey();
+
+    /**
+     * Returns the message key used for the subtitle component.
+     */
+    String subtitleKey();
+
+    /**
+     * Returns the timing profile applied to the title.
+     */
+    TimesProfile timesProfile();
+
+    /**
+     * Returns the cached title instance without additional placeholder
+     * resolution.
+     */
+    Title title();
+
+    /**
+     * Renders a title instance using the provided resolvers. Implementations
+     * must re-use the cached timings and avoid MiniMessage parsing on the hot
+     * path.
+     */
+    Title render(TagResolver... resolvers);
+}

--- a/src/main/java/com/heneria/nexus/service/api/TitleTemplateCache.java
+++ b/src/main/java/com/heneria/nexus/service/api/TitleTemplateCache.java
@@ -1,0 +1,28 @@
+package com.heneria.nexus.service.api;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Registry exposing immutable title templates keyed by their message entries
+ * and timing profile.
+ */
+public interface TitleTemplateCache {
+
+    /**
+     * Returns the title template matching the provided keys and profile if
+     * available.
+     */
+    Optional<TitleTemplate> find(String titleKey, String subtitleKey, TimesProfile profile);
+
+    /**
+     * Returns the title template matching the provided keys and profile or
+     * throws when absent.
+     */
+    TitleTemplate require(String titleKey, String subtitleKey, TimesProfile profile);
+
+    /**
+     * Returns all registered title templates.
+     */
+    Collection<TitleTemplate> templates();
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -53,3 +53,28 @@ degraded-mode:
 queue:
   tick_hz: 5
   vip_weight: 1
+
+ui:
+  minimessage:
+    strict: true
+  title:
+    times:
+      short:
+        fadeIn: 5
+        stay: 40
+        fadeOut: 10
+      normal:
+        fadeIn: 10
+        stay: 60
+        fadeOut: 20
+      long:
+        fadeIn: 20
+        stay: 100
+        fadeOut: 40
+  bossbar:
+    defaults:
+      color: PURPLE
+      overlay: NOTCHED_20
+      flags:
+        - DARKEN_SCREEN
+      updateEveryTicks: 10

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -22,3 +22,15 @@ admin:
   dump:
     header: "<gold>Dump Nexus</gold>"
     success: "<green>Dump généré.</green>"
+
+titles:
+  round_start:
+    title: "<gold>Début du round</gold>"
+    subtitle: "<gray>Préparez-vous au combat !</gray>"
+  victory:
+    title: "<green>Victoire !</green>"
+    subtitle: "<yellow>Félicitations <player_name/></yellow>"
+
+bossbars:
+  match_timer:
+    name: "<gold>Temps restant : <white><timer/></white></gold>"


### PR DESCRIPTION
## Summary
- add interfaces for the MiniMessage facade, tag resolver factory, audience gateway, and related templates/handles
- extend CoreConfig and ConfigValidator to surface UI settings for strict MiniMessage parsing, title times, and boss bar defaults
- seed config.yml and messages.yml with baseline entries for titles and boss bars

## Testing
- mvn -q -DskipTests compile *(fails: unable to resolve maven-resources-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8dfb476483248ca2cd4e626b700e