### PR TITLE
Ensure shaded build is reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
         <mariadb.version>3.3.3</mariadb.version>
         <hikari.version>5.1.0</hikari.version>
         <placeholderapi.version>2.11.5</placeholderapi.version>
+
+        <!--
+            Keep a fixed timestamp to guarantee that identical sources always produce identical
+            shaded artifacts. CI can override reproducible.build.outputTimestamp (for example with
+            SOURCE_DATE_EPOCH) when a deterministic but informative timestamp is required.
+        -->
+        <reproducible.build.outputTimestamp>1970-01-01T00:00:00Z</reproducible.build.outputTimestamp>
+        <project.build.outputTimestamp>${reproducible.build.outputTimestamp}</project.build.outputTimestamp>
     </properties>
 
     <repositories>
@@ -126,6 +134,11 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!--
+                                minimizeJar must stay disabled. Enabling it removes classes that are
+                                detected as unused during shading, which breaks runtime loading for
+                                libraries such as HikariCP.
+                            -->
                             <minimizeJar>false</minimizeJar>
                             <filters>
                                 <filter>
@@ -147,9 +160,34 @@
                                     <shadedPattern>com.heneria.nexus.lib.mariadb</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Implementation-Title>${project.name}</Implementation-Title>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-Vendor>${project.groupId}</Implementation-Vendor>
+                                        <Build-Timestamp>${project.build.outputTimestamp}</Build-Timestamp>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Build-Timestamp>${project.build.outputTimestamp}</Build-Timestamp>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- fix the shaded build metadata to keep a deterministic output timestamp and explain why jar minimisation stays disabled
- add manifest transformers so the shaded jar carries implementation details and a reproducible Build-Timestamp entry
- wire in the jar plugin to mirror the manifest metadata when the unshaded artifact is produced

## Testing
- mvn clean package *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ac42d8ac83248d3fbd84afca8b5b