### PR TITLE
feat: add daily statistics aggregation

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -10,6 +10,8 @@ import com.heneria.nexus.admin.PlayerEconomySnapshot;
 import com.heneria.nexus.admin.PlayerProfileSnapshot;
 import com.heneria.nexus.analytics.AnalyticsRepository;
 import com.heneria.nexus.analytics.AnalyticsService;
+import com.heneria.nexus.analytics.daily.DailyStatsAggregatorService;
+import com.heneria.nexus.analytics.daily.DailyStatsRepository;
 import com.heneria.nexus.budget.BudgetService;
 import com.heneria.nexus.budget.BudgetServiceImpl;
 import com.heneria.nexus.budget.BudgetSnapshot;
@@ -1003,6 +1005,8 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(WatchdogService.class, WatchdogServiceImpl.class);
         serviceRegistry.registerService(AnalyticsRepository.class, AnalyticsRepository.class);
         serviceRegistry.registerService(AnalyticsService.class, AnalyticsService.class);
+        serviceRegistry.registerService(DailyStatsRepository.class, DailyStatsRepository.class);
+        serviceRegistry.registerService(DailyStatsAggregatorService.class, DailyStatsAggregatorService.class);
         serviceRegistry.registerService(ArenaService.class, ArenaServiceImpl.class);
         serviceRegistry.registerService(HoloService.class, HoloServiceImpl.class);
         serviceRegistry.registerService(RewardService.class, RewardServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsAggregatorService.java
+++ b/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsAggregatorService.java
@@ -1,0 +1,285 @@
+package com.heneria.nexus.analytics.daily;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.util.NexusLogger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Periodically aggregates daily statistics and stores them in the {@code nexus_daily_stats} table.
+ */
+public final class DailyStatsAggregatorService implements LifecycleAware {
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.systemDefault();
+
+    private static final String MATCHES_COUNT_SQL = """
+            SELECT COUNT(*)
+            FROM nexus_matches
+            WHERE end_timestamp IS NOT NULL
+              AND end_timestamp >= ?
+              AND end_timestamp < ?
+            """;
+
+    private static final String UNIQUE_PLAYERS_SQL = """
+            SELECT COUNT(DISTINCT p.player_uuid)
+            FROM nexus_match_participants p
+            INNER JOIN nexus_matches m ON m.match_id = p.match_id
+            WHERE m.end_timestamp IS NOT NULL
+              AND m.end_timestamp >= ?
+              AND m.end_timestamp < ?
+            """;
+
+    private static final List<String> COINS_SQL_CANDIDATES = List.of(
+            "SELECT COALESCE(SUM(delta), 0) FROM nexus_economy_log WHERE delta > 0 AND created_at >= ? AND created_at < ?",
+            "SELECT COALESCE(SUM(amount_delta), 0) FROM nexus_economy_log WHERE amount_delta > 0 AND created_at >= ? AND created_at < ?",
+            "SELECT COALESCE(SUM(amount), 0) FROM nexus_economy_log WHERE amount > 0 AND created_at >= ? AND created_at < ?"
+    );
+
+    private static final List<String> BPXP_SQL_CANDIDATES = List.of(
+            "SELECT COALESCE(SUM(xp_delta), 0) FROM nexus_battle_pass_xp_log WHERE xp_delta > 0 AND created_at >= ? AND created_at < ?",
+            "SELECT COALESCE(SUM(delta), 0) FROM nexus_battle_pass_xp_log WHERE delta > 0 AND created_at >= ? AND created_at < ?",
+            "SELECT COALESCE(SUM(xp_amount), 0) FROM nexus_battle_pass_xp_log WHERE xp_amount > 0 AND created_at >= ? AND created_at < ?",
+            "SELECT COALESCE(SUM(xp_delta), 0) FROM nexus_battle_pass_log WHERE xp_delta > 0 AND created_at >= ? AND created_at < ?"
+    );
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final DbProvider dbProvider;
+    private final DailyStatsRepository repository;
+    private final Executor ioExecutor;
+    private final ZoneId zoneId;
+    private final boolean enabled;
+    private final Set<String> suppressedWarnings = ConcurrentHashMap.newKeySet();
+    private final Object chainLock = new Object();
+
+    private final AtomicReference<Throwable> lastError = new AtomicReference<>();
+    private final AtomicReference<BukkitTask> scheduledTask = new AtomicReference<>();
+    private volatile CompletableFuture<Void> tail = CompletableFuture.completedFuture(null);
+
+    public DailyStatsAggregatorService(JavaPlugin plugin,
+                                       NexusLogger logger,
+                                       DbProvider dbProvider,
+                                       DailyStatsRepository repository,
+                                       ExecutorManager executorManager,
+                                       CoreConfig coreConfig) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+        this.zoneId = DEFAULT_ZONE;
+        this.enabled = Objects.requireNonNull(coreConfig, "coreConfig").databaseSettings().enabled();
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        if (!enabled) {
+            logger.info("Agrégation quotidienne désactivée (base de données inopérante)");
+            return CompletableFuture.completedFuture(null);
+        }
+        scheduleNextRun();
+        LocalDate yesterday = LocalDate.now(zoneId).minusDays(1);
+        aggregateFor(yesterday).whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                logger.warn("Agrégation quotidienne initiale en échec", unwrap(throwable));
+            }
+        });
+        logger.info("Agrégateur de statistiques quotidiennes initialisé");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        cancelScheduledTask();
+        CompletableFuture<Void> pending;
+        synchronized (chainLock) {
+            pending = tail;
+        }
+        return pending.exceptionally(throwable -> null);
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return lastError.get() == null;
+    }
+
+    @Override
+    public java.util.Optional<Throwable> lastError() {
+        return java.util.Optional.ofNullable(lastError.get());
+    }
+
+    /**
+     * Triggers aggregation for the provided date.
+     */
+    public CompletableFuture<Void> aggregateFor(LocalDate date) {
+        Objects.requireNonNull(date, "date");
+        if (!enabled) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (date.isAfter(LocalDate.now(zoneId))) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Impossible d'agréger une date future"));
+        }
+        CompletableFuture<Void> result;
+        synchronized (chainLock) {
+            tail = tail.exceptionally(throwable -> null)
+                    .thenCompose(ignored -> performAggregation(date));
+            result = tail;
+        }
+        return result;
+    }
+
+    /**
+     * Immediately launches aggregation for the previous day without waiting for the scheduled run.
+     */
+    public CompletableFuture<Void> aggregateYesterday() {
+        return aggregateFor(LocalDate.now(zoneId).minusDays(1));
+    }
+
+    private CompletableFuture<Void> performAggregation(LocalDate targetDate) {
+        return dbProvider.execute(connection -> computeSnapshot(connection, targetDate), ioExecutor)
+                .thenCompose(repository::saveOrUpdate)
+                .whenComplete((ignored, throwable) -> {
+                    if (throwable != null) {
+                        lastError.set(unwrap(throwable));
+                        logger.warn("Échec de l'agrégation quotidienne pour " + targetDate, unwrap(throwable));
+                    } else {
+                        lastError.set(null);
+                        logger.debug(() -> "Statistiques quotidiennes agrégées pour " + targetDate);
+                    }
+                });
+    }
+
+    private DailyStatsSnapshot computeSnapshot(Connection connection, LocalDate date) throws SQLException {
+        Timestamp start = Timestamp.from(date.atStartOfDay(zoneId).toInstant());
+        Timestamp end = Timestamp.from(date.plusDays(1).atStartOfDay(zoneId).toInstant());
+
+        int matches = queryCount(connection, MATCHES_COUNT_SQL, start, end);
+        int uniquePlayers = queryCount(connection, UNIQUE_PLAYERS_SQL, start, end);
+        long coins = queryMetricWithFallback(connection, COINS_SQL_CANDIDATES, start, end, "coins");
+        long battlePassXp = queryMetricWithFallback(connection, BPXP_SQL_CANDIDATES, start, end, "battle pass xp");
+
+        if (coins < 0L) {
+            coins = 0L;
+        }
+        if (battlePassXp < 0L) {
+            battlePassXp = 0L;
+        }
+
+        return new DailyStatsSnapshot(date, matches, uniquePlayers, coins, battlePassXp);
+    }
+
+    private int queryCount(Connection connection, String sql, Timestamp start, Timestamp end) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setTimestamp(1, start);
+            statement.setTimestamp(2, end);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getInt(1);
+                }
+            }
+        }
+        return 0;
+    }
+
+    private long queryMetricWithFallback(Connection connection,
+                                         List<String> candidates,
+                                         Timestamp start,
+                                         Timestamp end,
+                                         String metricName) {
+        List<SQLException> failures = new ArrayList<>();
+        for (String sql : candidates) {
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.setTimestamp(1, start);
+                statement.setTimestamp(2, end);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        return Math.max(0L, resultSet.getLong(1));
+                    }
+                }
+            } catch (SQLException exception) {
+                failures.add(exception);
+            }
+        }
+        if (!failures.isEmpty()) {
+            SQLException last = failures.getLast();
+            String sqlState = last.getSQLState();
+            String key = metricName + ':' + (sqlState != null ? sqlState : last.getClass().getName());
+            if (suppressedWarnings.add(key)) {
+                logger.warn("Impossible de calculer la métrique %s (utilisation de 0)".formatted(metricName), last);
+            } else {
+                logger.debug(() -> "Échec répété pour la métrique %s: %s".formatted(metricName, last.getMessage()));
+            }
+        }
+        return 0L;
+    }
+
+    private void scheduleNextRun() {
+        cancelScheduledTask();
+        long delayTicks = Math.max(1L, (computeDelayToNextRun().toMillis() + 49L) / 50L);
+        BukkitTask task = plugin.getServer().getScheduler()
+                .runTaskLaterAsynchronously(plugin, this::runScheduledAggregation, delayTicks);
+        scheduledTask.set(task);
+    }
+
+    private void runScheduledAggregation() {
+        if (!plugin.isEnabled()) {
+            return;
+        }
+        aggregateYesterday().whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                logger.warn("Exécution planifiée de l'agrégateur en échec", unwrap(throwable));
+            }
+            scheduleNextRun();
+        });
+    }
+
+    private Duration computeDelayToNextRun() {
+        ZonedDateTime now = ZonedDateTime.now(zoneId);
+        ZonedDateTime nextRun = now.truncatedTo(ChronoUnit.DAYS)
+                .plusDays(1)
+                .withHour(0)
+                .withMinute(5)
+                .withSecond(0)
+                .withNano(0);
+        if (!nextRun.isAfter(now)) {
+            nextRun = nextRun.plusDays(1);
+        }
+        return Duration.between(now, nextRun);
+    }
+
+    private void cancelScheduledTask() {
+        BukkitTask task = scheduledTask.getAndSet(null);
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        if (throwable instanceof java.util.concurrent.CompletionException completion && completion.getCause() != null) {
+            return completion.getCause();
+        }
+        return throwable;
+    }
+}

