### PR TITLE
Fix build timestamp for reproducible JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,9 @@
             Keep a fixed timestamp to guarantee that identical sources always produce identical
             shaded artifacts. CI can override reproducible.build.outputTimestamp (for example with
             SOURCE_DATE_EPOCH) when a deterministic but informative timestamp is required.
+            The earliest timestamp allowed by the JAR specification is 1980-01-01T00:00:02Z.
         -->
-        <reproducible.build.outputTimestamp>1970-01-01T00:00:00Z</reproducible.build.outputTimestamp>
+        <reproducible.build.outputTimestamp>1980-01-01T00:00:02Z</reproducible.build.outputTimestamp>
         <project.build.outputTimestamp>${reproducible.build.outputTimestamp}</project.build.outputTimestamp>
     </properties>
 


### PR DESCRIPTION
## Summary
- update the fixed reproducible build timestamp to the earliest JAR-compliant value
- document the JAR timestamp lower bound in the POM comments

## Testing
- mvn -B -DskipTests package *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c0a03fa0832484cf31f51674fb45