### PR TITLE
Fix hologram text rendering

### DIFF
--- a/src/main/java/com/heneria/nexus/hologram/Hologram.java
+++ b/src/main/java/com/heneria/nexus/hologram/Hologram.java
@@ -321,7 +321,7 @@ public final class Hologram {
                 continue;
             }
             Component component = deserialize(resolved);
-            displays.get(index).setText(String.valueOf(component));
+            displays.get(index).text(component);
             line.onRendered(resolved);
         }
     }


### PR DESCRIPTION
## Summary
- pass Adventure components directly to hologram text displays so formatted text renders correctly

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d19cac6a5c83248c4b3fd62a98475f