### PR TITLE
Persist match snapshots asynchronously

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -14,6 +14,8 @@ import com.heneria.nexus.db.DatabaseMigrator;
 import com.heneria.nexus.db.DbProvider;
 import com.heneria.nexus.db.repository.EconomyRepository;
 import com.heneria.nexus.db.repository.EconomyRepositoryImpl;
+import com.heneria.nexus.db.repository.MatchRepository;
+import com.heneria.nexus.db.repository.MatchRepositoryImpl;
 import com.heneria.nexus.db.repository.ProfileRepository;
 import com.heneria.nexus.db.repository.ProfileRepositoryImpl;
 import com.heneria.nexus.hologram.HoloService;
@@ -637,6 +639,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(MapService.class, MapServiceImpl.class);
         serviceRegistry.registerService(ProfileRepository.class, ProfileRepositoryImpl.class);
         serviceRegistry.registerService(EconomyRepository.class, EconomyRepositoryImpl.class);
+        serviceRegistry.registerService(MatchRepository.class, MatchRepositoryImpl.class);
         serviceRegistry.registerService(PersistenceService.class, PersistenceServiceImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
         serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/db/repository/MatchRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/MatchRepository.java
@@ -1,0 +1,18 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.match.MatchSnapshot;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository responsible for persisting match snapshots to the database.
+ */
+public interface MatchRepository {
+
+    /**
+     * Persists the supplied match snapshot asynchronously.
+     *
+     * @param snapshot snapshot describing the match outcome
+     * @return future completing once the snapshot has been persisted
+     */
+    CompletableFuture<Void> save(MatchSnapshot snapshot);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/MatchRepositoryImpl.java
@@ -1,0 +1,119 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.match.MatchSnapshot;
+import com.heneria.nexus.match.MatchSnapshot.ParticipantStats;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Default MariaDB-backed implementation of {@link MatchRepository}.
+ */
+public final class MatchRepositoryImpl implements MatchRepository {
+
+    private static final String INSERT_MATCH_SQL =
+            "INSERT INTO nexus_matches (match_id, map_id, arena_mode, start_timestamp, end_timestamp, winning_team) " +
+                    "VALUES (?, ?, ?, ?, ?, ?)";
+
+    private static final String INSERT_PARTICIPANT_SQL =
+            "INSERT INTO nexus_match_participants (match_id, player_uuid, team, kills, deaths, elo_change) " +
+                    "VALUES (?, ?, ?, ?, ?, ?)";
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public MatchRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletableFuture<Void> save(MatchSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        return dbProvider.execute(connection -> persistSnapshot(connection, snapshot), ioExecutor);
+    }
+
+    private Void persistSnapshot(Connection connection, MatchSnapshot snapshot) throws SQLException {
+        boolean previousAutoCommit = getAutoCommit(connection);
+        connection.setAutoCommit(false);
+        try {
+            insertMatch(connection, snapshot);
+            insertParticipants(connection, snapshot.matchId(), snapshot.participants());
+            connection.commit();
+            return null;
+        } catch (Throwable throwable) {
+            rollbackQuietly(connection);
+            if (throwable instanceof SQLException exception) {
+                throw exception;
+            }
+            if (throwable instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new SQLException("Unexpected error while persisting match snapshot", throwable);
+        } finally {
+            restoreAutoCommit(connection, previousAutoCommit);
+        }
+    }
+
+    private void insertMatch(Connection connection, MatchSnapshot snapshot) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(INSERT_MATCH_SQL)) {
+            statement.setString(1, snapshot.matchId().toString());
+            statement.setString(2, snapshot.mapId());
+            statement.setString(3, snapshot.mode().name());
+            statement.setTimestamp(4, Timestamp.from(snapshot.startTime()));
+            statement.setTimestamp(5, Timestamp.from(snapshot.endTime()));
+            statement.setString(6, snapshot.winningTeam().orElse(null));
+            statement.executeUpdate();
+        }
+    }
+
+    private void insertParticipants(Connection connection, java.util.UUID matchId, List<ParticipantStats> participants)
+            throws SQLException {
+        if (participants.isEmpty()) {
+            return;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(INSERT_PARTICIPANT_SQL)) {
+            for (ParticipantStats participant : participants) {
+                statement.setString(1, matchId.toString());
+                statement.setString(2, participant.playerId().toString());
+                statement.setString(3, participant.team());
+                statement.setInt(4, participant.kills());
+                statement.setInt(5, participant.deaths());
+                statement.setInt(6, participant.eloChange());
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+    }
+
+    private boolean getAutoCommit(Connection connection) {
+        try {
+            return connection.getAutoCommit();
+        } catch (SQLException ignored) {
+            return true;
+        }
+    }
+
+    private void restoreAutoCommit(Connection connection, boolean value) {
+        try {
+            connection.setAutoCommit(value);
+        } catch (SQLException ignored) {
+            // Ignore
+        }
+    }
+
+    private void rollbackQuietly(Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException ignored) {
+            // Ignore
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/match/MatchSnapshot.java
+++ b/src/main/java/com/heneria/nexus/match/MatchSnapshot.java
@@ -1,0 +1,42 @@
+package com.heneria.nexus.match;
+
+import com.heneria.nexus.api.ArenaMode;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Immutable snapshot describing the outcome of a played match.
+ */
+public record MatchSnapshot(UUID matchId,
+                            String mapId,
+                            ArenaMode mode,
+                            Instant startTime,
+                            Instant endTime,
+                            Optional<String> winningTeam,
+                            List<ParticipantStats> participants) {
+
+    public MatchSnapshot {
+        Objects.requireNonNull(matchId, "matchId");
+        Objects.requireNonNull(mapId, "mapId");
+        Objects.requireNonNull(mode, "mode");
+        Objects.requireNonNull(startTime, "startTime");
+        Objects.requireNonNull(endTime, "endTime");
+        Objects.requireNonNull(winningTeam, "winningTeam");
+        Objects.requireNonNull(participants, "participants");
+    }
+
+    public record ParticipantStats(UUID playerId,
+                                   String team,
+                                   int kills,
+                                   int deaths,
+                                   int eloChange) {
+
+        public ParticipantStats {
+            Objects.requireNonNull(playerId, "playerId");
+            Objects.requireNonNull(team, "team");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an immutable `MatchSnapshot` record with nested participant statistics
- add a transactional `MatchRepository` implementation that writes matches and participant rows on the I/O executor
- inject the repository into `ArenaServiceImpl` to persist a snapshot when an arena reaches the END phase and register the repository with the service registry

## Testing
- `mvn -q -DskipTests compile` *(fails: remote Maven repository returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e3b4a65c8324b09a24c13065adf0