### PR TITLE
Refactor data access into repositories with health checks

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -12,6 +12,10 @@ import com.heneria.nexus.config.CoreConfig;
 import com.heneria.nexus.config.ReloadReport;
 import com.heneria.nexus.db.DatabaseMigrator;
 import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.db.repository.EconomyRepository;
+import com.heneria.nexus.db.repository.EconomyRepositoryImpl;
+import com.heneria.nexus.db.repository.ProfileRepository;
+import com.heneria.nexus.db.repository.ProfileRepositoryImpl;
 import com.heneria.nexus.hologram.HoloService;
 import com.heneria.nexus.hologram.HoloServiceImpl;
 import com.heneria.nexus.hologram.Hologram;
@@ -624,6 +628,8 @@ public final class NexusPlugin extends JavaPlugin {
     private void registerServices() {
         serviceRegistry.registerService(RingScheduler.class, RingScheduler.class);
         serviceRegistry.registerService(MapService.class, MapServiceImpl.class);
+        serviceRegistry.registerService(ProfileRepository.class, ProfileRepositoryImpl.class);
+        serviceRegistry.registerService(EconomyRepository.class, EconomyRepositoryImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
         serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);
         serviceRegistry.registerService(TimerService.class, TimerServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/db/repository/EconomyRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/EconomyRepository.java
@@ -1,0 +1,47 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.api.EconomyTransferResult;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository dedicated to player economy persistence.
+ */
+public interface EconomyRepository {
+
+    /**
+     * Retrieves the persisted balance for the given account.
+     *
+     * @param playerUuid unique identifier of the account
+     * @return future yielding the current balance in minor units
+     */
+    CompletableFuture<Long> getBalance(UUID playerUuid);
+
+    /**
+     * Sets the balance for the given account.
+     *
+     * @param playerUuid unique identifier of the account
+     * @param balance    new balance in minor units
+     * @return future yielding the resulting balance
+     */
+    CompletableFuture<Long> setBalance(UUID playerUuid, long balance);
+
+    /**
+     * Applies a delta to the stored balance.
+     *
+     * @param playerUuid unique identifier of the account
+     * @param amount     delta to apply (positive or negative)
+     * @return future yielding the resulting balance
+     */
+    CompletableFuture<Long> addToBalance(UUID playerUuid, long amount);
+
+    /**
+     * Transfers the specified amount between two accounts atomically.
+     *
+     * @param from   account debited
+     * @param to     account credited
+     * @param amount amount to transfer in minor units
+     * @return future yielding resulting balances for both accounts
+     */
+    CompletableFuture<EconomyTransferResult> transfer(UUID from, UUID to, long amount);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/EconomyRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/EconomyRepositoryImpl.java
@@ -1,0 +1,191 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.api.EconomyTransferResult;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Default MariaDB-backed implementation of {@link EconomyRepository}.
+ */
+public final class EconomyRepositoryImpl implements EconomyRepository {
+
+    private static final String SELECT_BALANCE_SQL =
+            "SELECT balance FROM nexus_economy WHERE player_uuid = ?";
+    private static final String SELECT_BALANCE_FOR_UPDATE_SQL =
+            "SELECT balance FROM nexus_economy WHERE player_uuid = ? FOR UPDATE";
+    private static final String UPDATE_BALANCE_SQL =
+            "UPDATE nexus_economy SET balance = ? WHERE player_uuid = ?";
+    private static final String INSERT_BALANCE_SQL =
+            "INSERT INTO nexus_economy (player_uuid, balance) VALUES (?, ?)";
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public EconomyRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletableFuture<Long> getBalance(UUID playerUuid) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(SELECT_BALANCE_SQL)) {
+                statement.setString(1, playerUuid.toString());
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        return resultSet.getLong("balance");
+                    }
+                    return 0L;
+                }
+            }
+        }, ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<Long> setBalance(UUID playerUuid, long balance) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        if (balance < 0L) {
+            throw new IllegalArgumentException("balance must be >= 0");
+        }
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement update = connection.prepareStatement(UPDATE_BALANCE_SQL)) {
+                update.setLong(1, balance);
+                update.setString(2, playerUuid.toString());
+                int affected = update.executeUpdate();
+                if (affected == 0) {
+                    try (PreparedStatement insert = connection.prepareStatement(INSERT_BALANCE_SQL)) {
+                        insert.setString(1, playerUuid.toString());
+                        insert.setLong(2, balance);
+                        insert.executeUpdate();
+                    }
+                }
+            }
+            return balance;
+        }, ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<Long> addToBalance(UUID playerUuid, long amount) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        return dbProvider.execute(connection -> adjustBalance(connection, playerUuid, amount), ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<EconomyTransferResult> transfer(UUID from, UUID to, long amount) {
+        Objects.requireNonNull(from, "from");
+        Objects.requireNonNull(to, "to");
+        if (amount < 0L) {
+            throw new IllegalArgumentException("amount must be >= 0");
+        }
+        return dbProvider.execute(connection -> transferInternal(connection, from, to, amount), ioExecutor);
+    }
+
+    private long adjustBalance(Connection connection, UUID playerUuid, long amount) throws SQLException {
+        boolean previousAutoCommit = getAutoCommit(connection);
+        connection.setAutoCommit(false);
+        try {
+            BalanceSnapshot snapshot = lockBalance(connection, playerUuid);
+            long next = snapshot.balance() + amount;
+            if (next < 0L) {
+                throw new IllegalStateException("Solde insuffisant pour " + playerUuid);
+            }
+            persistBalance(connection, playerUuid, next, snapshot.exists());
+            connection.commit();
+            return next;
+        } catch (Throwable throwable) {
+            rollbackQuietly(connection);
+            throw throwable;
+        } finally {
+            restoreAutoCommit(connection, previousAutoCommit);
+        }
+    }
+
+    private EconomyTransferResult transferInternal(Connection connection, UUID from, UUID to, long amount) throws SQLException {
+        boolean previousAutoCommit = getAutoCommit(connection);
+        connection.setAutoCommit(false);
+        try {
+            BalanceSnapshot fromSnapshot = lockBalance(connection, from);
+            BalanceSnapshot toSnapshot = lockBalance(connection, to);
+            long nextFrom = fromSnapshot.balance() - amount;
+            if (nextFrom < 0L) {
+                throw new IllegalStateException("Solde insuffisant pour " + from);
+            }
+            long nextTo = toSnapshot.balance() + amount;
+            persistBalance(connection, from, nextFrom, fromSnapshot.exists());
+            persistBalance(connection, to, nextTo, toSnapshot.exists());
+            connection.commit();
+            return new EconomyTransferResult(nextFrom, nextTo);
+        } catch (Throwable throwable) {
+            rollbackQuietly(connection);
+            throw throwable;
+        } finally {
+            restoreAutoCommit(connection, previousAutoCommit);
+        }
+    }
+
+    private BalanceSnapshot lockBalance(Connection connection, UUID playerUuid) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_BALANCE_FOR_UPDATE_SQL)) {
+            statement.setString(1, playerUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return new BalanceSnapshot(true, resultSet.getLong("balance"));
+                }
+            }
+        }
+        return new BalanceSnapshot(false, 0L);
+    }
+
+    private void persistBalance(Connection connection, UUID playerUuid, long balance, boolean existed) throws SQLException {
+        if (existed) {
+            try (PreparedStatement update = connection.prepareStatement(UPDATE_BALANCE_SQL)) {
+                update.setLong(1, balance);
+                update.setString(2, playerUuid.toString());
+                int affected = update.executeUpdate();
+                if (affected > 0) {
+                    return;
+                }
+            }
+        }
+        try (PreparedStatement insert = connection.prepareStatement(INSERT_BALANCE_SQL)) {
+            insert.setString(1, playerUuid.toString());
+            insert.setLong(2, balance);
+            insert.executeUpdate();
+        }
+    }
+
+    private boolean getAutoCommit(Connection connection) {
+        try {
+            return connection.getAutoCommit();
+        } catch (SQLException ignored) {
+            return true;
+        }
+    }
+
+    private void restoreAutoCommit(Connection connection, boolean value) {
+        try {
+            connection.setAutoCommit(value);
+        } catch (SQLException ignored) {
+            // Ignore
+        }
+    }
+
+    private void rollbackQuietly(Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException ignored) {
+            // Ignore
+        }
+    }
+
+    private record BalanceSnapshot(boolean exists, long balance) {
+    }
+}

