### PR TITLE
Fix locale resolution for non-player senders

### DIFF
--- a/src/main/java/com/heneria/nexus/util/MessageFacade.java
+++ b/src/main/java/com/heneria/nexus/util/MessageFacade.java
@@ -178,11 +178,10 @@ public final class MessageFacade {
     }
 
     private Locale resolveLocale(CommandSender sender) {
-        try {
-            return sender.locale();
-        } catch (Throwable ignored) {
-            return null;
+        if (sender instanceof Player player) {
+            return player.locale();
         }
+        return null;
     }
 
     private Component missingMessage(String key) {


### PR DESCRIPTION
## Summary
- avoid calling CommandSender#locale since only players support locales
- default to the server fallback locale for console and other senders

## Testing
- `mvn -q -e -DskipTests package` *(fails: unable to resolve Maven plugins due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ae4ad3348324a294258f03cb58f6