### PR TITLE
Implement write-behind persistence for player data

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -34,6 +34,8 @@ import com.heneria.nexus.api.service.TimerService;
 import com.heneria.nexus.service.core.ArenaServiceImpl;
 import com.heneria.nexus.service.core.EconomyServiceImpl;
 import com.heneria.nexus.service.core.MapServiceImpl;
+import com.heneria.nexus.service.core.PersistenceService;
+import com.heneria.nexus.service.core.PersistenceServiceImpl;
 import com.heneria.nexus.service.core.ProfileServiceImpl;
 import com.heneria.nexus.service.core.QueueServiceImpl;
 import com.heneria.nexus.service.core.TimerServiceImpl;
@@ -179,6 +181,11 @@ public final class NexusPlugin extends JavaPlugin {
             servicesExposed = false;
         }
         if (serviceRegistry != null) {
+            try {
+                serviceRegistry.get(PersistenceService.class).flushAllOnShutdown();
+            } catch (Exception exception) {
+                logger.error("Impossible de flush le cache de persistance avant l'arrêt", exception);
+            }
             serviceRegistry.stopAll(Duration.ofMillis(bundle != null ? bundle.core().timeoutSettings().stopMs() : 3000L));
         }
         if (executorManager != null) {
@@ -630,6 +637,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(MapService.class, MapServiceImpl.class);
         serviceRegistry.registerService(ProfileRepository.class, ProfileRepositoryImpl.class);
         serviceRegistry.registerService(EconomyRepository.class, EconomyRepositoryImpl.class);
+        serviceRegistry.registerService(PersistenceService.class, PersistenceServiceImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
         serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);
         serviceRegistry.registerService(TimerService.class, TimerServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/config/ConfigValidator.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigValidator.java
@@ -80,6 +80,7 @@ public final class ConfigValidator {
         int poolMax = positiveInt(yaml, "database.pool.maxSize", 10, issues, false);
         int poolMin = nonNegativeInt(yaml, "database.pool.minIdle", 2, issues);
         long poolTimeout = positiveLong(yaml, "database.pool.connTimeoutMs", 3000L, issues, true);
+        long writeBehindSeconds = positiveLong(yaml, "database.write_behind_interval_seconds", 60L, issues, true);
 
         boolean exposeServices = yaml.getBoolean("services.expose-bukkit-services", false);
         long timeoutStart = positiveLong(yaml, "timeouts.startMs", 5000L, issues, true);
@@ -205,7 +206,8 @@ public final class ConfigValidator {
             issues.error("database.pool", exception.getMessage());
             poolSettings = new CoreConfig.PoolSettings(10, 2, 3000L);
         }
-        databaseSettings = new CoreConfig.DatabaseSettings(databaseEnabled, jdbc, user, password, poolSettings);
+        databaseSettings = new CoreConfig.DatabaseSettings(databaseEnabled, jdbc, user, password, poolSettings,
+                java.time.Duration.ofSeconds(Math.max(1L, writeBehindSeconds)));
 
         CoreConfig.TimeoutSettings.WatchdogSettings watchdogSettings;
         try {

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -149,12 +149,17 @@ public final class CoreConfig {
         }
     }
 
-    public record DatabaseSettings(boolean enabled, String jdbcUrl, String username, String password, PoolSettings poolSettings) {
+    public record DatabaseSettings(boolean enabled, String jdbcUrl, String username, String password,
+                                   PoolSettings poolSettings, Duration writeBehindInterval) {
         public DatabaseSettings {
             Objects.requireNonNull(jdbcUrl, "jdbcUrl");
             Objects.requireNonNull(username, "username");
             Objects.requireNonNull(password, "password");
             Objects.requireNonNull(poolSettings, "poolSettings");
+            Objects.requireNonNull(writeBehindInterval, "writeBehindInterval");
+            if (writeBehindInterval.isZero() || writeBehindInterval.isNegative()) {
+                throw new IllegalArgumentException("writeBehindInterval must be > 0");
+            }
         }
     }
 

--- a/src/main/java/com/heneria/nexus/db/repository/EconomyRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/EconomyRepository.java
@@ -1,6 +1,7 @@
 package com.heneria.nexus.db.repository;
 
 import com.heneria.nexus.api.EconomyTransferResult;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -44,4 +45,12 @@ public interface EconomyRepository {
      * @return future yielding resulting balances for both accounts
      */
     CompletableFuture<EconomyTransferResult> transfer(UUID from, UUID to, long amount);
+
+    /**
+     * Persists the provided balances in a single batch.
+     *
+     * @param balances map of account identifiers to balances
+     * @return future completed once the batch has been executed
+     */
+    CompletableFuture<Void> saveAll(Map<UUID, Long> balances);
 }

--- a/src/main/java/com/heneria/nexus/db/repository/ProfileRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/ProfileRepository.java
@@ -1,6 +1,7 @@
 package com.heneria.nexus.db.repository;
 
 import com.heneria.nexus.api.PlayerProfile;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -25,4 +26,12 @@ public interface ProfileRepository {
      * @return future completed once the profile has been saved
      */
     CompletableFuture<Void> createOrUpdate(PlayerProfile profile);
+
+    /**
+     * Persists the provided collection of profiles in a single batch.
+     *
+     * @param profiles profiles to persist
+     * @return future completed once the batch has been executed
+     */
+    CompletableFuture<Void> saveAll(Collection<PlayerProfile> profiles);
 }

--- a/src/main/java/com/heneria/nexus/service/core/PersistenceService.java
+++ b/src/main/java/com/heneria/nexus/service/core/PersistenceService.java
@@ -1,0 +1,42 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.api.PlayerProfile;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Coordinates write-behind persistence for player related data.
+ */
+public interface PersistenceService extends LifecycleAware {
+
+    /**
+     * Marks the profile of the provided player as dirty. The supplier will be
+     * invoked during the next flush to obtain the most up-to-date snapshot.
+     */
+    void markProfileDirty(UUID playerId, Supplier<PlayerProfile> snapshotSupplier);
+
+    /**
+     * Marks the balance of the provided player as dirty. The supplier will be
+     * invoked during the next flush to obtain the current balance.
+     */
+    void markEconomyDirty(UUID playerId, LongSupplier balanceSupplier);
+
+    /**
+     * Forces a synchronous flush of all pending changes. Intended for shutdown
+     * sequences.
+     */
+    void flushAllOnShutdown();
+
+    @Override
+    default CompletableFuture<Void> start() {
+        return LifecycleAware.super.start();
+    }
+
+    @Override
+    default CompletableFuture<Void> stop() {
+        return LifecycleAware.super.stop();
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/PersistenceServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/PersistenceServiceImpl.java
@@ -1,0 +1,241 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.api.PlayerProfile;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.db.repository.EconomyRepository;
+import com.heneria.nexus.db.repository.ProfileRepository;
+import com.heneria.nexus.util.NamedThreadFactory;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Default implementation of the write-behind persistence orchestrator.
+ */
+public final class PersistenceServiceImpl implements PersistenceService {
+
+    private final NexusLogger logger;
+    private final ProfileRepository profileRepository;
+    private final EconomyRepository economyRepository;
+    private final Duration flushInterval;
+    private final Set<UUID> dirtyPlayers = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<UUID, DirtyEntry> dirtyEntries = new ConcurrentHashMap<>();
+    private final ReentrantLock flushLock = new ReentrantLock();
+    private final AtomicBoolean running = new AtomicBoolean();
+    private volatile ScheduledExecutorService scheduler;
+
+    public PersistenceServiceImpl(NexusLogger logger,
+                                  ExecutorManager executorManager,
+                                  CoreConfig coreConfig,
+                                  ProfileRepository profileRepository,
+                                  EconomyRepository economyRepository) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        Objects.requireNonNull(executorManager, "executorManager");
+        this.profileRepository = Objects.requireNonNull(profileRepository, "profileRepository");
+        this.economyRepository = Objects.requireNonNull(economyRepository, "economyRepository");
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        this.flushInterval = coreConfig.databaseSettings().writeBehindInterval();
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        if (!running.compareAndSet(false, true)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        ScheduledExecutorService executor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(
+                new NamedThreadFactory("Nexus-Persistence", true, logger));
+        long intervalMs = Math.max(1L, flushInterval.toMillis());
+        executor.scheduleAtFixedRate(this::runScheduledFlush, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+        this.scheduler = executor;
+        logger.info("Write-behind persistence activée (intervalle=%d ms)".formatted(intervalMs));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        running.set(false);
+        ScheduledExecutorService executor = scheduler;
+        if (executor != null) {
+            executor.shutdownNow();
+            scheduler = null;
+        }
+        return flushWithLock(true);
+    }
+
+    @Override
+    public void markProfileDirty(UUID playerId, Supplier<PlayerProfile> snapshotSupplier) {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(snapshotSupplier, "snapshotSupplier");
+        dirtyEntries.compute(playerId, (id, existing) -> {
+            DirtyEntry entry = existing != null ? existing : new DirtyEntry();
+            entry.profileSupplier = snapshotSupplier;
+            return entry;
+        });
+        dirtyPlayers.add(playerId);
+    }
+
+    @Override
+    public void markEconomyDirty(UUID playerId, LongSupplier balanceSupplier) {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(balanceSupplier, "balanceSupplier");
+        dirtyEntries.compute(playerId, (id, existing) -> {
+            DirtyEntry entry = existing != null ? existing : new DirtyEntry();
+            entry.balanceSupplier = balanceSupplier;
+            return entry;
+        });
+        dirtyPlayers.add(playerId);
+    }
+
+    @Override
+    public void flushAllOnShutdown() {
+        try {
+            flushWithLock(true).join();
+        } catch (Exception exception) {
+            Throwable cause = exception instanceof java.util.concurrent.CompletionException ce && ce.getCause() != null
+                    ? ce.getCause()
+                    : exception;
+            logger.error("Échec lors du flush final du cache de persistance", cause);
+        }
+    }
+
+    private void runScheduledFlush() {
+        if (!running.get()) {
+            return;
+        }
+        flushWithLock(false);
+    }
+
+    private CompletableFuture<Void> flushWithLock(boolean blocking) {
+        boolean acquired;
+        if (blocking) {
+            flushLock.lock();
+            acquired = true;
+        } else {
+            acquired = flushLock.tryLock();
+        }
+        if (!acquired) {
+            return CompletableFuture.completedFuture(null);
+        }
+        CompletableFuture<Void> future;
+        try {
+            future = flushInternal();
+        } catch (Throwable throwable) {
+            flushLock.unlock();
+            throw throwable;
+        }
+        future.whenComplete((ignored, throwable) -> flushLock.unlock());
+        return future;
+    }
+
+    private CompletableFuture<Void> flushInternal() {
+        Map<UUID, DirtyEntry> snapshot = snapshotDirtyEntries();
+        if (snapshot.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        ArrayList<PlayerProfile> profiles = new ArrayList<>();
+        HashMap<UUID, Long> balances = new HashMap<>();
+        try {
+            snapshot.forEach((uuid, entry) -> {
+                Supplier<PlayerProfile> profileSupplier = entry.profileSupplier;
+                if (profileSupplier != null) {
+                    PlayerProfile profile = invokeProfileSupplier(uuid, profileSupplier);
+                    if (profile != null) {
+                        profiles.add(profile);
+                    }
+                }
+                LongSupplier balanceSupplier = entry.balanceSupplier;
+                if (balanceSupplier != null) {
+                    long balance = invokeBalanceSupplier(uuid, balanceSupplier);
+                    balances.put(uuid, balance);
+                }
+            });
+        } catch (Throwable throwable) {
+            snapshot.forEach((uuid, entry) -> {
+                dirtyEntries.put(uuid, entry);
+                dirtyPlayers.add(uuid);
+            });
+            throw throwable;
+        }
+        CompletableFuture<Void> persistFuture = persistBatch(profiles, balances);
+        return persistFuture.whenComplete((ignored, throwable) -> {
+            if (throwable == null) {
+                if (!profiles.isEmpty() || !balances.isEmpty()) {
+                    logger.info("[NEXUS] Sauvegardé %d profils et %d soldes modifiés en base de données.".formatted(
+                            profiles.size(), balances.size()));
+                }
+            } else {
+                logger.error("Erreur lors de la sauvegarde batch des données joueurs", throwable);
+                snapshot.forEach((uuid, entry) -> {
+                    dirtyEntries.put(uuid, entry);
+                    dirtyPlayers.add(uuid);
+                });
+            }
+        });
+    }
+
+    private Map<UUID, DirtyEntry> snapshotDirtyEntries() {
+        Map<UUID, DirtyEntry> snapshot = new HashMap<>();
+        synchronized (dirtyPlayers) {
+            if (dirtyPlayers.isEmpty()) {
+                return snapshot;
+            }
+            for (UUID uuid : dirtyPlayers) {
+                DirtyEntry entry = dirtyEntries.remove(uuid);
+                if (entry != null) {
+                    snapshot.put(uuid, entry);
+                }
+            }
+            dirtyPlayers.clear();
+        }
+        return snapshot;
+    }
+
+    private PlayerProfile invokeProfileSupplier(UUID playerId, Supplier<PlayerProfile> supplier) {
+        try {
+            return supplier.get();
+        } catch (Throwable throwable) {
+            throw new IllegalStateException("Impossible d'obtenir le profil pour " + playerId, throwable);
+        }
+    }
+
+    private long invokeBalanceSupplier(UUID playerId, LongSupplier supplier) {
+        try {
+            return supplier.getAsLong();
+        } catch (Throwable throwable) {
+            throw new IllegalStateException("Impossible d'obtenir le solde pour " + playerId, throwable);
+        }
+    }
+
+    private CompletableFuture<Void> persistBatch(ArrayList<PlayerProfile> profiles, HashMap<UUID, Long> balances) {
+        ArrayList<CompletableFuture<Void>> futures = new ArrayList<>(2);
+        if (!profiles.isEmpty()) {
+            futures.add(profileRepository.saveAll(profiles));
+        }
+        if (!balances.isEmpty()) {
+            futures.add(economyRepository.saveAll(balances));
+        }
+        if (futures.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    private static final class DirtyEntry {
+        private Supplier<PlayerProfile> profileSupplier;
+        private LongSupplier balanceSupplier;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,6 +40,7 @@ database:
     maxSize: 10
     minIdle: 2
     connTimeoutMs: 3000
+  write_behind_interval_seconds: 60
 
 services:
   expose-bukkit-services: false


### PR DESCRIPTION
## Summary
- add a PersistenceService that batches profile and balance snapshots and flushes them asynchronously to the database
- update the profile and economy services to mutate in-memory state, mark dirty players, and rely on the write-behind cache instead of immediate JDBC writes
- extend the repositories, configuration, and plugin bootstrap to support batched persistence and a configurable flush interval

## Testing
- `mvn -q -DskipTests package` *(fails: blocked from downloading Paper/Vault dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d24f50848324b76718d87f6c32b6