### PR TITLE
Implement configurable LRU profile cache for player profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <paper.version>1.21.1-R0.1-SNAPSHOT</paper.version>
         <mariadb.version>3.3.3</mariadb.version>
         <hikari.version>5.1.0</hikari.version>
+        <caffeine.version>3.1.8</caffeine.version>
         <placeholderapi.version>2.11.5</placeholderapi.version>
 
         <!--
@@ -72,6 +73,11 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${mariadb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
@@ -159,6 +165,10 @@
                                 <relocation>
                                     <pattern>org.mariadb.jdbc</pattern>
                                     <shadedPattern>com.heneria.nexus.lib.mariadb</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.github.benmanes.caffeine</pattern>
+                                    <shadedPattern>com.heneria.nexus.lib.caffeine</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -150,15 +150,35 @@ public final class CoreConfig {
     }
 
     public record DatabaseSettings(boolean enabled, String jdbcUrl, String username, String password,
-                                   PoolSettings poolSettings, Duration writeBehindInterval) {
+                                   PoolSettings poolSettings, Duration writeBehindInterval,
+                                   CacheSettings cacheSettings) {
         public DatabaseSettings {
             Objects.requireNonNull(jdbcUrl, "jdbcUrl");
             Objects.requireNonNull(username, "username");
             Objects.requireNonNull(password, "password");
             Objects.requireNonNull(poolSettings, "poolSettings");
             Objects.requireNonNull(writeBehindInterval, "writeBehindInterval");
+            Objects.requireNonNull(cacheSettings, "cacheSettings");
             if (writeBehindInterval.isZero() || writeBehindInterval.isNegative()) {
                 throw new IllegalArgumentException("writeBehindInterval must be > 0");
+            }
+        }
+
+        public record CacheSettings(ProfileCacheSettings profiles) {
+            public CacheSettings {
+                Objects.requireNonNull(profiles, "profiles");
+            }
+        }
+
+        public record ProfileCacheSettings(long maxSize, Duration expireAfterAccess) {
+            public ProfileCacheSettings {
+                if (maxSize <= 0L) {
+                    throw new IllegalArgumentException("maxSize must be > 0");
+                }
+                Objects.requireNonNull(expireAfterAccess, "expireAfterAccess");
+                if (expireAfterAccess.isZero() || expireAfterAccess.isNegative()) {
+                    throw new IllegalArgumentException("expireAfterAccess must be > 0");
+                }
             }
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,6 +41,10 @@ database:
     minIdle: 2
     connTimeoutMs: 3000
   write_behind_interval_seconds: 60
+  cache:
+    profiles:
+      max_size: 1000
+      expire_after_access_minutes: 15
 
 services:
   expose-bukkit-services: false


### PR DESCRIPTION
## Summary
- add the shaded Caffeine dependency to provide an in-memory LRU cache
- extend the core configuration with database profile cache settings
- back the profile service cache with Caffeine and support explicit invalidation

## Testing
- mvn -q -DskipTests package *(fails: repository access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e5c48098832494a41e999ad5bcda