### PR TITLE
Disable shade minimization to retain MariaDB driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <minimizeJar>true</minimizeJar>
+                            <minimizeJar>false</minimizeJar>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>


### PR DESCRIPTION
## Summary
- disable Maven Shade's jar minimization so shaded dependencies like the MariaDB driver remain in the final plugin artifact

## Testing
- mvn -q -DskipTests package *(fails: Network is unreachable while resolving maven-resources-plugin 3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d06edbc96483249c7bd10cfc9cecbb