--- a/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsRepository.java
+++ b/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsRepository.java
@@ -1,0 +1,53 @@
+package com.heneria.nexus.analytics.daily;
+
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Repository responsible for persisting aggregated daily statistics.
+ */
+public final class DailyStatsRepository {
+
+    private static final String UPSERT_SQL = """
+            INSERT INTO nexus_daily_stats (stat_date, total_matches_played, total_players_unique,
+                                           total_coins_earned, total_bpxp_earned)
+            VALUES (?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                total_matches_played = VALUES(total_matches_played),
+                total_players_unique = VALUES(total_players_unique),
+                total_coins_earned = VALUES(total_coins_earned),
+                total_bpxp_earned = VALUES(total_bpxp_earned)
+            """;
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public DailyStatsRepository(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    public CompletableFuture<Void> saveOrUpdate(DailyStatsSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        return dbProvider.execute(connection -> persist(connection, snapshot), ioExecutor);
+    }
+
+    private Void persist(Connection connection, DailyStatsSnapshot snapshot) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(UPSERT_SQL)) {
+            statement.setDate(1, Date.valueOf(snapshot.statDate()));
+            statement.setInt(2, snapshot.totalMatchesPlayed());
+            statement.setInt(3, snapshot.totalPlayersUnique());
+            statement.setLong(4, snapshot.totalCoinsEarned());
+            statement.setLong(5, snapshot.totalBattlePassXpEarned());
+            statement.executeUpdate();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsSnapshot.java
+++ b/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsSnapshot.java
@@ -1,0 +1,30 @@
+package com.heneria.nexus.analytics.daily;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * Immutable representation of a row stored in the {@code nexus_daily_stats} table.
+ */
+public record DailyStatsSnapshot(LocalDate statDate,
+                                 int totalMatchesPlayed,
+                                 int totalPlayersUnique,
+                                 long totalCoinsEarned,
+                                 long totalBattlePassXpEarned) {
+
+    public DailyStatsSnapshot {
+        Objects.requireNonNull(statDate, "statDate");
+        if (totalMatchesPlayed < 0) {
+            throw new IllegalArgumentException("totalMatchesPlayed must be >= 0");
+        }
+        if (totalPlayersUnique < 0) {
+            throw new IllegalArgumentException("totalPlayersUnique must be >= 0");
+        }
+        if (totalCoinsEarned < 0) {
+            throw new IllegalArgumentException("totalCoinsEarned must be >= 0");
+        }
+        if (totalBattlePassXpEarned < 0) {
+            throw new IllegalArgumentException("totalBattlePassXpEarned must be >= 0");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V4__Add_Daily_Stats_Table.sql
+++ b/src/main/resources/db/migration/V4__Add_Daily_Stats_Table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS nexus_daily_stats (
+    stat_date DATE NOT NULL PRIMARY KEY,
+    total_matches_played INT NOT NULL DEFAULT 0,
+    total_players_unique INT NOT NULL DEFAULT 0,
+    total_coins_earned BIGINT NOT NULL DEFAULT 0,
+    total_bpxp_earned BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- add the `nexus_daily_stats` aggregation table
- implement a daily aggregation service and repository to compute and persist metrics
- register the new service so it runs alongside the existing analytics pipeline

## Testing
- `mvn -q -DskipTests compile` *(fails: cannot download provided server dependencies in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f80c94ec83248eeeb94ffa21f6c1