### PR TITLE
Use DataSource class for shaded Hikari configuration

### DIFF
--- a/src/main/java/com/heneria/nexus/db/DbProvider.java
+++ b/src/main/java/com/heneria/nexus/db/DbProvider.java
@@ -83,10 +83,11 @@ public final class DbProvider implements LifecycleAware {
 
     private HikariConfig toHikariConfig(CoreConfig.DatabaseSettings settings) {
         HikariConfig config = new HikariConfig();
-        config.setClassLoader(plugin.getClass().getClassLoader());
-        config.setJdbcUrl(settings.jdbcUrl());
-        config.setUsername(settings.username());
-        config.setPassword(settings.password());
+        // Utilise la configuration recommandée pour HikariCP 5.x avec un driver relocalisé
+        config.setDataSourceClassName("com.heneria.nexus.lib.mariadb.jdbc.MariaDbDataSource");
+        config.addDataSourceProperty("url", settings.jdbcUrl());
+        config.addDataSourceProperty("user", settings.username());
+        config.addDataSourceProperty("password", settings.password());
         config.setMaximumPoolSize(settings.poolSettings().maxSize());
         config.setMinimumIdle(settings.poolSettings().minIdle());
         config.setConnectionTimeout(settings.poolSettings().connectionTimeoutMs());


### PR DESCRIPTION
## Summary
- configure HikariCP to instantiate the relocated MariaDB datasource class directly
- supply JDBC credentials through datasource properties while preserving the pool tuning

## Testing
- mvn -q test *(fails: unable to resolve maven-resources-plugin due to network unavailability)*

------
https://chatgpt.com/codex/tasks/task_e_68d0629100ec8324b5972a210d08bf42