### PR TITLE
Add hologram proximity visibility listener

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -12,6 +12,7 @@ import com.heneria.nexus.db.DbProvider;
 import com.heneria.nexus.hologram.HoloService;
 import com.heneria.nexus.hologram.HoloServiceImpl;
 import com.heneria.nexus.hologram.Hologram;
+import com.heneria.nexus.hologram.HologramVisibilityListener;
 import com.heneria.nexus.scheduler.GamePhase;
 import com.heneria.nexus.scheduler.RingScheduler;
 import com.heneria.nexus.scheduler.RingScheduler.TaskProfile;
@@ -49,6 +50,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.Location;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -120,6 +122,7 @@ public final class NexusPlugin extends JavaPlugin {
 
         this.messageFacade.update(bundle.messages());
         registerCommands();
+        registerListeners();
         logEnvironment();
         configureDatabase(bundle.core().databaseSettings());
 
@@ -178,6 +181,11 @@ public final class NexusPlugin extends JavaPlugin {
         NexusCommand executor = new NexusCommand(this);
         command.setExecutor(executor);
         command.setTabCompleter(executor);
+    }
+
+    private void registerListeners() {
+        PluginManager manager = getServer().getPluginManager();
+        manager.registerEvents(new HologramVisibilityListener(serviceRegistry.get(HoloService.class)), this);
     }
 
     private void logEnvironment() {

--- a/src/main/java/com/heneria/nexus/hologram/Hologram.java
+++ b/src/main/java/com/heneria/nexus/hologram/Hologram.java
@@ -83,6 +83,10 @@ public final class Hologram {
         return lines.stream().map(Line::raw).toList();
     }
 
+    public double viewRange() {
+        return viewRange;
+    }
+
     void applySettings(CoreConfig.HologramSettings settings) {
         Objects.requireNonNull(settings, "settings");
         this.lineSpacing = settings.lineSpacing();

--- a/src/main/java/com/heneria/nexus/hologram/HologramVisibilityListener.java
+++ b/src/main/java/com/heneria/nexus/hologram/HologramVisibilityListener.java
@@ -1,0 +1,90 @@
+package com.heneria.nexus.hologram;
+
+import java.util.Objects;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Gère la visibilité dynamique des hologrammes en fonction de la position des joueurs.
+ */
+public final class HologramVisibilityListener implements Listener {
+
+    private final HoloService holoService;
+
+    public HologramVisibilityListener(HoloService holoService) {
+        this.holoService = Objects.requireNonNull(holoService, "holoService");
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        updateVisibility(player);
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (event.getTo() == null) {
+            return;
+        }
+        if (event.getFrom().getChunk().equals(event.getTo().getChunk())) {
+            return;
+        }
+        Player player = event.getPlayer();
+        updateVisibility(player);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        hideAll(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        Player player = event.getPlayer();
+        hideAll(player);
+        updateVisibility(player);
+    }
+
+    private void updateVisibility(Player player) {
+        Location playerLocation = player.getLocation();
+        World playerWorld = playerLocation.getWorld();
+        for (Hologram hologram : holoService.holograms()) {
+            Location location = hologram.location();
+            if (location == null) {
+                hologram.hideFrom(player);
+                continue;
+            }
+            World hologramWorld = location.getWorld();
+            if (playerWorld == null || hologramWorld == null || !playerWorld.equals(hologramWorld)) {
+                hologram.hideFrom(player);
+                continue;
+            }
+            double range = hologram.viewRange();
+            if (range <= 0D) {
+                hologram.hideFrom(player);
+                continue;
+            }
+            double distanceSquared = playerLocation.distanceSquared(location);
+            double rangeSquared = range * range;
+            if (distanceSquared <= rangeSquared) {
+                hologram.showTo(player);
+            } else {
+                hologram.hideFrom(player);
+            }
+        }
+    }
+
+    private void hideAll(Player player) {
+        for (Hologram hologram : holoService.holograms()) {
+            hologram.hideFrom(player);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose hologram view range so listeners can react to proximity
- add a HologramVisibilityListener to show and hide holograms around players
- register the listener during plugin enablement to update visibility on join, movement, world changes, and quit

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable when resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68d0755daa6c8324ae07cf26ec431b7d