--- a/src/main/java/com/heneria/nexus/db/repository/ProfileRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/ProfileRepository.java
@@ -1,0 +1,28 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.api.PlayerProfile;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository dedicated to player profile persistence.
+ */
+public interface ProfileRepository {
+
+    /**
+     * Loads the profile stored for the provided player identifier.
+     *
+     * @param playerUuid unique identifier of the player
+     * @return future yielding the stored profile when available
+     */
+    CompletableFuture<Optional<PlayerProfile>> findByUuid(UUID playerUuid);
+
+    /**
+     * Creates or updates the profile for the provided player.
+     *
+     * @param profile profile instance to persist
+     * @return future completed once the profile has been saved
+     */
+    CompletableFuture<Void> createOrUpdate(PlayerProfile profile);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/ProfileRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/ProfileRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.api.PlayerProfile;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+/**
+ * Default MariaDB-backed implementation of {@link ProfileRepository}.
+ */
+public final class ProfileRepositoryImpl implements ProfileRepository {
+
+    private static final String SELECT_PROFILE_SQL =
+            "SELECT elo_rating, total_kills, total_deaths, total_wins, total_losses, matches_played " +
+                    "FROM nexus_profiles WHERE player_uuid = ?";
+    private static final String UPSERT_PROFILE_SQL =
+            "INSERT INTO nexus_profiles (player_uuid, elo_rating, total_kills, total_deaths, total_wins, total_losses, matches_played) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?) " +
+                    "ON DUPLICATE KEY UPDATE " +
+                    "elo_rating = VALUES(elo_rating), " +
+                    "total_kills = VALUES(total_kills), " +
+                    "total_deaths = VALUES(total_deaths), " +
+                    "total_wins = VALUES(total_wins), " +
+                    "total_losses = VALUES(total_losses), " +
+                    "matches_played = VALUES(matches_played)";
+
+    private static final String STAT_ELO = "elo_rating";
+    private static final String STAT_TOTAL_KILLS = "total_kills";
+    private static final String STAT_TOTAL_DEATHS = "total_deaths";
+    private static final String STAT_TOTAL_WINS = "total_wins";
+    private static final String STAT_TOTAL_LOSSES = "total_losses";
+    private static final String STAT_MATCHES_PLAYED = "matches_played";
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public ProfileRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletableFuture<Optional<PlayerProfile>> findByUuid(UUID playerUuid) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(SELECT_PROFILE_SQL)) {
+                statement.setString(1, playerUuid.toString());
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (!resultSet.next()) {
+                        return Optional.empty();
+                    }
+                    Map<String, Long> statistics = new ConcurrentHashMap<>();
+                    statistics.put(STAT_ELO, (long) resultSet.getInt("elo_rating"));
+                    statistics.put(STAT_TOTAL_KILLS, (long) resultSet.getInt("total_kills"));
+                    statistics.put(STAT_TOTAL_DEATHS, (long) resultSet.getInt("total_deaths"));
+                    statistics.put(STAT_TOTAL_WINS, (long) resultSet.getInt("total_wins"));
+                    statistics.put(STAT_TOTAL_LOSSES, (long) resultSet.getInt("total_losses"));
+                    statistics.put(STAT_MATCHES_PLAYED, (long) resultSet.getInt("matches_played"));
+                    PlayerProfile profile = new PlayerProfile(
+                            playerUuid,
+                            statistics,
+                            new ConcurrentHashMap<>(),
+                            new ArrayList<>(),
+                            Instant.now());
+                    return Optional.of(profile);
+                }
+            }
+        }, ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<Void> createOrUpdate(PlayerProfile profile) {
+        Objects.requireNonNull(profile, "profile");
+        Map<String, Long> statistics = profile.statistics();
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(UPSERT_PROFILE_SQL)) {
+                statement.setString(1, profile.playerId().toString());
+                statement.setInt(2, longToInt(statistics.getOrDefault(STAT_ELO, 1000L)));
+                statement.setInt(3, longToInt(statistics.getOrDefault(STAT_TOTAL_KILLS, 0L)));
+                statement.setInt(4, longToInt(statistics.getOrDefault(STAT_TOTAL_DEATHS, 0L)));
+                statement.setInt(5, longToInt(statistics.getOrDefault(STAT_TOTAL_WINS, 0L)));
+                statement.setInt(6, longToInt(statistics.getOrDefault(STAT_TOTAL_LOSSES, 0L)));
+                statement.setInt(7, longToInt(statistics.getOrDefault(STAT_MATCHES_PLAYED, 0L)));
+                statement.executeUpdate();
+            }
+            return null;
+        }, ioExecutor);
+    }
+
+    private int longToInt(long value) {
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (value < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) value;
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
@@ -1,39 +1,50 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.config.CoreConfig;
-import com.heneria.nexus.db.DbProvider;
-import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.api.EconomyException;
 import com.heneria.nexus.api.EconomyService;
 import com.heneria.nexus.api.EconomyTransaction;
 import com.heneria.nexus.api.EconomyTransferResult;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.db.repository.EconomyRepository;
 import com.heneria.nexus.util.NexusLogger;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 /**
- * Default implementation storing balances in memory with write-behind hooks.
+ * Default implementation using a MariaDB repository with in-memory fallback.
  */
 public final class EconomyServiceImpl implements EconomyService {
 
     private final NexusLogger logger;
     private final DbProvider dbProvider;
     private final ExecutorManager executorManager;
+    private final EconomyRepository economyRepository;
     private final ConcurrentHashMap<UUID, BalanceEntry> balances = new ConcurrentHashMap<>();
     private final AtomicBoolean degraded = new AtomicBoolean();
+    private final AtomicBoolean forcedFallback = new AtomicBoolean();
     private final AtomicReference<CoreConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
 
-    public EconomyServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorManager executorManager, CoreConfig config) {
+    public EconomyServiceImpl(NexusLogger logger,
+                              DbProvider dbProvider,
+                              ExecutorManager executorManager,
+                              CoreConfig config,
+                              EconomyRepository economyRepository) {
         this.logger = Objects.requireNonNull(logger, "logger");
         this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
         this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
+        this.economyRepository = Objects.requireNonNull(economyRepository, "economyRepository");
         this.degradedSettings.set(config.degradedModeSettings());
     }
 
@@ -45,11 +56,22 @@ public final class EconomyServiceImpl implements EconomyService {
     @Override
     public CompletionStage<Long> getBalance(UUID accountId) {
         Objects.requireNonNull(accountId, "accountId");
-        return executorManager.supplyIo(() -> {
-            refreshDegradedState();
-            BalanceEntry entry = balances.get(accountId);
-            return entry != null ? entry.balance() : 0L;
-        });
+        boolean providerDegraded = dbProvider.isDegraded();
+        refreshDegradedState(providerDegraded);
+        if (providerDegraded) {
+            return executorManager.supplyIo(() -> getBalanceFromFallback(accountId));
+        }
+        if (forcedFallback.get()) {
+            triggerHealthProbe();
+            return executorManager.supplyIo(() -> getBalanceFromFallback(accountId));
+        }
+        return economyRepository.getBalance(accountId)
+                .thenApply(balance -> {
+                    clearForcedFallback();
+                    updateFallbackBalance(accountId, balance);
+                    return balance;
+                })
+                .exceptionallyCompose(throwable -> fallbackBalance(accountId, throwable));
     }
 
     @Override
@@ -58,17 +80,23 @@ public final class EconomyServiceImpl implements EconomyService {
         if (amount < 0L) {
             return CompletableFuture.failedFuture(new EconomyException("Montant négatif"));
         }
-        return executorManager.supplyIo(() -> {
-            boolean fallback = refreshDegradedState();
-            BalanceEntry updated = balances.compute(accountId, (id, entry) -> {
-                long current = entry != null ? entry.balance() : 0L;
-                return new BalanceEntry(current + amount, Instant.now());
-            });
-            if (!fallback) {
-                logger.debug(() -> "Écriture async crédit " + amount + " pour " + accountId + " (" + reason + ")");
-            }
-            return updated.balance();
-        });
+        boolean providerDegraded = dbProvider.isDegraded();
+        refreshDegradedState(providerDegraded);
+        if (providerDegraded) {
+            return executorManager.supplyIo(() -> applyDeltaInFallback(accountId, amount));
+        }
+        if (forcedFallback.get()) {
+            triggerHealthProbe();
+            return executorManager.supplyIo(() -> applyDeltaInFallback(accountId, amount));
+        }
+        return economyRepository.addToBalance(accountId, amount)
+                .thenApply(balance -> {
+                    clearForcedFallback();
+                    updateFallbackBalance(accountId, balance);
+                    logger.debug(() -> "Crédit " + amount + " pour " + accountId + " (" + reason + ")");
+                    return balance;
+                })
+                .exceptionallyCompose(throwable -> fallbackCredit(accountId, amount, throwable));
     }
 
     @Override
@@ -77,27 +105,25 @@ public final class EconomyServiceImpl implements EconomyService {
         if (amount < 0L) {
             return CompletableFuture.failedFuture(new EconomyException("Montant négatif"));
         }
-        return executorManager.supplyIo(() -> {
-            boolean fallback = refreshDegradedState();
-            BalanceEntry updated = balances.compute(accountId, (id, entry) -> {
-                long current = entry != null ? entry.balance() : 0L;
-                long next = current - amount;
-                if (next < 0L) {
-                    throw new IllegalStateException("Solde insuffisant");
-                }
-                return new BalanceEntry(next, Instant.now());
-            });
-            if (!fallback) {
-                logger.debug(() -> "Écriture async débit " + amount + " pour " + accountId + " (" + reason + ")");
-            }
-            return updated.balance();
-        }).exceptionallyCompose(throwable -> {
-            Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
-            if (cause instanceof IllegalStateException) {
-                return CompletableFuture.failedFuture(new EconomyException(cause.getMessage()));
-            }
-            return CompletableFuture.failedFuture(cause);
-        });
+        boolean providerDegraded = dbProvider.isDegraded();
+        refreshDegradedState(providerDegraded);
+        if (providerDegraded) {
+            return executorManager.supplyIo(() -> applyDeltaInFallback(accountId, -amount))
+                    .exceptionallyCompose(this::propagateEconomyFailure);
+        }
+        if (forcedFallback.get()) {
+            triggerHealthProbe();
+            return executorManager.supplyIo(() -> applyDeltaInFallback(accountId, -amount))
+                    .exceptionallyCompose(this::propagateEconomyFailure);
+        }
+        return economyRepository.addToBalance(accountId, -amount)
+                .thenApply(balance -> {
+                    clearForcedFallback();
+                    updateFallbackBalance(accountId, balance);
+                    logger.debug(() -> "Débit " + amount + " pour " + accountId + " (" + reason + ")");
+                    return balance;
+                })
+                .exceptionallyCompose(throwable -> fallbackDebit(accountId, amount, throwable));
     }
 
     @Override
@@ -107,35 +133,31 @@ public final class EconomyServiceImpl implements EconomyService {
         if (amount < 0L) {
             return CompletableFuture.failedFuture(new EconomyException("Montant négatif"));
         }
-        return executorManager.supplyIo(() -> {
-            boolean fallback = refreshDegradedState();
-            synchronized (balances) {
-                long fromBalance = balances.getOrDefault(from, new BalanceEntry(0L, Instant.now())).balance();
-                long toBalance = balances.getOrDefault(to, new BalanceEntry(0L, Instant.now())).balance();
-                if (fromBalance < amount) {
-                    throw new IllegalStateException("Solde insuffisant");
-                }
-                fromBalance -= amount;
-                toBalance += amount;
-                balances.put(from, new BalanceEntry(fromBalance, Instant.now()));
-                balances.put(to, new BalanceEntry(toBalance, Instant.now()));
-                if (!fallback) {
-                    logger.debug(() -> "Écriture async transfert " + amount + " de " + from + " vers " + to + " (" + reason + ")");
-                }
-                return new EconomyTransferResult(fromBalance, toBalance);
-            }
-        }).exceptionallyCompose(throwable -> {
-            Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
-            if (cause instanceof IllegalStateException) {
-                return CompletableFuture.failedFuture(new EconomyException(cause.getMessage()));
-            }
-            return CompletableFuture.failedFuture(cause);
-        });
+        boolean providerDegraded = dbProvider.isDegraded();
+        refreshDegradedState(providerDegraded);
+        if (providerDegraded) {
+            return executorManager.supplyIo(() -> performFallbackTransfer(from, to, amount))
+                    .exceptionallyCompose(this::propagateEconomyFailure);
+        }
+        if (forcedFallback.get()) {
+            triggerHealthProbe();
+            return executorManager.supplyIo(() -> performFallbackTransfer(from, to, amount))
+                    .exceptionallyCompose(this::propagateEconomyFailure);
+        }
+        return economyRepository.transfer(from, to, amount)
+                .thenApply(result -> {
+                    clearForcedFallback();
+                    updateFallbackBalance(from, result.fromBalance());
+                    updateFallbackBalance(to, result.toBalance());
+                    logger.debug(() -> "Transfert " + amount + " de " + from + " vers " + to + " (" + reason + ")");
+                    return result;
+                })
+                .exceptionallyCompose(throwable -> fallbackTransfer(from, to, amount, throwable));
     }
 
     @Override
     public EconomyTransaction beginTransaction() {
-        return new InMemoryTransaction();
+        return new RepositoryAwareTransaction();
     }
 
     @Override
@@ -149,7 +171,11 @@ public final class EconomyServiceImpl implements EconomyService {
     }
 
     private boolean refreshDegradedState() {
-        boolean fallback = dbProvider.isDegraded();
+        return refreshDegradedState(dbProvider.isDegraded());
+    }
+
+    private boolean refreshDegradedState(boolean providerDegraded) {
+        boolean fallback = providerDegraded || forcedFallback.get();
         boolean previous = degraded.getAndSet(fallback);
         if (fallback && !previous) {
             CoreConfig.DegradedModeSettings settings = degradedSettings.get();
@@ -163,10 +189,147 @@ public final class EconomyServiceImpl implements EconomyService {
         return fallback;
     }
 
+    private long getBalanceFromFallback(UUID accountId) {
+        BalanceEntry entry = balances.get(accountId);
+        return entry != null ? entry.balance() : 0L;
+    }
+
+    private long applyDeltaInFallback(UUID accountId, long delta) {
+        synchronized (balances) {
+            BalanceEntry entry = balances.getOrDefault(accountId, new BalanceEntry(0L, Instant.now()));
+            long next = entry.balance() + delta;
+            if (next < 0L) {
+                throw new IllegalStateException("Solde insuffisant");
+            }
+            BalanceEntry updated = new BalanceEntry(next, Instant.now());
+            balances.put(accountId, updated);
+            return updated.balance();
+        }
+    }
+
+    private EconomyTransferResult performFallbackTransfer(UUID from, UUID to, long amount) {
+        synchronized (balances) {
+            long fromBalance = balances.getOrDefault(from, new BalanceEntry(0L, Instant.now())).balance();
+            long toBalance = balances.getOrDefault(to, new BalanceEntry(0L, Instant.now())).balance();
+            if (fromBalance < amount) {
+                throw new IllegalStateException("Solde insuffisant");
+            }
+            fromBalance -= amount;
+            toBalance += amount;
+            balances.put(from, new BalanceEntry(fromBalance, Instant.now()));
+            balances.put(to, new BalanceEntry(toBalance, Instant.now()));
+            return new EconomyTransferResult(fromBalance, toBalance);
+        }
+    }
+
+    private void updateFallbackBalance(UUID accountId, long balance) {
+        balances.put(accountId, new BalanceEntry(balance, Instant.now()));
+    }
+
+    private CompletableFuture<Long> fallbackBalance(UUID accountId, Throwable throwable) {
+        return handleRepositoryFailure("lecture du solde", throwable,
+                () -> executorManager.supplyIo(() -> getBalanceFromFallback(accountId)));
+    }
+
+    private CompletableFuture<Long> fallbackCredit(UUID accountId, long amount, Throwable throwable) {
+        return handleRepositoryFailure("crédit", throwable,
+                () -> executorManager.supplyIo(() -> applyDeltaInFallback(accountId, amount)));
+    }
+
+    private CompletableFuture<Long> fallbackDebit(UUID accountId, long amount, Throwable throwable) {
+        return handleRepositoryFailure("débit", throwable,
+                () -> executorManager.supplyIo(() -> applyDeltaInFallback(accountId, -amount)));
+    }
+
+    private CompletableFuture<EconomyTransferResult> fallbackTransfer(UUID from, UUID to, long amount, Throwable throwable) {
+        return handleRepositoryFailure("transfert", throwable,
+                () -> executorManager.supplyIo(() -> performFallbackTransfer(from, to, amount)));
+    }
+
+    private CompletableFuture<Void> fallbackTransaction(Map<UUID, Long> deltas, Throwable throwable) {
+        return handleRepositoryFailure("transaction", throwable,
+                () -> executorManager.runIo(() -> applyDeltasFallback(deltas)));
+    }
+
+    private void applyDeltasFallback(Map<UUID, Long> deltas) {
+        synchronized (balances) {
+            for (Map.Entry<UUID, Long> entry : deltas.entrySet()) {
+                long delta = entry.getValue();
+                if (delta == 0L) {
+                    continue;
+                }
+                BalanceEntry current = balances.getOrDefault(entry.getKey(), new BalanceEntry(0L, Instant.now()));
+                long next = current.balance() + delta;
+                if (next < 0L) {
+                    throw new IllegalStateException("Solde insuffisant pour " + entry.getKey());
+                }
+                balances.put(entry.getKey(), new BalanceEntry(next, Instant.now()));
+            }
+        }
+    }
+
+    private void activateFallback(String action, Throwable throwable) {
+        Throwable cause = unwrap(throwable);
+        if (forcedFallback.compareAndSet(false, true)) {
+            logger.warn("Échec lors de la %s, bascule en mode mémoire".formatted(action), cause);
+        } else {
+            logger.debug(() -> "Échec lors de la %s : %s".formatted(action, cause != null ? cause.getMessage() : "inconnu"));
+        }
+        refreshDegradedState();
+        triggerHealthProbe();
+    }
+
+    private void clearForcedFallback() {
+        if (forcedFallback.compareAndSet(true, false)) {
+            refreshDegradedState();
+        }
+    }
+
+    private <T> CompletableFuture<T> propagateEconomyFailure(Throwable throwable) {
+        Throwable cause = unwrap(throwable);
+        if (cause instanceof IllegalStateException) {
+            return CompletableFuture.failedFuture(new EconomyException(cause.getMessage()));
+        }
+        return CompletableFuture.failedFuture(cause);
+    }
+
+    private <T> CompletableFuture<T> handleRepositoryFailure(String action,
+                                                             Throwable throwable,
+                                                             Supplier<CompletableFuture<T>> fallbackSupplier) {
+        Throwable cause = unwrap(throwable);
+        if (cause instanceof IllegalStateException) {
+            return CompletableFuture.failedFuture(new EconomyException(cause.getMessage()));
+        }
+        activateFallback(action, cause);
+        return fallbackSupplier.get().exceptionallyCompose(this::propagateEconomyFailure);
+    }
+
+    private void triggerHealthProbe() {
+        if (!forcedFallback.get()) {
+            return;
+        }
+        dbProvider.checkHealth(executorManager.io())
+                .thenAccept(healthy -> {
+                    if (healthy && forcedFallback.compareAndSet(true, false)) {
+                        refreshDegradedState();
+                    }
+                });
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        if (throwable instanceof CompletionException completion && completion.getCause() != null) {
+            return unwrap(completion.getCause());
+        }
+        if (throwable instanceof ExecutionException execution && execution.getCause() != null) {
+            return unwrap(execution.getCause());
+        }
+        return throwable;
+    }
+
     private record BalanceEntry(long balance, Instant updatedAt) {
     }
 
-    private final class InMemoryTransaction implements EconomyTransaction {
+    private final class RepositoryAwareTransaction implements EconomyTransaction {
 
         private final Map<UUID, Long> deltas = new ConcurrentHashMap<>();
         private volatile boolean closed;
@@ -195,26 +358,31 @@ public final class EconomyServiceImpl implements EconomyService {
                 return CompletableFuture.completedFuture(null);
             }
             closed = true;
-            return executorManager.runIo(() -> {
-                synchronized (balances) {
-                    for (Map.Entry<UUID, Long> entry : deltas.entrySet()) {
-                        UUID account = entry.getKey();
-                        long delta = entry.getValue();
-                        BalanceEntry current = balances.getOrDefault(account, new BalanceEntry(0L, Instant.now()));
-                        long next = current.balance() + delta;
-                        if (next < 0L) {
-                            throw new IllegalStateException("Solde insuffisant pour " + account);
-                        }
-                        balances.put(account, new BalanceEntry(next, Instant.now()));
-                    }
+            if (deltas.isEmpty()) {
+                return CompletableFuture.completedFuture(null);
+            }
+            boolean providerDegraded = dbProvider.isDegraded();
+            refreshDegradedState(providerDegraded);
+            if (providerDegraded) {
+                return executorManager.runIo(() -> applyDeltasFallback(deltas))
+                        .exceptionallyCompose(EconomyServiceImpl.this::propagateEconomyFailure);
+            }
+            if (forcedFallback.get()) {
+                triggerHealthProbe();
+                return executorManager.runIo(() -> applyDeltasFallback(deltas))
+                        .exceptionallyCompose(EconomyServiceImpl.this::propagateEconomyFailure);
+            }
+            CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+            for (Map.Entry<UUID, Long> entry : deltas.entrySet()) {
+                long delta = entry.getValue();
+                if (delta == 0L) {
+                    continue;
                 }
-            }).exceptionallyCompose(throwable -> {
-                Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
-                if (cause instanceof IllegalStateException) {
-                    return CompletableFuture.failedFuture(new EconomyException(cause.getMessage()));
-                }
-                return CompletableFuture.failedFuture(cause);
-            });
+                chain = chain.thenCompose(ignored -> economyRepository.addToBalance(entry.getKey(), delta)
+                        .thenAccept(balance -> updateFallbackBalance(entry.getKey(), balance)));
+            }
+            CompletableFuture<Void> persistent = chain.thenRun(EconomyServiceImpl.this::clearForcedFallback);
+            return persistent.exceptionallyCompose(throwable -> fallbackTransaction(deltas, throwable));
         }
 
         @Override

--- a/src/main/java/com/heneria/nexus/service/core/ProfileServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/ProfileServiceImpl.java
@@ -1,17 +1,20 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.config.CoreConfig;
-import com.heneria.nexus.db.DbProvider;
-import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.api.PlayerProfile;
 import com.heneria.nexus.api.ProfileService;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.db.repository.ProfileRepository;
 import com.heneria.nexus.util.NexusLogger;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -22,19 +25,32 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class ProfileServiceImpl implements ProfileService {
 
     private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+    private static final String STAT_ELO = "elo_rating";
+    private static final String STAT_TOTAL_KILLS = "total_kills";
+    private static final String STAT_TOTAL_DEATHS = "total_deaths";
+    private static final String STAT_TOTAL_WINS = "total_wins";
+    private static final String STAT_TOTAL_LOSSES = "total_losses";
+    private static final String STAT_MATCHES_PLAYED = "matches_played";
 
     private final NexusLogger logger;
     private final DbProvider dbProvider;
     private final ExecutorManager executorManager;
+    private final ProfileRepository profileRepository;
     private final ConcurrentHashMap<UUID, CacheEntry> cache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, PlayerProfile> persistentStore = new ConcurrentHashMap<>();
     private final AtomicBoolean degraded = new AtomicBoolean();
+    private final AtomicBoolean forcedFallback = new AtomicBoolean();
     private final AtomicReference<CoreConfig.DegradedModeSettings> degradedSettings = new AtomicReference<>();
 
-    public ProfileServiceImpl(NexusLogger logger, DbProvider dbProvider, ExecutorManager executorManager, CoreConfig config) {
+    public ProfileServiceImpl(NexusLogger logger,
+                              DbProvider dbProvider,
+                              ExecutorManager executorManager,
+                              CoreConfig config,
+                              ProfileRepository profileRepository) {
         this.logger = Objects.requireNonNull(logger, "logger");
         this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
         this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
+        this.profileRepository = Objects.requireNonNull(profileRepository, "profileRepository");
         this.degradedSettings.set(config.degradedModeSettings());
     }
 
@@ -50,29 +66,49 @@ public final class ProfileServiceImpl implements ProfileService {
         if (cached != null && !cached.isExpired()) {
             return CompletableFuture.completedFuture(copyProfile(cached.profile()));
         }
-        return executorManager.supplyIo(() -> {
-            boolean fallback = refreshDegradedState();
-            if (fallback) {
-                return cache.compute(playerId, (id, entry) -> {
-                    PlayerProfile profile = entry != null ? entry.profile() : defaultProfile(playerId);
-                    return new CacheEntry(copyProfile(profile), Instant.now());
-                }).profile();
-            }
-            PlayerProfile stored = persistentStore.computeIfAbsent(playerId, this::defaultProfile);
-            CacheEntry entry = new CacheEntry(copyProfile(stored), Instant.now());
-            cache.put(playerId, entry);
-            return copyProfile(entry.profile());
-        });
+        boolean providerDegraded = dbProvider.isDegraded();
+        refreshDegradedState(providerDegraded);
+        if (providerDegraded) {
+            return executorManager.supplyIo(() -> loadFromFallback(playerId));
+        }
+        if (forcedFallback.get()) {
+            triggerHealthProbe();
+            return executorManager.supplyIo(() -> loadFromFallback(playerId));
+        }
+        return profileRepository.findByUuid(playerId)
+                .thenCompose(optional -> {
+                    if (optional.isPresent()) {
+                        return CompletableFuture.completedFuture(optional.get());
+                    }
+                    PlayerProfile created = defaultProfile(playerId);
+                    return profileRepository.createOrUpdate(created).thenApply(ignored -> created);
+                })
+                .thenApply(profile -> {
+                    clearForcedFallback();
+                    return snapshotAndCopy(profile);
+                })
+                .exceptionallyCompose(throwable -> fallbackLoad(playerId, throwable));
     }
 
     @Override
     public CompletableFuture<Void> saveAsync(PlayerProfile profile) {
         Objects.requireNonNull(profile, "profile");
-        PlayerProfile copy = copyProfile(profile);
-        return executorManager.runIo(() -> {
-            persistentStore.put(profile.playerId(), copyProfile(copy));
-            cache.put(profile.playerId(), new CacheEntry(copyProfile(copy), Instant.now()));
-        });
+        PlayerProfile snapshot = copyProfile(profile);
+        boolean providerDegraded = dbProvider.isDegraded();
+        refreshDegradedState(providerDegraded);
+        if (providerDegraded) {
+            return executorManager.runIo(() -> snapshotLocally(snapshot));
+        }
+        if (forcedFallback.get()) {
+            triggerHealthProbe();
+            return executorManager.runIo(() -> snapshotLocally(snapshot));
+        }
+        return profileRepository.createOrUpdate(snapshot)
+                .thenRun(() -> {
+                    clearForcedFallback();
+                    snapshotLocally(snapshot);
+                })
+                .exceptionallyCompose(throwable -> fallbackSave(snapshot, throwable));
     }
 
     @Override
@@ -91,7 +127,11 @@ public final class ProfileServiceImpl implements ProfileService {
     }
 
     private boolean refreshDegradedState() {
-        boolean fallback = dbProvider.isDegraded();
+        return refreshDegradedState(dbProvider.isDegraded());
+    }
+
+    private boolean refreshDegradedState(boolean providerDegraded) {
+        boolean fallback = providerDegraded || forcedFallback.get();
         boolean previous = degraded.getAndSet(fallback);
         if (fallback && !previous) {
             CoreConfig.DegradedModeSettings settings = degradedSettings.get();
@@ -106,7 +146,14 @@ public final class ProfileServiceImpl implements ProfileService {
     }
 
     private PlayerProfile defaultProfile(UUID playerId) {
-        return new PlayerProfile(playerId, new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), List.of(), Instant.now());
+        ConcurrentHashMap<String, Long> statistics = new ConcurrentHashMap<>();
+        statistics.put(STAT_ELO, 1000L);
+        statistics.put(STAT_TOTAL_KILLS, 0L);
+        statistics.put(STAT_TOTAL_DEATHS, 0L);
+        statistics.put(STAT_TOTAL_WINS, 0L);
+        statistics.put(STAT_TOTAL_LOSSES, 0L);
+        statistics.put(STAT_MATCHES_PLAYED, 0L);
+        return new PlayerProfile(playerId, statistics, new ConcurrentHashMap<>(), new ArrayList<>(), Instant.now());
     }
 
     private PlayerProfile copyProfile(PlayerProfile profile) {
@@ -114,8 +161,76 @@ public final class ProfileServiceImpl implements ProfileService {
                 profile.playerId(),
                 new ConcurrentHashMap<>(profile.statistics()),
                 new ConcurrentHashMap<>(profile.preferences()),
-                List.copyOf(profile.cosmetics()),
+                new ArrayList<>(profile.cosmetics()),
                 profile.lastUpdate());
+    }
+
+    private PlayerProfile snapshotAndCopy(PlayerProfile profile) {
+        snapshotLocally(profile);
+        CacheEntry entry = cache.get(profile.playerId());
+        return entry != null ? copyProfile(entry.profile()) : copyProfile(profile);
+    }
+
+    private PlayerProfile loadFromFallback(UUID playerId) {
+        PlayerProfile stored = persistentStore.compute(playerId, (id, existing) -> existing != null ? existing : defaultProfile(id));
+        CacheEntry entry = new CacheEntry(copyProfile(stored), Instant.now());
+        cache.put(playerId, entry);
+        return copyProfile(entry.profile());
+    }
+
+    private void snapshotLocally(PlayerProfile profile) {
+        PlayerProfile canonical = copyProfile(profile);
+        persistentStore.put(profile.playerId(), canonical);
+        cache.put(profile.playerId(), new CacheEntry(copyProfile(canonical), Instant.now()));
+    }
+
+    private CompletableFuture<PlayerProfile> fallbackLoad(UUID playerId, Throwable throwable) {
+        activateFallback("chargement du profil", throwable);
+        return executorManager.supplyIo(() -> loadFromFallback(playerId));
+    }
+
+    private CompletableFuture<Void> fallbackSave(PlayerProfile snapshot, Throwable throwable) {
+        activateFallback("sauvegarde du profil", throwable);
+        return executorManager.runIo(() -> snapshotLocally(snapshot));
+    }
+
+    private void activateFallback(String action, Throwable throwable) {
+        Throwable cause = unwrap(throwable);
+        if (forcedFallback.compareAndSet(false, true)) {
+            logger.warn("Échec lors du %s, bascule en mode mémoire".formatted(action), cause);
+        } else {
+            logger.debug(() -> "Échec lors du %s : %s".formatted(action, cause != null ? cause.getMessage() : "inconnu"));
+        }
+        refreshDegradedState();
+        triggerHealthProbe();
+    }
+
+    private void clearForcedFallback() {
+        if (forcedFallback.compareAndSet(true, false)) {
+            refreshDegradedState();
+        }
+    }
+
+    private void triggerHealthProbe() {
+        if (!forcedFallback.get()) {
+            return;
+        }
+        dbProvider.checkHealth(executorManager.io())
+                .thenAccept(healthy -> {
+                    if (healthy && forcedFallback.compareAndSet(true, false)) {
+                        refreshDegradedState();
+                    }
+                });
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        if (throwable instanceof CompletionException completion && completion.getCause() != null) {
+            return unwrap(completion.getCause());
+        }
+        if (throwable instanceof ExecutionException execution && execution.getCause() != null) {
+            return unwrap(execution.getCause());
+        }
+        return throwable;
     }
 
     private record CacheEntry(PlayerProfile profile, Instant loadedAt) {

--- a/src/main/java/com/heneria/nexus/util/DumpUtil.java
+++ b/src/main/java/com/heneria/nexus/util/DumpUtil.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -86,6 +87,12 @@ public final class DumpUtil {
                 databaseEnabled ? NamedTextColor.GRAY : NamedTextColor.DARK_GRAY));
         lines.add(Component.text("Mode : " + (dbDiagnostics.degraded() ? "Dégradé" : "Normal"),
                 stateColor(!dbDiagnostics.degraded())));
+        boolean health = dbProvider.checkHealth(executorManager.io())
+                .orTimeout(3, TimeUnit.SECONDS)
+                .exceptionally(throwable -> false)
+                .join();
+        lines.add(Component.text("Health check : " + (health ? "OK" : "KO"),
+                health ? NamedTextColor.GRAY : NamedTextColor.RED));
         lines.add(Component.text("Connexions actives : " + formatNumber(dbDiagnostics.activeConnections()), NamedTextColor.GRAY));
         lines.add(Component.text("Connexions libres : " + formatNumber(dbDiagnostics.idleConnections()), NamedTextColor.GRAY));
         lines.add(Component.text("Connexions totales : " + formatNumber(dbDiagnostics.totalConnections()), NamedTextColor.GRAY));


### PR DESCRIPTION
## Summary
- add profile and economy repositories backed by DbProvider for SQL access
- refactor profile and economy services to use the new repositories with improved degraded-mode handling
- expose an asynchronous database health check and display it in the dump diagnostics

## Testing
- `mvn -q -DskipTests compile` *(fails: dependency downloads blocked by repository access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ce54edfc83248994f37dd9ddf2ec