### PR TITLE
Add arena budget enforcement and admin command

### DIFF
--- a/src/main/java/com/heneria/nexus/budget/BudgetService.java
+++ b/src/main/java/com/heneria/nexus/budget/BudgetService.java
@@ -1,0 +1,41 @@
+package com.heneria.nexus.budget;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.service.api.ArenaHandle;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+
+/**
+ * Centralises arena related runtime budgets and provides enforcement hooks.
+ */
+public interface BudgetService extends LifecycleAware {
+
+    void registerArena(ArenaHandle handle);
+
+    void unregisterArena(ArenaHandle handle);
+
+    boolean canSpawn(UUID arenaId, EntityType type, int amount);
+
+    void markPending(UUID arenaId, Entity entity, BudgetType type);
+
+    void cancelPending(Entity entity);
+
+    void recordEntityAdded(Entity entity);
+
+    void recordEntityRemoved(Entity entity);
+
+    void trackParticle(UUID arenaId, int count);
+
+    Optional<BudgetSnapshot> getSnapshot(UUID arenaId);
+
+    Collection<BudgetSnapshot> snapshots();
+
+    Optional<UUID> resolveArenaId(Location location);
+
+    void applySettings(CoreConfig.ArenaSettings settings);
+}

--- a/src/main/java/com/heneria/nexus/budget/BudgetServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/budget/BudgetServiceImpl.java
@@ -1,0 +1,530 @@
+package com.heneria.nexus.budget;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.service.api.ArenaHandle;
+import com.heneria.nexus.service.api.ArenaMode;
+import com.heneria.nexus.util.NexusLogger;
+import io.papermc.paper.event.entity.EntityAddToWorldEvent;
+import io.papermc.paper.event.entity.EntityRemoveFromWorldEvent;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Default implementation of {@link BudgetService} enforcing per arena budgets.
+ */
+public final class BudgetServiceImpl implements BudgetService {
+
+    private static final Pattern WORLD_ID_PATTERN = Pattern.compile(
+            "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})");
+    private static final long WARN_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final NamespacedKey arenaKey;
+    private final ConcurrentHashMap<UUID, BudgetTracker> trackers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, EntityRegistration> trackedEntities = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, UUID> worldArenaIndex = new ConcurrentHashMap<>();
+    private final AtomicReference<CoreConfig.ArenaSettings> settingsRef;
+    private final CopyOnWriteArrayList<Listener> registeredListeners = new CopyOnWriteArrayList<>();
+
+    public BudgetServiceImpl(JavaPlugin plugin, NexusLogger logger, CoreConfig config) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        Objects.requireNonNull(config, "config");
+        this.settingsRef = new AtomicReference<>(config.arenaSettings());
+        this.arenaKey = new NamespacedKey(plugin, "arena-id");
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        if (!registeredListeners.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        PluginManager manager = plugin.getServer().getPluginManager();
+        Listener entitySpawn = new com.heneria.nexus.budget.listener.EntitySpawnListener(this);
+        Listener itemSpawn = new com.heneria.nexus.budget.listener.ItemSpawnListener(this);
+        Listener projectileSpawn = new com.heneria.nexus.budget.listener.ProjectileLaunchListener(this);
+        Listener lifecycle = new EntityLifecycleListener();
+        manager.registerEvents(entitySpawn, plugin);
+        manager.registerEvents(itemSpawn, plugin);
+        manager.registerEvents(projectileSpawn, plugin);
+        manager.registerEvents(lifecycle, plugin);
+        registeredListeners.addAll(List.of(entitySpawn, itemSpawn, projectileSpawn, lifecycle));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        registeredListeners.forEach(HandlerList::unregisterAll);
+        registeredListeners.clear();
+        trackers.clear();
+        trackedEntities.clear();
+        worldArenaIndex.clear();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void registerArena(ArenaHandle handle) {
+        Objects.requireNonNull(handle, "handle");
+        CoreConfig.ArenaSettings settings = settingsRef.get();
+        trackers.put(handle.id(), new BudgetTracker(handle, settings));
+    }
+
+    @Override
+    public void unregisterArena(ArenaHandle handle) {
+        Objects.requireNonNull(handle, "handle");
+        trackers.remove(handle.id());
+        trackedEntities.entrySet().removeIf(entry -> entry.getValue().arenaId.equals(handle.id()));
+        worldArenaIndex.entrySet().removeIf(entry -> entry.getValue().equals(handle.id()));
+    }
+
+    @Override
+    public boolean canSpawn(UUID arenaId, EntityType type, int amount) {
+        Objects.requireNonNull(arenaId, "arenaId");
+        Objects.requireNonNull(type, "type");
+        if (amount <= 0) {
+            return true;
+        }
+        BudgetTracker tracker = trackers.get(arenaId);
+        if (tracker == null) {
+            return true;
+        }
+        BudgetType budgetType = classify(type);
+        if (budgetType == null || budgetType == BudgetType.PARTICLE) {
+            return true;
+        }
+        if (tracker.canReserve(budgetType, amount)) {
+            return true;
+        }
+        tracker.warnExceeded(budgetType, logger);
+        return false;
+    }
+
+    @Override
+    public void markPending(UUID arenaId, Entity entity, BudgetType type) {
+        Objects.requireNonNull(entity, "entity");
+        Objects.requireNonNull(type, "type");
+        BudgetTracker tracker = trackers.get(arenaId);
+        if (tracker == null) {
+            return;
+        }
+        tracker.addPending(type, 1);
+        trackedEntities.compute(entity.getUniqueId(), (id, existing) ->
+                new EntityRegistration(arenaId, type, true));
+    }
+
+    @Override
+    public void cancelPending(Entity entity) {
+        Objects.requireNonNull(entity, "entity");
+        trackedEntities.computeIfPresent(entity.getUniqueId(), (id, registration) -> {
+            if (!registration.pending) {
+                return registration;
+            }
+            BudgetTracker tracker = trackers.get(registration.arenaId);
+            if (tracker != null) {
+                tracker.cancelPending(registration.type, 1);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void recordEntityAdded(Entity entity) {
+        Objects.requireNonNull(entity, "entity");
+        BudgetType type = classify(entity);
+        if (type == null) {
+            return;
+        }
+        UUID entityId = entity.getUniqueId();
+        trackedEntities.compute(entityId, (id, registration) -> {
+            if (registration != null) {
+                BudgetTracker tracker = trackers.get(registration.arenaId);
+                if (tracker == null) {
+                    return null;
+                }
+                if (registration.pending) {
+                    tracker.confirm(registration.type, 1);
+                    registration.pending = false;
+                }
+                worldArenaIndex.put(entity.getWorld().getUID(), registration.arenaId);
+                return registration;
+            }
+            Optional<UUID> arenaId = resolveArenaId(entity.getLocation());
+            if (arenaId.isEmpty()) {
+                return null;
+            }
+            BudgetTracker tracker = trackers.get(arenaId.get());
+            if (tracker == null) {
+                return null;
+            }
+            tracker.addExisting(type, 1);
+            worldArenaIndex.put(entity.getWorld().getUID(), arenaId.get());
+            return new EntityRegistration(arenaId.get(), type, false);
+        });
+    }
+
+    @Override
+    public void recordEntityRemoved(Entity entity) {
+        Objects.requireNonNull(entity, "entity");
+        trackedEntities.computeIfPresent(entity.getUniqueId(), (id, registration) -> {
+            BudgetTracker tracker = trackers.get(registration.arenaId);
+            if (tracker != null) {
+                if (registration.pending) {
+                    tracker.cancelPending(registration.type, 1);
+                } else {
+                    tracker.release(registration.type, 1);
+                }
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void trackParticle(UUID arenaId, int count) {
+        if (count <= 0) {
+            return;
+        }
+        BudgetTracker tracker = trackers.get(arenaId);
+        if (tracker == null) {
+            return;
+        }
+        tracker.trackParticles(count, logger);
+    }
+
+    @Override
+    public Optional<BudgetSnapshot> getSnapshot(UUID arenaId) {
+        BudgetTracker tracker = trackers.get(arenaId);
+        if (tracker == null) {
+            return Optional.empty();
+        }
+        return Optional.of(tracker.snapshot());
+    }
+
+    @Override
+    public Collection<BudgetSnapshot> snapshots() {
+        List<BudgetSnapshot> snapshots = new ArrayList<>();
+        trackers.values().forEach(tracker -> snapshots.add(tracker.snapshot()));
+        return List.copyOf(snapshots);
+    }
+
+    @Override
+    public Optional<UUID> resolveArenaId(Location location) {
+        if (location == null) {
+            return Optional.empty();
+        }
+        World world = location.getWorld();
+        if (world == null) {
+            return Optional.empty();
+        }
+        UUID worldId = world.getUID();
+        UUID cached = worldArenaIndex.get(worldId);
+        if (cached != null && trackers.containsKey(cached)) {
+            return Optional.of(cached);
+        }
+        PersistentDataContainer container = world.getPersistentDataContainer();
+        String stored = container.get(arenaKey, PersistentDataType.STRING);
+        if (stored != null) {
+            try {
+                UUID parsed = UUID.fromString(stored);
+                if (trackers.containsKey(parsed)) {
+                    worldArenaIndex.put(worldId, parsed);
+                    return Optional.of(parsed);
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        Matcher matcher = WORLD_ID_PATTERN.matcher(world.getName());
+        if (matcher.find()) {
+            try {
+                UUID parsed = UUID.fromString(matcher.group(1));
+                if (trackers.containsKey(parsed)) {
+                    worldArenaIndex.put(worldId, parsed);
+                    return Optional.of(parsed);
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void applySettings(CoreConfig.ArenaSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        settingsRef.set(settings);
+        trackers.values().forEach(tracker -> tracker.apply(settings));
+    }
+
+    private BudgetType classify(EntityType type) {
+        if (type == EntityType.PLAYER) {
+            return null;
+        }
+        if (type == EntityType.DROPPED_ITEM) {
+            return BudgetType.ITEM;
+        }
+        Class<? extends Entity> entityClass = type.getEntityClass();
+        if (entityClass != null && Projectile.class.isAssignableFrom(entityClass)) {
+            return BudgetType.PROJECTILE;
+        }
+        return BudgetType.ENTITY;
+    }
+
+    private BudgetType classify(Entity entity) {
+        if (entity instanceof Player) {
+            return null;
+        }
+        if (entity.getType() == EntityType.DROPPED_ITEM) {
+            return BudgetType.ITEM;
+        }
+        if (entity instanceof Projectile) {
+            return BudgetType.PROJECTILE;
+        }
+        return BudgetType.ENTITY;
+    }
+
+    private final class EntityLifecycleListener implements Listener {
+
+        @EventHandler
+        public void onEntityAdd(EntityAddToWorldEvent event) {
+            recordEntityAdded(event.getEntity());
+        }
+
+        @EventHandler
+        public void onEntityRemove(EntityRemoveFromWorldEvent event) {
+            recordEntityRemoved(event.getEntity());
+        }
+    }
+
+    private static final class EntityRegistration {
+        private final UUID arenaId;
+        private final BudgetType type;
+        private volatile boolean pending;
+
+        private EntityRegistration(UUID arenaId, BudgetType type, boolean pending) {
+            this.arenaId = arenaId;
+            this.type = type;
+            this.pending = pending;
+        }
+    }
+
+    private static final class BudgetTracker {
+
+        private final UUID arenaId;
+        private final String mapId;
+        private final ArenaMode mode;
+        private final Map<BudgetType, Counter> active;
+        private final Map<BudgetType, Counter> pending;
+        private final Map<BudgetType, AtomicLong> warnTimestamps;
+        private volatile int maxEntities;
+        private volatile int maxItems;
+        private volatile int maxProjectiles;
+        private volatile int particlesSoftCap;
+        private volatile int particlesHardCap;
+        private final Object particleLock = new Object();
+        private final AtomicLong particleWindow = new AtomicLong(-1L);
+        private final Counter particleCounter = new Counter();
+
+        private BudgetTracker(ArenaHandle handle, CoreConfig.ArenaSettings settings) {
+            this.arenaId = handle.id();
+            this.mapId = handle.mapId();
+            this.mode = handle.mode();
+            this.active = Map.of(
+                    BudgetType.ENTITY, new Counter(),
+                    BudgetType.ITEM, new Counter(),
+                    BudgetType.PROJECTILE, new Counter(),
+                    BudgetType.PARTICLE, new Counter());
+            this.pending = Map.of(
+                    BudgetType.ENTITY, new Counter(),
+                    BudgetType.ITEM, new Counter(),
+                    BudgetType.PROJECTILE, new Counter(),
+                    BudgetType.PARTICLE, new Counter());
+            this.warnTimestamps = Map.of(
+                    BudgetType.ENTITY, new AtomicLong(),
+                    BudgetType.ITEM, new AtomicLong(),
+                    BudgetType.PROJECTILE, new AtomicLong(),
+                    BudgetType.PARTICLE, new AtomicLong());
+            apply(settings);
+        }
+
+        private void apply(CoreConfig.ArenaSettings settings) {
+            this.maxEntities = settings.maxEntities();
+            this.maxItems = settings.maxItems();
+            this.maxProjectiles = settings.maxProjectiles();
+            this.particlesSoftCap = settings.particlesSoftCap();
+            this.particlesHardCap = settings.particlesHardCap();
+        }
+
+        private boolean canReserve(BudgetType type, int amount) {
+            long limit = limitFor(type);
+            if (limit <= 0) {
+                return false;
+            }
+            long used = active.get(type).value() + pending.get(type).value();
+            return used + amount <= limit;
+        }
+
+        private void addPending(BudgetType type, int amount) {
+            pending.get(type).add(amount);
+        }
+
+        private void confirm(BudgetType type, int amount) {
+            pending.get(type).remove(amount);
+            active.get(type).add(amount);
+        }
+
+        private void cancelPending(BudgetType type, int amount) {
+            pending.get(type).remove(amount);
+        }
+
+        private void addExisting(BudgetType type, int amount) {
+            active.get(type).add(amount);
+        }
+
+        private void release(BudgetType type, int amount) {
+            active.get(type).remove(amount);
+        }
+
+        private void trackParticles(int count, NexusLogger logger) {
+            if (count <= 0) {
+                return;
+            }
+            long current;
+            synchronized (particleLock) {
+                long window = System.currentTimeMillis() / 50L;
+                long previous = particleWindow.get();
+                if (previous != window) {
+                    particleCounter.reset();
+                    particleWindow.set(window);
+                }
+                particleCounter.add(count);
+                current = particleCounter.value();
+            }
+            if (current > particlesHardCap) {
+                warnParticles(logger, current, true);
+            } else if (current > particlesSoftCap) {
+                warnParticles(logger, current, false);
+            }
+        }
+
+        private void warnExceeded(BudgetType type, NexusLogger logger) {
+            long now = System.currentTimeMillis();
+            if (!shouldWarn(type, now)) {
+                return;
+            }
+            long activeCount = active.get(type).value();
+            long pendingCount = pending.get(type).value();
+            long limit = limitFor(type);
+            String message = "Budget pour %s dépassé dans l'arène %s (map=%s, mode=%s). Spawn annulé. (Actuel: %d, en file: %d, Max: %d)"
+                    .formatted(type.label(), arenaId, mapId, mode, activeCount, pendingCount, limit);
+            logger.warn(message);
+        }
+
+        private void warnParticles(NexusLogger logger, long current, boolean hard) {
+            long now = System.currentTimeMillis();
+            if (!shouldWarn(BudgetType.PARTICLE, now)) {
+                return;
+            }
+            String severity = hard ? "hard" : "soft";
+            String message = "Budget %s des particules dépassé dans l'arène %s (map=%s, mode=%s). Actuel: %d, Soft: %d, Hard: %d"
+                    .formatted(severity, arenaId, mapId, mode, current, particlesSoftCap, particlesHardCap);
+            logger.warn(message);
+        }
+
+        private boolean shouldWarn(BudgetType type, long now) {
+            AtomicLong reference = warnTimestamps.get(type);
+            long previous = reference.get();
+            if (now - previous < WARN_INTERVAL_MS) {
+                return false;
+            }
+            return reference.compareAndSet(previous, now);
+        }
+
+        private long limitFor(BudgetType type) {
+            return switch (type) {
+                case ENTITY -> maxEntities;
+                case ITEM -> maxItems;
+                case PROJECTILE -> maxProjectiles;
+                case PARTICLE -> particlesHardCap;
+            };
+        }
+
+        private BudgetSnapshot snapshot() {
+            long particles;
+            synchronized (particleLock) {
+                particles = particleCounter.value();
+            }
+            return new BudgetSnapshot(
+                    arenaId,
+                    mapId,
+                    mode,
+                    active.get(BudgetType.ENTITY).value(),
+                    pending.get(BudgetType.ENTITY).value(),
+                    maxEntities,
+                    active.get(BudgetType.ITEM).value(),
+                    pending.get(BudgetType.ITEM).value(),
+                    maxItems,
+                    active.get(BudgetType.PROJECTILE).value(),
+                    pending.get(BudgetType.PROJECTILE).value(),
+                    maxProjectiles,
+                    particles,
+                    particlesSoftCap,
+                    particlesHardCap);
+        }
+    }
+
+    private static final class Counter {
+        private final LongAdder additions = new LongAdder();
+        private final LongAdder removals = new LongAdder();
+
+        private void add(long amount) {
+            if (amount <= 0) {
+                return;
+            }
+            additions.add(amount);
+        }
+
+        private void remove(long amount) {
+            if (amount <= 0) {
+                return;
+            }
+            removals.add(amount);
+        }
+
+        private void reset() {
+            additions.reset();
+            removals.reset();
+        }
+
+        private long value() {
+            long current = additions.sum() - removals.sum();
+            return Math.max(0L, current);
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/budget/BudgetSnapshot.java
+++ b/src/main/java/com/heneria/nexus/budget/BudgetSnapshot.java
@@ -1,0 +1,24 @@
+package com.heneria.nexus.budget;
+
+import com.heneria.nexus.service.api.ArenaMode;
+import java.util.UUID;
+
+/**
+ * Immutable snapshot describing the live counters of an arena budget.
+ */
+public record BudgetSnapshot(UUID arenaId,
+                              String mapId,
+                              ArenaMode mode,
+                              long entities,
+                              long pendingEntities,
+                              long maxEntities,
+                              long items,
+                              long pendingItems,
+                              long maxItems,
+                              long projectiles,
+                              long pendingProjectiles,
+                              long maxProjectiles,
+                              long particles,
+                              long particlesSoftCap,
+                              long particlesHardCap) {
+}

--- a/src/main/java/com/heneria/nexus/budget/BudgetType.java
+++ b/src/main/java/com/heneria/nexus/budget/BudgetType.java
@@ -1,0 +1,22 @@
+package com.heneria.nexus.budget;
+
+/**
+ * Enumerates the different runtime budgets enforced for arenas.
+ */
+public enum BudgetType {
+
+    ENTITY("entités"),
+    ITEM("items"),
+    PROJECTILE("projectiles"),
+    PARTICLE("particules");
+
+    private final String label;
+
+    BudgetType(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+}

--- a/src/main/java/com/heneria/nexus/budget/listener/EntitySpawnListener.java
+++ b/src/main/java/com/heneria/nexus/budget/listener/EntitySpawnListener.java
@@ -1,0 +1,56 @@
+package com.heneria.nexus.budget.listener;
+
+import com.heneria.nexus.budget.BudgetService;
+import com.heneria.nexus.budget.BudgetType;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntitySpawnEvent;
+
+/**
+ * Intercepts entity spawns (excluding items and projectiles) to enforce budgets.
+ */
+public final class EntitySpawnListener implements Listener {
+
+    private final BudgetService budgetService;
+
+    public EntitySpawnListener(BudgetService budgetService) {
+        this.budgetService = budgetService;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntitySpawn(EntitySpawnEvent event) {
+        Entity entity = event.getEntity();
+        EntityType type = entity.getType();
+        if (type == EntityType.PLAYER || type == EntityType.DROPPED_ITEM || entity instanceof Projectile) {
+            return;
+        }
+        Optional<UUID> arenaId = budgetService.resolveArenaId(entity.getLocation());
+        if (arenaId.isEmpty()) {
+            return;
+        }
+        if (!budgetService.canSpawn(arenaId.get(), type, 1)) {
+            event.setCancelled(true);
+            return;
+        }
+        budgetService.markPending(arenaId.get(), entity, BudgetType.ENTITY);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
+    public void onEntitySpawnPost(EntitySpawnEvent event) {
+        Entity entity = event.getEntity();
+        EntityType type = entity.getType();
+        if (type == EntityType.PLAYER || type == EntityType.DROPPED_ITEM || entity instanceof Projectile) {
+            return;
+        }
+        if (!event.isCancelled()) {
+            return;
+        }
+        budgetService.cancelPending(entity);
+    }
+}

--- a/src/main/java/com/heneria/nexus/budget/listener/ItemSpawnListener.java
+++ b/src/main/java/com/heneria/nexus/budget/listener/ItemSpawnListener.java
@@ -1,0 +1,45 @@
+package com.heneria.nexus.budget.listener;
+
+import com.heneria.nexus.budget.BudgetService;
+import com.heneria.nexus.budget.BudgetType;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.entity.Item;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemSpawnEvent;
+
+/**
+ * Enforces item stack budgets for arenas.
+ */
+public final class ItemSpawnListener implements Listener {
+
+    private final BudgetService budgetService;
+
+    public ItemSpawnListener(BudgetService budgetService) {
+        this.budgetService = budgetService;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemSpawn(ItemSpawnEvent event) {
+        Item entity = event.getEntity();
+        Optional<UUID> arenaId = budgetService.resolveArenaId(entity.getLocation());
+        if (arenaId.isEmpty()) {
+            return;
+        }
+        if (!budgetService.canSpawn(arenaId.get(), entity.getType(), 1)) {
+            event.setCancelled(true);
+            return;
+        }
+        budgetService.markPending(arenaId.get(), entity, BudgetType.ITEM);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
+    public void onItemSpawnPost(ItemSpawnEvent event) {
+        if (!event.isCancelled()) {
+            return;
+        }
+        budgetService.cancelPending(event.getEntity());
+    }
+}

--- a/src/main/java/com/heneria/nexus/budget/listener/ProjectileLaunchListener.java
+++ b/src/main/java/com/heneria/nexus/budget/listener/ProjectileLaunchListener.java
@@ -1,0 +1,45 @@
+package com.heneria.nexus.budget.listener;
+
+import com.heneria.nexus.budget.BudgetService;
+import com.heneria.nexus.budget.BudgetType;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+
+/**
+ * Guards projectile launches to ensure arena budgets are respected.
+ */
+public final class ProjectileLaunchListener implements Listener {
+
+    private final BudgetService budgetService;
+
+    public ProjectileLaunchListener(BudgetService budgetService) {
+        this.budgetService = budgetService;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onProjectileLaunch(ProjectileLaunchEvent event) {
+        Projectile projectile = event.getEntity();
+        Optional<UUID> arenaId = budgetService.resolveArenaId(projectile.getLocation());
+        if (arenaId.isEmpty()) {
+            return;
+        }
+        if (!budgetService.canSpawn(arenaId.get(), projectile.getType(), 1)) {
+            event.setCancelled(true);
+            return;
+        }
+        budgetService.markPending(arenaId.get(), projectile, BudgetType.PROJECTILE);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
+    public void onProjectileLaunchPost(ProjectileLaunchEvent event) {
+        if (!event.isCancelled()) {
+            return;
+        }
+        budgetService.cancelPending(event.getEntity());
+    }
+}

--- a/src/main/java/com/heneria/nexus/command/NexusCommand.java
+++ b/src/main/java/com/heneria/nexus/command/NexusCommand.java
@@ -15,7 +15,7 @@ import org.bukkit.command.TabCompleter;
  */
 public final class NexusCommand implements CommandExecutor, TabCompleter {
 
-    private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump");
+    private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump", "budget");
 
     private final NexusPlugin plugin;
 
@@ -43,6 +43,10 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                 plugin.handleDump(sender);
                 yield true;
             }
+            case "budget" -> {
+                plugin.handleBudget(sender, args);
+                yield true;
+            }
             default -> {
                 plugin.sendHelp(sender);
                 yield true;
@@ -56,13 +60,20 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
             String prefix = args[0].toLowerCase(Locale.ROOT);
             return SUB_COMMANDS.stream()
                     .filter(sub -> {
-                        if (sub.equals("reload") || sub.equals("dump")) {
+                        if (sub.equals("reload") || sub.equals("dump") || sub.equals("budget")) {
                             return sender.hasPermission("nexus.admin." + sub);
                         }
                         return true;
                     })
                     .filter(sub -> sub.startsWith(prefix))
                     .collect(Collectors.toList());
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("budget")) {
+            if (!sender.hasPermission("nexus.admin.budget")) {
+                return Collections.emptyList();
+            }
+            String prefix = args[1].toLowerCase(Locale.ROOT);
+            return plugin.suggestBudgetArenas(prefix);
         }
         return Collections.emptyList();
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -10,6 +10,7 @@ help:
   admin:
     reload: "<gray>/nexus reload</gray> <dark_gray>-</dark_gray> <yellow>Recharge les configurations et messages.</yellow>"
     dump: "<gray>/nexus dump</gray> <dark_gray>-</dark_gray> <yellow>Affiche l'état courant (threads, DB, scheduler).</yellow>"
+    budget: "<gray>/nexus budget [arène]</gray> <dark_gray>-</dark_gray> <yellow>Inspecte les budgets en cours.</yellow>"
 
 errors:
   no_permission: "<red>Vous n'avez pas la permission requise.</red>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ load: POSTWORLD
 commands:
   nexus:
     description: Commande principale du plugin Nexus.
-    usage: /<command> help|reload|dump
+    usage: /<command> help|reload|dump|budget [arena]
     permission: nexus.use
     aliases: [nx]
 permissions:
@@ -21,9 +21,13 @@ permissions:
   nexus.admin.dump:
     description: Afficher un dump d'état Nexus.
     default: op
+  nexus.admin.budget:
+    description: Inspecter les budgets des arènes.
+    default: op
   nexus.admin.*:
     description: Accès complet aux commandes d'administration Nexus.
     default: op
     children:
       nexus.admin.reload: true
       nexus.admin.dump: true
+      nexus.admin.budget: true


### PR DESCRIPTION
## Summary
- add a budget service that tracks arena entities, projectiles, items and particles with per-arena counters and throttled warnings
- listen to spawn, launch and lifecycle events while integrating the new service into arena creation, configuration reloads and dumps
- expose an admin `/nexus budget` command plus permissions and help entries to inspect live budgets

## Testing
- mvn -q -DskipTests package *(fails: network unreachable when resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cfda5507ec832491c1d283ff44f47c