### PR TITLE
Add reward claim idempotency infrastructure

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -23,6 +23,8 @@ import com.heneria.nexus.db.repository.PlayerCosmeticRepository;
 import com.heneria.nexus.db.repository.PlayerCosmeticRepositoryImpl;
 import com.heneria.nexus.db.repository.ProfileRepository;
 import com.heneria.nexus.db.repository.ProfileRepositoryImpl;
+import com.heneria.nexus.db.repository.RewardClaimRepository;
+import com.heneria.nexus.db.repository.RewardClaimRepositoryImpl;
 import com.heneria.nexus.hologram.HoloService;
 import com.heneria.nexus.hologram.HoloServiceImpl;
 import com.heneria.nexus.hologram.Hologram;
@@ -36,6 +38,7 @@ import com.heneria.nexus.api.ArenaService;
 import com.heneria.nexus.api.EconomyService;
 import com.heneria.nexus.api.MapService;
 import com.heneria.nexus.api.ProfileService;
+import com.heneria.nexus.api.RewardService;
 import com.heneria.nexus.api.QueueService;
 import com.heneria.nexus.api.ShopService;
 import com.heneria.nexus.api.service.TimerService;
@@ -46,6 +49,7 @@ import com.heneria.nexus.service.core.PersistenceService;
 import com.heneria.nexus.service.core.PersistenceServiceImpl;
 import com.heneria.nexus.service.core.ProfileServiceImpl;
 import com.heneria.nexus.service.core.QueueServiceImpl;
+import com.heneria.nexus.service.core.RewardServiceImpl;
 import com.heneria.nexus.service.core.ShopServiceImpl;
 import com.heneria.nexus.service.core.TimerServiceImpl;
 import com.heneria.nexus.service.core.VaultEconomyService;
@@ -652,6 +656,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(PlayerCosmeticRepository.class, PlayerCosmeticRepositoryImpl.class);
         serviceRegistry.registerService(EconomyRepository.class, EconomyRepositoryImpl.class);
         serviceRegistry.registerService(MatchRepository.class, MatchRepositoryImpl.class);
+        serviceRegistry.registerService(RewardClaimRepository.class, RewardClaimRepositoryImpl.class);
         serviceRegistry.registerService(PersistenceService.class, PersistenceServiceImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
         serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);
@@ -663,6 +668,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(AnalyticsService.class, AnalyticsService.class);
         serviceRegistry.registerService(ArenaService.class, ArenaServiceImpl.class);
         serviceRegistry.registerService(HoloService.class, HoloServiceImpl.class);
