### PR TITLE
Add scheduled purge for old match history data

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -61,6 +61,7 @@ import com.heneria.nexus.service.core.RewardServiceImpl;
 import com.heneria.nexus.service.core.ShopServiceImpl;
 import com.heneria.nexus.service.core.TimerServiceImpl;
 import com.heneria.nexus.service.core.VaultEconomyService;
+import com.heneria.nexus.service.maintenance.DataPurgeService;
 import com.heneria.nexus.service.permissions.NexusContextManager;
 import com.heneria.nexus.util.DumpUtil;
 import com.heneria.nexus.util.MessageFacade;
@@ -424,6 +425,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.updateSingleton(CoreConfig.class, newBundle.core());
         serviceRegistry.updateSingleton(EconomyConfig.class, newBundle.economy());
         configureDatabase(newBundle.core().databaseSettings());
+        serviceRegistry.get(DataPurgeService.class).applyConfiguration(newBundle.core());
         serviceRegistry.get(QueueService.class).applySettings(newBundle.core().queueSettings());
         serviceRegistry.get(ArenaService.class).applyArenaSettings(newBundle.core().arenaSettings());
         serviceRegistry.get(ArenaService.class).applyWatchdogSettings(newBundle.core().timeoutSettings().watchdog());
@@ -990,6 +992,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(PlayerCosmeticRepository.class, PlayerCosmeticRepositoryImpl.class);
         serviceRegistry.registerService(EconomyRepository.class, EconomyRepositoryImpl.class);
         serviceRegistry.registerService(MatchRepository.class, MatchRepositoryImpl.class);
