### PR TITLE
Fix DbProvider class loading for relocated MariaDB driver

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -97,6 +97,7 @@ public final class NexusPlugin extends JavaPlugin {
         this.messageFacade = new MessageFacade(bundle.messages(), logger);
         this.executorManager = new ExecutorManager(this, logger, bundle.core().executorSettings());
         this.serviceRegistry = new ServiceRegistry(logger);
+        this.dbProvider = new DbProvider(logger, this);
 
         registerSingletons();
         registerServices();
@@ -492,10 +493,10 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerSingleton(ConfigBundle.class, bundle);
         serviceRegistry.registerSingleton(CoreConfig.class, bundle.core());
         serviceRegistry.registerSingleton(ExecutorManager.class, executorManager);
+        serviceRegistry.registerSingleton(DbProvider.class, dbProvider);
     }
 
     private void registerServices() {
-        serviceRegistry.registerService(DbProvider.class, DbProvider.class);
         serviceRegistry.registerService(RingScheduler.class, RingScheduler.class);
         serviceRegistry.registerService(MapService.class, MapServiceImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/db/DbProvider.java
+++ b/src/main/java/com/heneria/nexus/db/DbProvider.java
@@ -6,6 +6,7 @@ import com.heneria.nexus.util.NexusLogger;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
+import org.bukkit.plugin.java.JavaPlugin;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -26,13 +27,15 @@ public final class DbProvider implements LifecycleAware {
     private static final Duration LEAK_DETECTION = Duration.ofSeconds(15);
 
     private final NexusLogger logger;
+    private final JavaPlugin plugin;
     private final AtomicReference<HikariDataSource> dataSourceRef = new AtomicReference<>();
     private final AtomicReference<CoreConfig.DatabaseSettings> settingsRef = new AtomicReference<>();
     private final AtomicLong failedAttempts = new AtomicLong();
     private volatile boolean degraded;
 
-    public DbProvider(NexusLogger logger) {
+    public DbProvider(NexusLogger logger, JavaPlugin plugin) {
         this.logger = Objects.requireNonNull(logger, "logger");
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
     }
 
     public CompletableFuture<Boolean> applyConfiguration(CoreConfig.DatabaseSettings settings, Executor executor) {
@@ -80,6 +83,7 @@ public final class DbProvider implements LifecycleAware {
 
     private HikariConfig toHikariConfig(CoreConfig.DatabaseSettings settings) {
         HikariConfig config = new HikariConfig();
+        config.setClassLoader(plugin.getClass().getClassLoader());
         config.setJdbcUrl(settings.jdbcUrl());
         config.setUsername(settings.username());
         config.setPassword(settings.password());


### PR DESCRIPTION
## Summary
- construct `DbProvider` with a `JavaPlugin` reference and register it as a singleton
- configure HikariCP to use the plugin class loader so the relocated MariaDB driver can be found

## Testing
- ⚠️ `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d05d1d7f00832485b99be4c107db71