### PR TITLE
Implement internal hologram service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <paper.version>1.21.1-R0.1-SNAPSHOT</paper.version>
         <mariadb.version>3.3.3</mariadb.version>
         <hikari.version>5.1.0</hikari.version>
+        <placeholderapi.version>2.11.5</placeholderapi.version>
     </properties>
 
     <repositories>
@@ -50,6 +51,12 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${mariadb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>${placeholderapi.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/heneria/nexus/command/NexusCommand.java
+++ b/src/main/java/com/heneria/nexus/command/NexusCommand.java
@@ -15,7 +15,8 @@ import org.bukkit.command.TabCompleter;
  */
 public final class NexusCommand implements CommandExecutor, TabCompleter {
 
-    private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump", "budget");
+    private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump", "budget", "holo");
+    private static final List<String> HOLO_SUB = List.of("create", "remove", "move", "list", "reload");
 
     private final NexusPlugin plugin;
 
@@ -47,6 +48,10 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                 plugin.handleBudget(sender, args);
                 yield true;
             }
+            case "holo" -> {
+                plugin.handleHologram(sender, args);
+                yield true;
+            }
             default -> {
                 plugin.sendHelp(sender);
                 yield true;
@@ -63,10 +68,32 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                         if (sub.equals("reload") || sub.equals("dump") || sub.equals("budget")) {
                             return sender.hasPermission("nexus.admin." + sub);
                         }
+                        if (sub.equals("holo")) {
+                            return sender.hasPermission("nexus.holo.manage");
+                        }
                         return true;
                     })
                     .filter(sub -> sub.startsWith(prefix))
                     .collect(Collectors.toList());
+        }
+        if (args.length >= 2 && args[0].equalsIgnoreCase("holo")) {
+            if (!sender.hasPermission("nexus.holo.manage")) {
+                return Collections.emptyList();
+            }
+            if (args.length == 2) {
+                String prefix = args[1].toLowerCase(Locale.ROOT);
+                return HOLO_SUB.stream()
+                        .filter(sub -> sub.startsWith(prefix))
+                        .toList();
+            }
+            if (args.length == 3 && (args[1].equalsIgnoreCase("move") || args[1].equalsIgnoreCase("remove"))) {
+                String prefix = args[2].toLowerCase(Locale.ROOT);
+                return plugin.suggestHolograms(prefix);
+            }
+            if (args.length == 4 && args[1].equalsIgnoreCase("create")) {
+                String prefix = args[3].toLowerCase(Locale.ROOT);
+                return "default".startsWith(prefix) ? List.of("default") : Collections.emptyList();
+            }
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("budget")) {
             if (!sender.hasPermission("nexus.admin.budget")) {

--- a/src/main/java/com/heneria/nexus/config/ConfigManager.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigManager.java
@@ -32,6 +32,7 @@ public final class ConfigManager implements AutoCloseable {
     private static final String MESSAGES_FILE = "messages.yml";
     private static final String MAPS_FILE = "maps.yml";
     private static final String ECONOMY_FILE = "economy.yml";
+    private static final String HOLOGRAMS_FILE = "holograms.yml";
 
     private final JavaPlugin plugin;
     private final NexusLogger logger;
@@ -189,6 +190,7 @@ public final class ConfigManager implements AutoCloseable {
         copyResourceIfMissing(MESSAGES_FILE);
         copyResourceIfMissing(MAPS_FILE);
         copyResourceIfMissing(ECONOMY_FILE);
+        copyResourceIfMissing(HOLOGRAMS_FILE);
     }
 
     private void copyResourceIfMissing(String resource) {

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -22,6 +22,7 @@ public final class CoreConfig {
     private final TimeoutSettings timeoutSettings;
     private final DegradedModeSettings degradedModeSettings;
     private final QueueSettings queueSettings;
+    private final HologramSettings hologramSettings;
     private final UiSettings uiSettings;
 
     public CoreConfig(String serverMode,
@@ -34,6 +35,7 @@ public final class CoreConfig {
                       TimeoutSettings timeoutSettings,
                       DegradedModeSettings degradedModeSettings,
                       QueueSettings queueSettings,
+                      HologramSettings hologramSettings,
                       UiSettings uiSettings) {
         this.serverMode = Objects.requireNonNull(serverMode, "serverMode");
         this.language = Objects.requireNonNull(language, "language");
@@ -45,6 +47,7 @@ public final class CoreConfig {
         this.timeoutSettings = Objects.requireNonNull(timeoutSettings, "timeoutSettings");
         this.degradedModeSettings = Objects.requireNonNull(degradedModeSettings, "degradedModeSettings");
         this.queueSettings = Objects.requireNonNull(queueSettings, "queueSettings");
+        this.hologramSettings = Objects.requireNonNull(hologramSettings, "hologramSettings");
         this.uiSettings = Objects.requireNonNull(uiSettings, "uiSettings");
     }
 
@@ -86,6 +89,10 @@ public final class CoreConfig {
 
     public QueueSettings queueSettings() {
         return queueSettings;
+    }
+
+    public HologramSettings hologramSettings() {
+        return hologramSettings;
     }
 
     public UiSettings uiSettings() {
@@ -187,6 +194,34 @@ public final class CoreConfig {
     }
 
     public record ServiceSettings(boolean exposeBukkitServices) {
+    }
+
+    public record HologramSettings(int updateHz,
+                                   int maxVisiblePerInstance,
+                                   double lineSpacing,
+                                   double viewRange,
+                                   int maxPooledTextDisplays,
+                                   int maxPooledInteractions) {
+        public HologramSettings {
+            if (updateHz <= 0) {
+                throw new IllegalArgumentException("updateHz must be positive");
+            }
+            if (maxVisiblePerInstance <= 0) {
+                throw new IllegalArgumentException("maxVisiblePerInstance must be positive");
+            }
+            if (lineSpacing <= 0D) {
+                throw new IllegalArgumentException("lineSpacing must be > 0");
+            }
+            if (viewRange <= 0D) {
+                throw new IllegalArgumentException("viewRange must be > 0");
+            }
+            if (maxPooledTextDisplays < 0) {
+                throw new IllegalArgumentException("maxPooledTextDisplays must be >= 0");
+            }
+            if (maxPooledInteractions < 0) {
+                throw new IllegalArgumentException("maxPooledInteractions must be >= 0");
+            }
+        }
     }
 
     public record TimeoutSettings(long startMs, long stopMs, WatchdogSettings watchdog) {

--- a/src/main/java/com/heneria/nexus/hologram/HoloService.java
+++ b/src/main/java/com/heneria/nexus/hologram/HoloService.java
@@ -1,0 +1,52 @@
+package com.heneria.nexus.hologram;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.bukkit.Location;
+
+/**
+ * API publique pour la gestion des hologrammes Nexus.
+ */
+public interface HoloService extends LifecycleAware {
+
+    /**
+     * Recharge toutes les définitions depuis holograms.yml.
+     */
+    void loadFromConfig();
+
+    /**
+     * Crée un nouvel hologramme dynamique.
+     */
+    Hologram createHologram(String id, Location location, List<String> lines);
+
+    /**
+     * Retourne un hologramme par son identifiant unique.
+     */
+    Optional<Hologram> getHologram(String id);
+
+    /**
+     * Supprime un hologramme et libère ses entités.
+     */
+    void removeHologram(String id);
+
+    /**
+     * Retourne la collection des hologrammes actifs.
+     */
+    Collection<Hologram> holograms();
+
+    /**
+     * Applique les paramètres runtime provenant de config.yml.
+     */
+    void applySettings(CoreConfig.HologramSettings settings);
+
+    /**
+     * Retourne les statistiques courantes utilisées par /nexus dump.
+     */
+    Diagnostics diagnostics();
+
+    record Diagnostics(int activeHolograms, int pooledTextDisplays, int pooledInteractions) {
+    }
+}

--- a/src/main/java/com/heneria/nexus/hologram/HoloServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/hologram/HoloServiceImpl.java
@@ -1,0 +1,245 @@
+package com.heneria.nexus.hologram;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.scheduler.GamePhase;
+import com.heneria.nexus.scheduler.RingScheduler;
+import com.heneria.nexus.util.NexusLogger;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Implémentation par défaut du {@link HoloService} basée sur les entités TextDisplay.
+ */
+public final class HoloServiceImpl implements HoloService {
+
+    private static final String CONFIG_FILE = "holograms.yml";
+    private static final String UPDATE_TASK_ID = "hologram-update";
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final RingScheduler scheduler;
+    private final AtomicReference<CoreConfig.HologramSettings> settingsRef;
+    private final HologramPool pool;
+    private final HologramFactory factory;
+    private final ConcurrentMap<String, HologramEntry> holograms = new ConcurrentHashMap<>();
+    private final AtomicBoolean placeholderFailureLogged = new AtomicBoolean();
+    private final boolean placeholderApiAvailable;
+
+    public HoloServiceImpl(JavaPlugin plugin, NexusLogger logger, CoreConfig coreConfig, RingScheduler scheduler) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        this.settingsRef = new AtomicReference<>(coreConfig.hologramSettings());
+        this.pool = new HologramPool(plugin, logger, coreConfig.hologramSettings());
+        this.placeholderApiAvailable = detectPlaceholderApi();
+        UnaryOperator<String> resolver = buildPlaceholderResolver();
+        this.factory = new HologramFactory(plugin, logger, pool, settingsRef::get, resolver);
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        scheduler.registerTask(UPDATE_TASK_ID, hzToTicks(settingsRef.get().updateHz()),
+                EnumSet.allOf(GamePhase.class), this::tick);
+        loadFromConfig();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        scheduler.unregisterTask(UPDATE_TASK_ID);
+        holograms.values().forEach(entry -> entry.hologram.destroy());
+        holograms.clear();
+        pool.clear();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public synchronized void loadFromConfig() {
+        removePersistent();
+        File file = new File(plugin.getDataFolder(), CONFIG_FILE);
+        if (!file.exists()) {
+            plugin.saveResource(CONFIG_FILE, false);
+        }
+        YamlConfiguration yaml = new YamlConfiguration();
+        try {
+            yaml.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            logger.warn("Lecture de " + CONFIG_FILE + " impossible", exception);
+            return;
+        }
+        ConfigurationSection hologramSection = yaml.getConfigurationSection("holograms");
+        if (hologramSection == null) {
+            logger.info("Chargé 0 hologrammes depuis " + CONFIG_FILE + ".");
+            return;
+        }
+        int loaded = 0;
+        for (String id : hologramSection.getKeys(false)) {
+            if (id == null || id.isBlank()) {
+                continue;
+            }
+            if (holograms.containsKey(id)) {
+                logger.warn("Hologramme " + id + " déjà chargé, définition ignorée");
+                continue;
+            }
+            ConfigurationSection section = hologramSection.getConfigurationSection(id);
+            if (section == null) {
+                logger.warn("Définition invalide pour " + id + " : section manquante");
+                continue;
+            }
+            String worldName = section.getString("world");
+            if (worldName == null || worldName.isBlank()) {
+                logger.warn("Hologramme " + id + " ignoré: monde non défini");
+                continue;
+            }
+            World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                logger.warn("Hologramme " + id + " ignoré: monde inexistant (" + worldName + ")");
+                continue;
+            }
+            double x = section.getDouble("x");
+            double y = section.getDouble("y");
+            double z = section.getDouble("z");
+            float yaw = (float) section.getDouble("yaw", 0D);
+            float pitch = (float) section.getDouble("pitch", 0D);
+            List<String> lines = section.getStringList("lines");
+            String group = section.getString("group", "default");
+            Location location = new Location(world, x, y, z, yaw, pitch);
+            registerFromConfig(id, location, lines, group);
+            loaded++;
+        }
+        logger.info("Chargé " + loaded + " hologrammes depuis " + CONFIG_FILE + ".");
+    }
+
+    @Override
+    public Hologram createHologram(String id, Location location, List<String> lines) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(lines, "lines");
+        if (holograms.containsKey(id)) {
+            throw new IllegalArgumentException("Hologramme " + id + " déjà enregistré");
+        }
+        Hologram hologram = factory.create(id, location.clone(), List.copyOf(lines), "default");
+        holograms.put(id, new HologramEntry(hologram, false));
+        warnPlaceholderIfNeeded(hologram);
+        return hologram;
+    }
+
+    @Override
+    public Optional<Hologram> getHologram(String id) {
+        HologramEntry entry = holograms.get(id);
+        return entry == null ? Optional.empty() : Optional.of(entry.hologram);
+    }
+
+    @Override
+    public void removeHologram(String id) {
+        HologramEntry entry = holograms.remove(id);
+        if (entry == null) {
+            return;
+        }
+        entry.hologram.destroy();
+    }
+
+    @Override
+    public Collection<Hologram> holograms() {
+        return holograms.values().stream().map(entry -> entry.hologram).toList();
+    }
+
+    @Override
+    public void applySettings(CoreConfig.HologramSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        settingsRef.set(settings);
+        pool.updateLimits(settings);
+        scheduler.updateTaskInterval(UPDATE_TASK_ID, hzToTicks(settings.updateHz()));
+        holograms.values().forEach(entry -> entry.hologram.applySettings(settings));
+    }
+
+    @Override
+    public Diagnostics diagnostics() {
+        return new Diagnostics(holograms.size(), pool.pooledTextDisplays(), pool.pooledInteractions());
+    }
+
+    private void registerFromConfig(String id, Location location, List<String> lines, String group) {
+        List<String> sanitized = lines == null ? List.of() : List.copyOf(lines);
+        Hologram hologram = factory.create(id, location, sanitized, group);
+        holograms.put(id, new HologramEntry(hologram, true));
+        warnPlaceholderIfNeeded(hologram);
+    }
+
+    private void removePersistent() {
+        for (Map.Entry<String, HologramEntry> entry : new ArrayList<>(holograms.entrySet())) {
+            if (!entry.getValue().persistent) {
+                continue;
+            }
+            entry.getValue().hologram.destroy();
+            holograms.remove(entry.getKey());
+        }
+    }
+
+    private void tick() {
+        holograms.values().forEach(entry -> entry.hologram.tick());
+    }
+
+    private long hzToTicks(int hz) {
+        return Math.max(1L, Math.round(20.0D / Math.max(1, hz)));
+    }
+
+    private boolean detectPlaceholderApi() {
+        PluginManager manager = plugin.getServer().getPluginManager();
+        boolean present = manager.getPlugin("PlaceholderAPI") != null;
+        if (!present) {
+            logger.warn("PlaceholderAPI introuvable, les placeholders des hologrammes resteront bruts.");
+        }
+        return present;
+    }
+
+    private UnaryOperator<String> buildPlaceholderResolver() {
+        if (!placeholderApiAvailable) {
+            return value -> value;
+        }
+        return value -> {
+            try {
+                return PlaceholderAPI.setPlaceholders(null, value);
+            } catch (Throwable throwable) {
+                if (placeholderFailureLogged.compareAndSet(false, true)) {
+                    logger.warn("Erreur lors de l'évaluation PlaceholderAPI", throwable);
+                }
+                return value;
+            }
+        };
+    }
+
+    private void warnPlaceholderIfNeeded(Hologram hologram) {
+        if (!placeholderApiAvailable && hologram.hasDynamicLines()) {
+            logger.warn("Hologramme " + hologram.id() + " utilise des placeholders sans PlaceholderAPI.");
+        }
+    }
+
+    private record HologramEntry(Hologram hologram, boolean persistent) {
+        private HologramEntry {
+            Objects.requireNonNull(hologram, "hologram");
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/hologram/Hologram.java
+++ b/src/main/java/com/heneria/nexus/hologram/Hologram.java
@@ -1,0 +1,385 @@
+package com.heneria.nexus.hologram;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.UnaryOperator;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Interaction;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Représente un hologramme multi-lignes rendu via les entités Display.
+ */
+public final class Hologram {
+
+    private final String id;
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final HologramPool pool;
+    private final MiniMessage miniMessage;
+    private final UnaryOperator<String> placeholderResolver;
+    private final List<Line> lines = new ArrayList<>();
+    private final List<TextDisplay> displays = new ArrayList<>();
+    private final Set<UUID> viewers = new CopyOnWriteArraySet<>();
+
+    private volatile Location baseLocation;
+    private volatile String group = "default";
+    private volatile double lineSpacing;
+    private volatile double viewRange;
+    private volatile int maxVisible;
+    private volatile boolean disposed;
+    private Interaction interaction;
+
+    Hologram(String id,
+             JavaPlugin plugin,
+             NexusLogger logger,
+             HologramPool pool,
+             MiniMessage miniMessage,
+             UnaryOperator<String> placeholderResolver,
+             CoreConfig.HologramSettings settings) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.pool = Objects.requireNonNull(pool, "pool");
+        this.miniMessage = Objects.requireNonNull(miniMessage, "miniMessage");
+        this.placeholderResolver = Objects.requireNonNull(placeholderResolver, "placeholderResolver");
+        applySettings(settings);
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String group() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        if (group == null || group.isBlank()) {
+            this.group = "default";
+            return;
+        }
+        this.group = group.toLowerCase(Locale.ROOT);
+    }
+
+    public Location location() {
+        return baseLocation == null ? null : baseLocation.clone();
+    }
+
+    public List<String> lines() {
+        return lines.stream().map(Line::raw).toList();
+    }
+
+    void applySettings(CoreConfig.HologramSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        this.lineSpacing = settings.lineSpacing();
+        this.viewRange = settings.viewRange();
+        this.maxVisible = settings.maxVisiblePerInstance();
+        for (TextDisplay display : displays) {
+            display.setViewRange((float) viewRange);
+        }
+        updatePositions();
+    }
+
+    public void teleport(Location location) {
+        ensureNotDisposed();
+        Objects.requireNonNull(location, "location");
+        this.baseLocation = location.clone();
+        updatePositions();
+    }
+
+    public void updateLines(List<String> newLines) {
+        ensureNotDisposed();
+        Objects.requireNonNull(newLines, "newLines");
+        Location location = Objects.requireNonNull(baseLocation, "location");
+        List<String> sanitized = newLines.stream().map(line -> line == null ? "" : line).toList();
+        for (int index = 0; index < sanitized.size(); index++) {
+            if (index < lines.size()) {
+                lines.get(index).updateRaw(sanitized.get(index));
+                continue;
+            }
+            TextDisplay display = pool.borrowTextDisplay(location, viewRange);
+            displays.add(display);
+            Line line = new Line(sanitized.get(index));
+            lines.add(line);
+        }
+        while (lines.size() > sanitized.size()) {
+            int lastIndex = lines.size() - 1;
+            Line removed = lines.remove(lastIndex);
+            TextDisplay display = displays.remove(lastIndex);
+            pool.releaseTextDisplay(display, resolveOnlineViewers());
+        }
+        updatePositions();
+        ensureInteraction();
+        lines.forEach(Line::markDirty);
+        tick();
+    }
+
+    public void showTo(Player player) {
+        ensureNotDisposed();
+        Objects.requireNonNull(player, "player");
+        if (!player.isOnline()) {
+            return;
+        }
+        if (baseLocation == null || !player.getWorld().equals(baseLocation.getWorld())) {
+            return;
+        }
+        if (!canView(player)) {
+            return;
+        }
+        cleanupViewers();
+        UUID uuid = player.getUniqueId();
+        if (!viewers.contains(uuid)) {
+            if (viewers.size() >= maxVisible) {
+                return;
+            }
+            viewers.add(uuid);
+        }
+        for (TextDisplay display : displays) {
+            player.showEntity(plugin, display);
+        }
+        if (interaction != null) {
+            player.showEntity(plugin, interaction);
+        }
+        tick();
+    }
+
+    public void hideFrom(Player player) {
+        Objects.requireNonNull(player, "player");
+        UUID uuid = player.getUniqueId();
+        if (!viewers.remove(uuid)) {
+            return;
+        }
+        for (TextDisplay display : displays) {
+            player.hideEntity(plugin, display);
+        }
+        if (interaction != null) {
+            player.hideEntity(plugin, interaction);
+        }
+    }
+
+    public void tick() {
+        if (disposed || baseLocation == null || lines.isEmpty()) {
+            return;
+        }
+        List<Player> activeViewers = cleanupViewers();
+        boolean hasViewers = !activeViewers.isEmpty();
+        boolean needsUpdate = false;
+        for (Line line : lines) {
+            if (line.needsUpdate(hasViewers)) {
+                needsUpdate = true;
+                break;
+            }
+        }
+        if (!needsUpdate) {
+            return;
+        }
+        renderLines();
+    }
+
+    boolean hasDynamicLines() {
+        return lines.stream().anyMatch(Line::dynamic);
+    }
+
+    void destroy() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        List<Player> activeViewers = resolveOnlineViewers();
+        for (Player player : activeViewers) {
+            for (TextDisplay display : displays) {
+                player.hideEntity(plugin, display);
+            }
+            if (interaction != null) {
+                player.hideEntity(plugin, interaction);
+            }
+        }
+        viewers.clear();
+        for (TextDisplay display : displays) {
+            pool.releaseTextDisplay(display, activeViewers);
+        }
+        displays.clear();
+        lines.clear();
+        if (interaction != null) {
+            pool.releaseInteraction(interaction, activeViewers);
+            interaction = null;
+        }
+    }
+
+    private boolean canView(Player player) {
+        return player.hasPermission("nexus.holo.view." + group)
+                || player.hasPermission("nexus.holo.view.*")
+                || player.hasPermission("nexus.holo.manage");
+    }
+
+    private List<Player> cleanupViewers() {
+        List<Player> players = new ArrayList<>();
+        Iterator<UUID> iterator = viewers.iterator();
+        while (iterator.hasNext()) {
+            UUID uuid = iterator.next();
+            Player player = Bukkit.getPlayer(uuid);
+            if (player == null || !player.isOnline()) {
+                iterator.remove();
+                continue;
+            }
+            if (baseLocation != null && !player.getWorld().equals(baseLocation.getWorld())) {
+                for (TextDisplay display : displays) {
+                    player.hideEntity(plugin, display);
+                }
+                if (interaction != null) {
+                    player.hideEntity(plugin, interaction);
+                }
+                iterator.remove();
+                continue;
+            }
+            players.add(player);
+        }
+        return players;
+    }
+
+    private List<Player> resolveOnlineViewers() {
+        List<Player> players = new ArrayList<>();
+        for (UUID uuid : viewers) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                players.add(player);
+            }
+        }
+        return players;
+    }
+
+    private void ensureInteraction() {
+        if (lines.isEmpty()) {
+            if (interaction != null) {
+                pool.releaseInteraction(interaction, resolveOnlineViewers());
+                interaction = null;
+            }
+            return;
+        }
+        if (interaction == null) {
+            interaction = pool.borrowInteraction(baseLocation);
+        }
+        updateInteractionBounds();
+    }
+
+    private void updatePositions() {
+        if (baseLocation == null || displays.isEmpty()) {
+            return;
+        }
+        Location origin = baseLocation.clone();
+        for (int index = 0; index < displays.size(); index++) {
+            TextDisplay display = displays.get(index);
+            Location target = origin.clone().subtract(0D, lineSpacing * index, 0D);
+            display.teleport(target);
+        }
+        updateInteractionBounds();
+    }
+
+    private void updateInteractionBounds() {
+        if (interaction == null || baseLocation == null || lines.isEmpty()) {
+            return;
+        }
+        double height = Math.max(0.3D, lineSpacing * lines.size());
+        Location center = baseLocation.clone().subtract(0D, lineSpacing * (lines.size() - 1) / 2D, 0D);
+        interaction.teleport(center);
+        interaction.setInteractionHeight((float) height);
+        interaction.setInteractionWidth(1.4F);
+    }
+
+    private void renderLines() {
+        for (int index = 0; index < lines.size(); index++) {
+            Line line = lines.get(index);
+            if (!line.shouldRender()) {
+                continue;
+            }
+            String resolved;
+            try {
+                resolved = placeholderResolver.apply(line.raw);
+            } catch (Exception exception) {
+                logger.warn("PlaceholderAPI a échoué pour l'hologramme " + id, exception);
+                resolved = line.raw;
+            }
+            if (!line.dirty && resolved.equals(line.lastResolved)) {
+                continue;
+            }
+            Component component = deserialize(resolved);
+            displays.get(index).setText(component);
+            line.onRendered(resolved);
+        }
+    }
+
+    private Component deserialize(String value) {
+        try {
+            return miniMessage.deserialize(value);
+        } catch (Exception exception) {
+            logger.warn("MiniMessage invalide pour l'hologramme " + id + ": " + value, exception);
+            return Component.text(value);
+        }
+    }
+
+    private void ensureNotDisposed() {
+        if (disposed) {
+            throw new IllegalStateException("Hologramme supprimé");
+        }
+    }
+
+    private static final class Line {
+
+        private String raw;
+        private boolean dirty = true;
+        private boolean dynamic;
+        private String lastResolved = "";
+
+        Line(String raw) {
+            updateRaw(raw);
+        }
+
+        String raw() {
+            return raw;
+        }
+
+        void updateRaw(String value) {
+            String sanitized = value == null ? "" : value;
+            if (!sanitized.equals(this.raw)) {
+                this.raw = sanitized;
+                this.dirty = true;
+            }
+            this.dynamic = sanitized.contains("%");
+        }
+
+        void markDirty() {
+            this.dirty = true;
+        }
+
+        boolean needsUpdate(boolean hasViewers) {
+            return dirty || (dynamic && hasViewers);
+        }
+
+        boolean shouldRender() {
+            return dirty || dynamic;
+        }
+
+        void onRendered(String resolved) {
+            this.lastResolved = resolved;
+            this.dirty = false;
+        }
+
+        boolean dynamic() {
+            return dynamic;
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/hologram/HologramFactory.java
+++ b/src/main/java/com/heneria/nexus/hologram/HologramFactory.java
@@ -1,0 +1,48 @@
+package com.heneria.nexus.hologram;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Fabrique centralisant l'initialisation des hologrammes.
+ */
+final class HologramFactory {
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final HologramPool pool;
+    private final Supplier<CoreConfig.HologramSettings> settingsSupplier;
+    private final UnaryOperator<String> placeholderResolver;
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+
+    HologramFactory(JavaPlugin plugin,
+                    NexusLogger logger,
+                    HologramPool pool,
+                    Supplier<CoreConfig.HologramSettings> settingsSupplier,
+                    UnaryOperator<String> placeholderResolver) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.pool = Objects.requireNonNull(pool, "pool");
+        this.settingsSupplier = Objects.requireNonNull(settingsSupplier, "settingsSupplier");
+        this.placeholderResolver = Objects.requireNonNull(placeholderResolver, "placeholderResolver");
+    }
+
+    Hologram create(String id, Location location, List<String> lines, String group) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(location, "location");
+        Hologram hologram = new Hologram(id, plugin, logger, pool, miniMessage, placeholderResolver, settingsSupplier.get());
+        hologram.setGroup(group);
+        hologram.teleport(location);
+        if (lines != null && !lines.isEmpty()) {
+            hologram.updateLines(lines);
+        }
+        return hologram;
+    }
+}

--- a/src/main/java/com/heneria/nexus/hologram/HologramPool.java
+++ b/src/main/java/com/heneria/nexus/hologram/HologramPool.java
@@ -1,0 +1,221 @@
+package com.heneria.nexus.hologram;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Interaction;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Pool réutilisable d'entités Display afin de limiter les allocations runtime.
+ */
+final class HologramPool {
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final ConcurrentLinkedDeque<TextDisplay> textPool = new ConcurrentLinkedDeque<>();
+    private final ConcurrentLinkedDeque<Interaction> interactionPool = new ConcurrentLinkedDeque<>();
+    private final AtomicInteger maxTextDisplays;
+    private final AtomicInteger maxInteractions;
+
+    HologramPool(JavaPlugin plugin, NexusLogger logger, CoreConfig.HologramSettings settings) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        Objects.requireNonNull(settings, "settings");
+        this.maxTextDisplays = new AtomicInteger(Math.max(0, settings.maxPooledTextDisplays()));
+        this.maxInteractions = new AtomicInteger(Math.max(0, settings.maxPooledInteractions()));
+    }
+
+    TextDisplay borrowTextDisplay(Location location, double viewRange) {
+        Objects.requireNonNull(location, "location");
+        TextDisplay display;
+        while ((display = textPool.pollFirst()) != null) {
+            if (!display.isValid() || display.isDead()) {
+                continue;
+            }
+            resetDisplay(display, location, viewRange);
+            return display;
+        }
+        return spawnDisplay(location, viewRange);
+    }
+
+    Interaction borrowInteraction(Location location) {
+        Objects.requireNonNull(location, "location");
+        Interaction interaction;
+        while ((interaction = interactionPool.pollFirst()) != null) {
+            if (!interaction.isValid() || interaction.isDead()) {
+                continue;
+            }
+            resetInteraction(interaction, location);
+            return interaction;
+        }
+        return spawnInteraction(location);
+    }
+
+    void releaseTextDisplay(TextDisplay display, Collection<Player> viewers) {
+        if (display == null) {
+            return;
+        }
+        hideFrom(viewers, display);
+        hideFromAll(display);
+        display.setText(Component.empty());
+        display.setGlowColorOverride(null);
+        if (!display.isValid() || textPool.size() >= maxTextDisplays.get()) {
+            display.remove();
+            return;
+        }
+        textPool.addLast(display);
+    }
+
+    void releaseInteraction(Interaction interaction, Collection<Player> viewers) {
+        if (interaction == null) {
+            return;
+        }
+        hideFrom(viewers, interaction);
+        hideFromAll(interaction);
+        interaction.setInteractionHeight(0F);
+        interaction.setInteractionWidth(0F);
+        if (!interaction.isValid() || interactionPool.size() >= maxInteractions.get()) {
+            interaction.remove();
+            return;
+        }
+        interactionPool.addLast(interaction);
+    }
+
+    void clear() {
+        textPool.forEach(entity -> {
+            try {
+                entity.remove();
+            } catch (Exception exception) {
+                logger.warn("Impossible de retirer un TextDisplay du pool", exception);
+            }
+        });
+        textPool.clear();
+        interactionPool.forEach(entity -> {
+            try {
+                entity.remove();
+            } catch (Exception exception) {
+                logger.warn("Impossible de retirer une Interaction du pool", exception);
+            }
+        });
+        interactionPool.clear();
+    }
+
+    void updateLimits(CoreConfig.HologramSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        maxTextDisplays.set(Math.max(0, settings.maxPooledTextDisplays()));
+        maxInteractions.set(Math.max(0, settings.maxPooledInteractions()));
+        trimPool(textPool, maxTextDisplays.get());
+        trimPool(interactionPool, maxInteractions.get());
+    }
+
+    int pooledTextDisplays() {
+        return textPool.size();
+    }
+
+    int pooledInteractions() {
+        return interactionPool.size();
+    }
+
+    private TextDisplay spawnDisplay(Location location, double viewRange) {
+        return location.getWorld().spawn(location, TextDisplay.class, entity -> {
+            entity.setPersistent(false);
+            entity.setGravity(false);
+            entity.setShadowed(false);
+            entity.setSeeThrough(true);
+            entity.setBillboard(Display.Billboard.CENTER);
+            entity.setAlignment(TextDisplay.TextAlignment.CENTER);
+            entity.setBrightness(new Display.Brightness(15, 15));
+            entity.setViewRange((float) viewRange);
+            entity.setRotation(location.getYaw(), location.getPitch());
+            entity.setText(Component.empty());
+            try {
+                entity.setVisibleByDefault(false);
+            } catch (NoSuchMethodError ignored) {
+                // Méthode absente selon la version Paper, on se contente de masquer via hideEntity.
+            }
+            hideFromAll(entity);
+        });
+    }
+
+    private void resetDisplay(TextDisplay display, Location location, double viewRange) {
+        display.teleport(location);
+        display.setViewRange((float) viewRange);
+        display.setRotation(location.getYaw(), location.getPitch());
+        display.setText(Component.empty());
+    }
+
+    private Interaction spawnInteraction(Location location) {
+        return location.getWorld().spawn(location, Interaction.class, entity -> {
+            entity.setPersistent(false);
+            entity.setGravity(false);
+            entity.setResponsive(false);
+            entity.setInteractionHeight(0F);
+            entity.setInteractionWidth(0F);
+            try {
+                entity.setVisibleByDefault(false);
+            } catch (NoSuchMethodError ignored) {
+                // Ignore lorsque l'API ne l'expose pas.
+            }
+            hideFromAll(entity);
+        });
+    }
+
+    private void resetInteraction(Interaction interaction, Location location) {
+        interaction.teleport(location);
+        interaction.setInteractionHeight(0F);
+        interaction.setInteractionWidth(0F);
+    }
+
+    private void hideFrom(Collection<Player> viewers, org.bukkit.entity.Entity entity) {
+        if (viewers == null || viewers.isEmpty()) {
+            return;
+        }
+        for (Player player : viewers) {
+            if (player == null) {
+                continue;
+            }
+            player.hideEntity(plugin, entity);
+        }
+    }
+
+    private void hideFromAll(org.bukkit.entity.Entity entity) {
+        for (Player player : plugin.getServer().getOnlinePlayers()) {
+            player.hideEntity(plugin, entity);
+        }
+    }
+
+    private <T extends org.bukkit.entity.Entity> void trimPool(ConcurrentLinkedDeque<T> pool, int maxSize) {
+        if (maxSize < 0) {
+            maxSize = 0;
+        }
+        if (pool.size() <= maxSize) {
+            return;
+        }
+        List<T> removed = new ArrayList<>();
+        Iterator<T> iterator = pool.descendingIterator();
+        while (pool.size() > maxSize && iterator.hasNext()) {
+            T entity = iterator.next();
+            iterator.remove();
+            removed.add(entity);
+        }
+        removed.forEach(entity -> {
+            try {
+                entity.remove();
+            } catch (Exception exception) {
+                logger.warn("Impossible de retirer une entité du pool", exception);
+            }
+        });
+    }
+}

--- a/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
+++ b/src/main/java/com/heneria/nexus/scheduler/RingScheduler.java
@@ -72,6 +72,17 @@ public final class RingScheduler implements LifecycleAware {
         tasks.put(id, new RingTask(id, runnable, phases, intervalTicks, offset));
     }
 
+    public void unregisterTask(String id) {
+        tasks.remove(id);
+    }
+
+    public void updateTaskInterval(String id, long intervalTicks) {
+        RingTask task = tasks.get(id);
+        if (task != null) {
+            task.updateInterval(intervalTicks);
+        }
+    }
+
     public void setPhase(GamePhase phase) {
         this.phase.set(Objects.requireNonNull(phase, "phase"));
     }

--- a/src/main/java/com/heneria/nexus/util/DumpUtil.java
+++ b/src/main/java/com/heneria/nexus/util/DumpUtil.java
@@ -5,6 +5,7 @@ import com.heneria.nexus.budget.BudgetSnapshot;
 import com.heneria.nexus.config.ConfigBundle;
 import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.hologram.HoloService;
 import com.heneria.nexus.scheduler.RingScheduler;
 import com.heneria.nexus.service.ServiceRegistry;
 import com.heneria.nexus.watchdog.WatchdogReport;
@@ -36,7 +37,8 @@ public final class DumpUtil {
                                              DbProvider dbProvider,
                                              ServiceRegistry serviceRegistry,
                                              BudgetService budgetService,
-                                             WatchdogService watchdogService) {
+                                             WatchdogService watchdogService,
+                                             HoloService holoService) {
         List<Component> lines = new ArrayList<>();
         lines.add(Component.text("=== État Nexus ===", NamedTextColor.GOLD));
         lines.add(Component.text("Serveur : " + server.getVersion(), NamedTextColor.YELLOW));
@@ -74,6 +76,13 @@ public final class DumpUtil {
         lines.add(Component.text("Connexions totales : " + dbDiagnostics.totalConnections(), NamedTextColor.GRAY));
         lines.add(Component.text("Threads en attente : " + dbDiagnostics.awaitingThreads(), NamedTextColor.GRAY));
         lines.add(Component.text("Tentatives échouées : " + dbDiagnostics.failedAttempts(), NamedTextColor.GRAY));
+
+        HoloService.Diagnostics holoDiagnostics = holoService.diagnostics();
+        lines.add(Component.empty());
+        lines.add(Component.text("-- Hologrammes --", NamedTextColor.AQUA));
+        lines.add(Component.text("Actifs : " + holoDiagnostics.activeHolograms(), NamedTextColor.GRAY));
+        lines.add(Component.text("Pool TextDisplay : " + holoDiagnostics.pooledTextDisplays(), NamedTextColor.GRAY));
+        lines.add(Component.text("Pool Interaction : " + holoDiagnostics.pooledInteractions(), NamedTextColor.GRAY));
 
         lines.add(Component.empty());
         lines.add(Component.text("-- Services --", NamedTextColor.AQUA));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -57,6 +57,15 @@ queue:
   tick_hz: 5
   vip_weight: 1
 
+holograms:
+  update_hz: 5
+  max_visible_per_instance: 80
+  line_spacing: 0.27
+  view_range: 48.0
+  pool:
+    max_text_displays: 64
+    max_interactions: 32
+
 ui:
   minimessage:
     strict: true

--- a/src/main/resources/holograms.yml
+++ b/src/main/resources/holograms.yml
@@ -1,0 +1,19 @@
+# =============================================
+#  Définition des hologrammes Nexus
+#  Chaque hologramme est défini par son monde, sa position et ses lignes.
+#  La position correspond à la première ligne (les lignes suivantes sont
+#  empilées vers le bas selon le line_spacing défini dans config.yml).
+# =============================================
+
+holograms:
+  hub_welcome:
+    world: world
+    x: 0.5
+    y: 70.5
+    z: 0.5
+    yaw: 180.0
+    pitch: 0.0
+    group: default
+    lines:
+      - "<gold>Bienvenue sur Nexus</gold>"
+      - "<gray>Tps: %server_tps%</gray>"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,6 +11,7 @@ help:
     reload: "<gray>/nexus reload</gray> <dark_gray>-</dark_gray> <yellow>Recharge les configurations et messages.</yellow>"
     dump: "<gray>/nexus dump</gray> <dark_gray>-</dark_gray> <yellow>Affiche l'état courant (threads, DB, scheduler).</yellow>"
     budget: "<gray>/nexus budget [arène]</gray> <dark_gray>-</dark_gray> <yellow>Inspecte les budgets en cours.</yellow>"
+    holo: "<gray>/nexus holo <create|remove|move|list|reload></gray> <dark_gray>-</dark_gray> <yellow>Gère les hologrammes.</yellow>"
 
 errors:
   no_permission: "<red>Vous n'avez pas la permission requise.</red>"
@@ -35,3 +36,22 @@ titles:
 bossbars:
   match_timer:
     name: "<gold>Temps restant : <white><timer/></white></gold>"
+
+holograms:
+  usage: "<gray>/nexus holo <create|remove|move|list|reload></gray>"
+  created: "<green>Hologramme <id> créé.</green>"
+  moved: "<green>Hologramme <id> déplacé.</green>"
+  removed: "<green>Hologramme <id> supprimé.</green>"
+  reload:
+    ok: "<green>Hologrammes rechargés depuis la configuration.</green>"
+  list:
+    header: "<gold>Hologrammes actifs (<count>) :</gold>"
+    entry: "<gray>- <white><id></white> @ <yellow><world></yellow> <aqua><x>, <y>, <z></aqua> (<lines> lignes, groupe <group>)</gray>"
+    empty: "<gray>Aucun hologramme actif.</gray>"
+  errors:
+    player_only: "<red>Cette commande doit être exécutée en jeu.</red>"
+    duplicate: "<red>Un hologramme avec l'identifiant <id> existe déjà.</red>"
+    not_found: "<red>Aucun hologramme trouvé pour <id>.</red>"
+    invalid_definition: "<red>Impossible de créer l'hologramme : aucune ligne valide.</red>"
+  create:
+    help: "<gray>Usage :</gray> <yellow>/nexus holo create <id> <groupe> <ligne1|ligne2|...></yellow>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ load: POSTWORLD
 commands:
   nexus:
     description: Commande principale du plugin Nexus.
-    usage: /<command> help|reload|dump|budget [arena]
+    usage: /<command> help|reload|dump|budget [arena]|holo
     permission: nexus.use
     aliases: [nx]
 permissions:
@@ -31,3 +31,12 @@ permissions:
       nexus.admin.reload: true
       nexus.admin.dump: true
       nexus.admin.budget: true
+  nexus.holo.manage:
+    description: Gérer les hologrammes Nexus via /nexus holo.
+    default: op
+  nexus.holo.view.default:
+    description: Voir les hologrammes du groupe default.
+    default: true
+  nexus.holo.view.*:
+    description: Voir tous les hologrammes, indépendamment du groupe.
+    default: op


### PR DESCRIPTION
## Summary
- add a new hologram module using pooled TextDisplay and Interaction entities with PlaceholderAPI support
- expose hologram management commands and configuration including holograms.yml loader and performance tuning
- surface hologram diagnostics in /nexus dump and integrate service lifecycle with the registry

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable while resolving plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cfeba486ec8324a09e3f1275143d6e