+        serviceRegistry.registerService(DataPurgeService.class, DataPurgeService.class);
         serviceRegistry.registerService(RewardClaimRepository.class, RewardClaimRepositoryImpl.class);
         serviceRegistry.registerService(PersistenceService.class, PersistenceServiceImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -151,7 +151,7 @@ public final class CoreConfig {
 
     public record DatabaseSettings(boolean enabled, String jdbcUrl, String username, String password,
                                    PoolSettings poolSettings, Duration writeBehindInterval,
-                                   CacheSettings cacheSettings) {
+                                   CacheSettings cacheSettings, DataRetentionSettings retentionPolicy) {
         public DatabaseSettings {
             Objects.requireNonNull(jdbcUrl, "jdbcUrl");
             Objects.requireNonNull(username, "username");
@@ -159,6 +159,7 @@ public final class CoreConfig {
             Objects.requireNonNull(poolSettings, "poolSettings");
             Objects.requireNonNull(writeBehindInterval, "writeBehindInterval");
             Objects.requireNonNull(cacheSettings, "cacheSettings");
+            Objects.requireNonNull(retentionPolicy, "retentionPolicy");
             if (writeBehindInterval.isZero() || writeBehindInterval.isNegative()) {
                 throw new IllegalArgumentException("writeBehindInterval must be > 0");
             }
@@ -178,6 +179,14 @@ public final class CoreConfig {
                 Objects.requireNonNull(expireAfterAccess, "expireAfterAccess");
                 if (expireAfterAccess.isZero() || expireAfterAccess.isNegative()) {
                     throw new IllegalArgumentException("expireAfterAccess must be > 0");
+                }
+            }
+        }
+
+        public record DataRetentionSettings(int matchHistoryDays) {
+            public DataRetentionSettings {
+                if (matchHistoryDays < 0) {
+                    throw new IllegalArgumentException("matchHistoryDays must be >= 0");
                 }
             }
         }

--- a/src/main/java/com/heneria/nexus/db/repository/MatchRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/MatchRepository.java
@@ -1,6 +1,7 @@
 package com.heneria.nexus.db.repository;
 
 import com.heneria.nexus.match.MatchSnapshot;
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -15,4 +16,12 @@ public interface MatchRepository {
      * @return future completing once the snapshot has been persisted
      */
     CompletableFuture<Void> save(MatchSnapshot snapshot);
+
+    /**
+     * Purges completed matches older than the provided timestamp.
+     *
+     * @param olderThan cutoff instant; matches with an end timestamp strictly before this instant are deleted
+     * @return future containing the number of deleted matches once the purge completes
+     */
+    CompletableFuture<Integer> purgeOldMatches(Instant olderThan);
 }

--- a/src/main/java/com/heneria/nexus/service/maintenance/DataPurgeService.java
+++ b/src/main/java/com/heneria/nexus/service/maintenance/DataPurgeService.java
@@ -1,0 +1,185 @@
+package com.heneria.nexus.service.maintenance;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.db.repository.MatchRepository;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Background service responsible for purging obsolete match history entries.
+ */
+public final class DataPurgeService implements LifecycleAware {
+
+    private static final int SCHEDULE_HOUR = 4;
+    private static final long MILLIS_PER_TICK = 50L;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final MatchRepository matchRepository;
+    private final AtomicReference<ServiceConfiguration> configurationRef;
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final Object taskLock = new Object();
+
+    private BukkitTask scheduledTask;
+
+    public DataPurgeService(JavaPlugin plugin,
+                            NexusLogger logger,
+                            MatchRepository matchRepository,
+                            CoreConfig coreConfig) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.matchRepository = Objects.requireNonNull(matchRepository, "matchRepository");
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        this.configurationRef = new AtomicReference<>(toConfiguration(coreConfig));
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        running.set(true);
+        scheduleNextRun();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        running.set(false);
+        cancelScheduledTask();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Applies the latest configuration after a reload.
+     */
+    public void applyConfiguration(CoreConfig coreConfig) {
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        ServiceConfiguration newConfig = toConfiguration(coreConfig);
+        ServiceConfiguration previous = configurationRef.getAndSet(newConfig);
+        if (!running.get()) {
+            return;
+        }
+        if (!newConfig.equals(previous)) {
+            scheduleNextRun();
+        }
+    }
+
+    private ServiceConfiguration toConfiguration(CoreConfig coreConfig) {
+        CoreConfig.DatabaseSettings database = coreConfig.databaseSettings();
+        return new ServiceConfiguration(
+                database.enabled(),
+                coreConfig.timezone(),
+                Math.max(0, database.retentionPolicy().matchHistoryDays()));
+    }
+
+    private void scheduleNextRun() {
+        if (!running.get()) {
+            return;
+        }
+        ServiceConfiguration config = configurationRef.get();
+        if (!config.databaseEnabled()) {
+            logger.info("Purge automatique des matchs désactivée (MariaDB désactivée)");
+            cancelScheduledTask();
+            return;
+        }
+        if (config.retentionDays() <= 0) {
+            logger.info("Purge automatique des matchs désactivée (match_history_days <= 0)");
+            cancelScheduledTask();
+            return;
+        }
+        ZonedDateTime now = ZonedDateTime.now(config.timezone());
+        ZonedDateTime nextRun = now.withHour(SCHEDULE_HOUR).withMinute(0).withSecond(0).withNano(0);
+        if (!nextRun.isAfter(now)) {
+            nextRun = nextRun.plusDays(1);
+        }
+        long delayTicks = Math.max(1L,
+                (Duration.between(now, nextRun).toMillis() + (MILLIS_PER_TICK - 1)) / MILLIS_PER_TICK);
+        synchronized (taskLock) {
+            if (!running.get()) {
+                return;
+            }
+            cancelScheduledTaskLocked();
+            scheduledTask = plugin.getServer().getScheduler()
+                    .runTaskLaterAsynchronously(plugin, this::executePurge, delayTicks);
+        }
+        ZonedDateTime finalNextRun = nextRun;
+        logger.info(() -> "Purge automatique des matchs planifiée le "
+                + DATE_TIME_FORMATTER.format(finalNextRun) + " (rétention "
+                + config.retentionDays() + "j)");
+    }
+
+    private void executePurge() {
+        synchronized (taskLock) {
+            scheduledTask = null;
+        }
+        if (!running.get()) {
+            return;
+        }
+        ServiceConfiguration config = configurationRef.get();
+        if (!config.databaseEnabled()) {
+            logger.info("Purge automatique des matchs ignorée (MariaDB désactivée)");
+            if (running.get()) {
+                scheduleNextRun();
+            }
+            return;
+        }
+        if (config.retentionDays() <= 0) {
+            logger.info("Purge automatique des matchs ignorée (match_history_days <= 0)");
+            if (running.get()) {
+                scheduleNextRun();
+            }
+            return;
+        }
+        Instant cutoff = Instant.now().minus(Duration.ofDays(config.retentionDays()));
+        matchRepository.purgeOldMatches(cutoff)
+                .whenComplete((deleted, throwable) -> {
+                    if (throwable != null) {
+                        logger.warn("Purge automatique des matchs en échec", unwrap(throwable));
+                    } else {
+                        logger.info(() -> "Purge automatique des matchs terminée — "
+                                + deleted + " match(s) supprimé(s) (rétention "
+                                + config.retentionDays() + "j)");
+                    }
+                    if (running.get()) {
+                        scheduleNextRun();
+                    }
+                });
+    }
+
+    private void cancelScheduledTask() {
+        synchronized (taskLock) {
+            cancelScheduledTaskLocked();
+        }
+    }
+
+    private void cancelScheduledTaskLocked() {
+        if (scheduledTask != null) {
+            scheduledTask.cancel();
+            scheduledTask = null;
+        }
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        while ((throwable instanceof CompletionException || throwable instanceof ExecutionException)
+                && throwable.getCause() != null) {
+            throwable = throwable.getCause();
+        }
+        return throwable;
+    }
+
+    private record ServiceConfiguration(boolean databaseEnabled, ZoneId timezone, int retentionDays) {
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -45,6 +45,9 @@ database:
     profiles:
       max_size: 1000
       expire_after_access_minutes: 15
+  retention_policy:
+    # Durée de conservation des historiques de matchs en jours. Mettre à 0 pour désactiver la purge.
+    match_history_days: 90
 
 services:
   expose-bukkit-services: false


### PR DESCRIPTION
## Summary
- add a configurable database retention policy for match history
- implement repository support and a DataPurgeService to purge old matches in daily batches
- register the purge service and apply updates on configuration reloads

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads blocked by 403 from papermc repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f4a62340832488f8dd0ede9e01ce