### PR TITLE
Fix MariaDB DataSource class path

### DIFF
--- a/src/main/java/com/heneria/nexus/db/DbProvider.java
+++ b/src/main/java/com/heneria/nexus/db/DbProvider.java
@@ -84,7 +84,7 @@ public final class DbProvider implements LifecycleAware {
     private HikariConfig toHikariConfig(CoreConfig.DatabaseSettings settings) {
         HikariConfig config = new HikariConfig();
         // Utilise la configuration recommandée pour HikariCP 5.x avec un driver relocalisé
-        config.setDataSourceClassName("com.heneria.nexus.lib.mariadb.jdbc.MariaDbDataSource");
+        config.setDataSourceClassName("com.heneria.nexus.lib.mariadb.MariaDbDataSource");
         config.addDataSourceProperty("url", settings.jdbcUrl());
         config.addDataSourceProperty("user", settings.username());
         config.addDataSourceProperty("password", settings.password());


### PR DESCRIPTION
## Summary
- update the MariaDB DataSource class name to match the relocated package

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d06c3f6cf88324a6a8780952961a35