+        serviceRegistry.registerService(RewardService.class, RewardServiceImpl.class);
     }
 
     private void maybeExposeServices() {

--- a/src/main/java/com/heneria/nexus/api/RewardService.java
+++ b/src/main/java/com/heneria/nexus/api/RewardService.java
@@ -1,0 +1,22 @@
+package com.heneria.nexus.api;
+
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Centralised entry point used to distribute unique rewards safely.
+ */
+public interface RewardService extends LifecycleAware {
+
+    /**
+     * Attempts to claim the provided reward for the given player.
+     *
+     * @param playerId unique identifier of the player receiving the reward
+     * @param rewardKey stable identifier describing the reward
+     * @param rewardAction side effect executed only when the reward is claimed for the first time
+     * @return asynchronous stage resolving to {@code true} when the reward has been granted,
+     *         or {@code false} if it was already claimed previously
+     */
+    CompletionStage<Boolean> claimReward(UUID playerId, String rewardKey, Runnable rewardAction);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/RewardClaimRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RewardClaimRepository.java
@@ -1,0 +1,20 @@
+package com.heneria.nexus.db.repository;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository tracking claimed one-time rewards to guarantee idempotence.
+ */
+public interface RewardClaimRepository {
+
+    /**
+     * Attempts to record a reward claim for the provided player.
+     *
+     * @param playerUuid unique identifier of the player claiming the reward
+     * @param rewardKey unique key identifying the reward
+     * @return future resolving to {@code true} when the reward was claimed for the first time
+     *         or {@code false} when the reward was already recorded
+     */
+    CompletableFuture<Boolean> tryClaim(UUID playerUuid, String rewardKey);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/RewardClaimRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RewardClaimRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * MariaDB-backed implementation persisting claimed reward keys.
+ */
+public final class RewardClaimRepositoryImpl implements RewardClaimRepository {
+
+    private static final int ERROR_DUPLICATE_ENTRY = 1062;
+    private static final String SQL_STATE_INTEGRITY_CONSTRAINT = "23000";
+    private static final String INSERT_CLAIM_SQL =
+            "INSERT INTO nexus_rewards_claimed (player_uuid, reward_key) VALUES (?, ?)";
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public RewardClaimRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> tryClaim(UUID playerUuid, String rewardKey) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        Objects.requireNonNull(rewardKey, "rewardKey");
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_CLAIM_SQL)) {
+                statement.setString(1, playerUuid.toString());
+                statement.setString(2, rewardKey);
+                statement.executeUpdate();
+                return true;
+            } catch (SQLException exception) {
+                if (isDuplicateClaim(exception)) {
+                    return false;
+                }
+                throw exception;
+            }
+        }, ioExecutor);
+    }
+
+    private boolean isDuplicateClaim(SQLException exception) {
+        SQLException current = exception;
+        while (current != null) {
+            if (current.getErrorCode() == ERROR_DUPLICATE_ENTRY) {
+                return true;
+            }
+            String sqlState = current.getSQLState();
+            if (sqlState != null && SQL_STATE_INTEGRITY_CONSTRAINT.equals(sqlState)) {
+                return true;
+            }
+            current = current.getNextException();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/RewardServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/RewardServiceImpl.java
@@ -1,0 +1,54 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.api.RewardService;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.repository.RewardClaimRepository;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+/**
+ * Default implementation ensuring unique rewards are granted at most once.
+ */
+public final class RewardServiceImpl implements RewardService {
+
+    private final NexusLogger logger;
+    private final RewardClaimRepository rewardClaimRepository;
+    private final Executor ioExecutor;
+
+    public RewardServiceImpl(NexusLogger logger,
+                             RewardClaimRepository rewardClaimRepository,
+                             ExecutorManager executorManager) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.rewardClaimRepository = Objects.requireNonNull(rewardClaimRepository, "rewardClaimRepository");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletionStage<Boolean> claimReward(UUID playerId, String rewardKey, Runnable rewardAction) {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(rewardKey, "rewardKey");
+        Objects.requireNonNull(rewardAction, "rewardAction");
+        String normalizedKey = rewardKey.trim();
+        if (normalizedKey.isEmpty()) {
+            throw new IllegalArgumentException("rewardKey must not be blank");
+        }
+        return rewardClaimRepository.tryClaim(playerId, normalizedKey)
+                .thenApplyAsync(claimed -> {
+                    if (!claimed) {
+                        return false;
+                    }
+                    try {
+                        rewardAction.run();
+                        return true;
+                    } catch (Throwable throwable) {
+                        logger.error("Échec de l'exécution de la récompense %s pour %s".formatted(normalizedKey, playerId),
+                                throwable);
+                        throw new CompletionException(throwable);
+                    }
+                }, ioExecutor);
+    }
+}

--- a/src/main/resources/db/migration/V3__Add_Rewards_Claim_Table.sql
+++ b/src/main/resources/db/migration/V3__Add_Rewards_Claim_Table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS nexus_rewards_claimed (
+    claim_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    player_uuid CHAR(36) NOT NULL,
+    reward_key VARCHAR(255) NOT NULL,
+    claimed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_player_reward (player_uuid, reward_key)
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- add a migration creating the `nexus_rewards_claimed` table with a unique constraint per player and reward key
- implement a repository and service that record reward claims and only execute the reward action on the first grant
- register the reward infrastructure in the plugin bootstrap so other systems can request idempotent rewards

## Testing
- mvn -q -DskipTests package *(fails: dependency downloads blocked by repository 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ed6ec1bc832480d11bac5e05681f