### PR TITLE
feat: add database-backed audit logging system

### DIFF
--- a/src/main/java/com/heneria/nexus/audit/AuditActionType.java
+++ b/src/main/java/com/heneria/nexus/audit/AuditActionType.java
@@ -1,0 +1,62 @@
+package com.heneria.nexus.audit;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Enumerates the different audit action categories persisted in the database.
+ */
+public enum AuditActionType {
+
+    ADMIN_COMMAND("ADMIN_COMMAND", "Commande admin"),
+    PLAYER_PURCHASE("PLAYER_PURCHASE", "Achat boutique"),
+    SYSTEM_EVENT("SYSTEM_EVENT", "Événement système"),
+    UNKNOWN("UNKNOWN", "Inconnu");
+
+    private static final Map<String, AuditActionType> LOOKUP = new ConcurrentHashMap<>();
+
+    static {
+        for (AuditActionType type : values()) {
+            LOOKUP.put(type.databaseValue, type);
+        }
+    }
+
+    private final String databaseValue;
+    private final String displayName;
+
+    AuditActionType(String databaseValue, String displayName) {
+        this.databaseValue = Objects.requireNonNull(databaseValue, "databaseValue");
+        this.displayName = Objects.requireNonNull(displayName, "displayName");
+    }
+
+    /**
+     * Identifier persisted in the database for this action type.
+     */
+    public String databaseValue() {
+        return databaseValue;
+    }
+
+    /**
+     * Human readable representation of the action type.
+     */
+    public String displayName() {
+        return displayName;
+    }
+
+    /**
+     * Resolves an {@link AuditActionType} from a persisted value.
+     */
+    public static AuditActionType fromDatabaseValue(String value) {
+        if (value == null) {
+            return UNKNOWN;
+        }
+        AuditActionType type = LOOKUP.get(value);
+        if (type != null) {
+            return type;
+        }
+        String normalised = value.toUpperCase(Locale.ROOT);
+        return LOOKUP.getOrDefault(normalised, UNKNOWN);
+    }
+}

--- a/src/main/java/com/heneria/nexus/audit/AuditEntry.java
+++ b/src/main/java/com/heneria/nexus/audit/AuditEntry.java
@@ -1,0 +1,30 @@
+package com.heneria.nexus.audit;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Describes an audit entry to be persisted.
+ */
+public record AuditEntry(UUID actorUuid,
+                         String actorName,
+                         AuditActionType actionType,
+                         UUID targetUuid,
+                         String targetName,
+                         String details) {
+
+    public AuditEntry {
+        Objects.requireNonNull(actionType, "actionType");
+        actorName = normaliseName(actorName);
+        targetName = normaliseName(targetName);
+        details = details != null ? details.trim() : "";
+    }
+
+    private static String normaliseName(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/com/heneria/nexus/audit/AuditLogQuery.java
+++ b/src/main/java/com/heneria/nexus/audit/AuditLogQuery.java
@@ -1,0 +1,29 @@
+package com.heneria.nexus.audit;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Query descriptor used when retrieving audit log entries.
+ */
+public record AuditLogQuery(int page,
+                            int pageSize,
+                            Optional<UUID> subjectUuid,
+                            Optional<String> subjectName) {
+
+    public AuditLogQuery {
+        if (page <= 0) {
+            throw new IllegalArgumentException("page must be positive");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("pageSize must be positive");
+        }
+        subjectUuid = Objects.requireNonNull(subjectUuid, "subjectUuid");
+        subjectName = Objects.requireNonNull(subjectName, "subjectName");
+    }
+
+    public int offset() {
+        return (page - 1) * pageSize;
+    }
+}

--- a/src/main/java/com/heneria/nexus/audit/AuditLogRecord.java
+++ b/src/main/java/com/heneria/nexus/audit/AuditLogRecord.java
@@ -1,0 +1,28 @@
+package com.heneria.nexus.audit;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Immutable representation of a persisted audit log row.
+ */
+public record AuditLogRecord(long id,
+                             Instant timestamp,
+                             UUID actorUuid,
+                             String actorName,
+                             AuditActionType actionType,
+                             UUID targetUuid,
+                             String targetName,
+                             String details) {
+
+    public AuditLogRecord {
+        Objects.requireNonNull(timestamp, "timestamp");
+        Objects.requireNonNull(actionType, "actionType");
+        details = details != null ? details : "";
+    }
+
+    public AuditLogRecord withId(long newId) {
+        return new AuditLogRecord(newId, timestamp, actorUuid, actorName, actionType, targetUuid, targetName, details);
+    }
+}

--- a/src/main/java/com/heneria/nexus/audit/AuditService.java
+++ b/src/main/java/com/heneria/nexus/audit/AuditService.java
@@ -1,0 +1,30 @@
+package com.heneria.nexus.audit;
+
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Entry point used to record and query audit logs.
+ */
+public interface AuditService extends LifecycleAware {
+
+    /**
+     * Schedules the provided entry for asynchronous persistence.
+     */
+    void log(AuditEntry entry);
+
+    /**
+     * Retrieves a page of audit logs matching the provided query.
+     */
+    CompletableFuture<AuditLogPage> query(AuditLogQuery query);
+
+    /**
+     * Immutable result returned by {@link #query(AuditLogQuery)}.
+     */
+    record AuditLogPage(int page, int pageSize, boolean hasNext, java.util.List<AuditLogRecord> entries) {
+        public AuditLogPage {
+            Objects.requireNonNull(entries, "entries");
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/audit/AuditServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/audit/AuditServiceImpl.java
@@ -1,0 +1,221 @@
+package com.heneria.nexus.audit;
+
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.db.repository.AuditLogRepository;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.util.NamedThreadFactory;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Default implementation buffering audit entries before persisting them in MariaDB.
+ */
+public final class AuditServiceImpl implements AuditService, LifecycleAware {
+
+    private static final int FLUSH_THRESHOLD = 32;
+    private static final int MAX_BATCH_SIZE = 256;
+    private static final int MAX_BUFFER_SIZE = 2_000;
+
+    private final NexusLogger logger;
+    private final AuditLogRepository repository;
+    private final ExecutorManager executorManager;
+    private final Duration flushInterval;
+    private final Queue<AuditLogRecord> pending = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger pendingSize = new AtomicInteger();
+    private final AtomicBoolean flushing = new AtomicBoolean();
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final AtomicBoolean overflowWarned = new AtomicBoolean();
+    private final AtomicReference<Throwable> lastError = new AtomicReference<>();
+    private volatile ScheduledExecutorService scheduler;
+
+    public AuditServiceImpl(NexusLogger logger,
+                            AuditLogRepository repository,
+                            ExecutorManager executorManager,
+                            CoreConfig coreConfig) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        this.flushInterval = coreConfig.databaseSettings().writeBehindInterval();
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        if (!running.compareAndSet(false, true)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        long intervalMs = Math.max(1000L, flushInterval.toMillis());
+        ScheduledExecutorService executor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(
+                new NamedThreadFactory("Nexus-Audit", true, logger));
+        executor.scheduleAtFixedRate(this::flushSilently, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+        scheduler = executor;
+        logger.info("Journal d'audit initialisé (intervalle=%d ms)".formatted(intervalMs));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        running.set(false);
+        ScheduledExecutorService executor = scheduler;
+        if (executor != null) {
+            executor.shutdownNow();
+            scheduler = null;
+        }
+        return flushAll();
+    }
+
+    @Override
+    public void log(AuditEntry entry) {
+        Objects.requireNonNull(entry, "entry");
+        AuditLogRecord record = new AuditLogRecord(
+                0L,
+                Instant.now(),
+                entry.actorUuid(),
+                entry.actorName(),
+                entry.actionType(),
+                entry.targetUuid(),
+                entry.targetName(),
+                entry.details());
+        pending.add(record);
+        int size = pendingSize.incrementAndGet();
+        if (size >= MAX_BUFFER_SIZE && overflowWarned.compareAndSet(false, true)) {
+            logger.warn("File de journal d'audit saturée (%d entrées).".formatted(size));
+        }
+        if (size >= FLUSH_THRESHOLD) {
+            flushSilently();
+        }
+    }
+
+    @Override
+    public CompletableFuture<AuditLogPage> query(AuditLogQuery query) {
+        Objects.requireNonNull(query, "query");
+        int fetchSize = Math.min(MAX_BATCH_SIZE, query.pageSize() + 1);
+        Optional<UUID> subjectUuid = query.subjectUuid();
+        Optional<String> subjectName = query.subjectName();
+        return repository.findRecent(subjectUuid, subjectName, fetchSize, query.offset())
+                .thenApply(records -> {
+                    boolean hasNext = records.size() > query.pageSize();
+                    List<AuditLogRecord> trimmed = records;
+                    if (hasNext) {
+                        trimmed = records.subList(0, query.pageSize());
+                    }
+                    return new AuditLogPage(query.page(), query.pageSize(), hasNext, List.copyOf(trimmed));
+                });
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return lastError.get() == null;
+    }
+
+    @Override
+    public Optional<Throwable> lastError() {
+        return Optional.ofNullable(lastError.get());
+    }
+
+    private void flushSilently() {
+        if (!running.get() && pending.isEmpty()) {
+            return;
+        }
+        triggerFlush(false);
+    }
+
+    private CompletableFuture<Void> flushAll() {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        executorManager.runIo(() -> triggerFlush(true))
+                .whenComplete((ignored, throwable) -> {
+                    if (throwable != null) {
+                        future.completeExceptionally(throwable);
+                    } else if (pending.isEmpty()) {
+                        future.complete(null);
+                    } else {
+                        triggerFlush(true);
+                        future.complete(null);
+                    }
+                });
+        return future;
+    }
+
+    private void triggerFlush(boolean blocking) {
+        if (!flushing.compareAndSet(false, true)) {
+            return;
+        }
+        List<AuditLogRecord> batch = drainBatch();
+        if (batch.isEmpty()) {
+            flushing.set(false);
+            return;
+        }
+        CompletableFuture<Void> future = repository.saveAll(batch);
+        if (blocking) {
+            future = future.whenComplete((ignored, throwable) -> {
+                if (throwable != null) {
+                    handleFlushFailure(batch, throwable);
+                } else {
+                    lastError.set(null);
+                }
+            });
+            try {
+                future.join();
+            } catch (Exception exception) {
+                flushing.set(false);
+                throw exception;
+            }
+            flushing.set(false);
+            if (!pending.isEmpty()) {
+                triggerFlush(blocking);
+            }
+            return;
+        }
+        future.whenComplete((ignored, throwable) -> {
+            try {
+                if (throwable != null) {
+                    handleFlushFailure(batch, throwable);
+                } else {
+                    lastError.set(null);
+                }
+            } finally {
+                flushing.set(false);
+            }
+            if (!pending.isEmpty()) {
+                flushSilently();
+            }
+        });
+    }
+
+    private List<AuditLogRecord> drainBatch() {
+        ArrayList<AuditLogRecord> batch = new ArrayList<>();
+        while (batch.size() < MAX_BATCH_SIZE) {
+            AuditLogRecord record = pending.poll();
+            if (record == null) {
+                break;
+            }
+            pendingSize.decrementAndGet();
+            batch.add(record);
+        }
+        return batch;
+    }
+
+    private void handleFlushFailure(List<AuditLogRecord> batch, Throwable throwable) {
+        lastError.set(throwable);
+        logger.error("Erreur lors de la persistance du journal d'audit", throwable);
+        for (AuditLogRecord record : batch) {
+            pending.add(record);
+            pendingSize.incrementAndGet();
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/command/NexusCommand.java
+++ b/src/main/java/com/heneria/nexus/command/NexusCommand.java
@@ -17,8 +17,9 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
 
     private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump", "budget", "holo", "admin");
     private static final List<String> HOLO_SUB = List.of("create", "remove", "move", "list", "reload");
-    private static final List<String> ADMIN_SUB = List.of("player");
+    private static final List<String> ADMIN_SUB = List.of("player", "audit");
     private static final List<String> ADMIN_PLAYER_ACTIONS = List.of("export", "import");
+    private static final List<String> ADMIN_AUDIT_ACTIONS = List.of("log");
 
     private final NexusPlugin plugin;
 
@@ -99,11 +100,32 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                 String prefix = args[2].toLowerCase(Locale.ROOT);
                 return plugin.suggestAdminPlayerTargets(prefix);
             }
+            if (args.length == 3 && args[1].equalsIgnoreCase("audit")) {
+                String prefix = args[2].toLowerCase(Locale.ROOT);
+                return ADMIN_AUDIT_ACTIONS.stream()
+                        .filter(action -> action.startsWith(prefix))
+                        .toList();
+            }
             if (args.length == 4 && args[1].equalsIgnoreCase("player")) {
                 String prefix = args[3].toLowerCase(Locale.ROOT);
                 return ADMIN_PLAYER_ACTIONS.stream()
                         .filter(action -> action.startsWith(prefix))
                         .toList();
+            }
+            if (args.length == 4 && args[1].equalsIgnoreCase("audit") && args[2].equalsIgnoreCase("log")) {
+                String prefix = args[3].toLowerCase(Locale.ROOT);
+                List<String> suggestions = plugin.suggestAdminPlayerTargets(prefix);
+                if ("*".startsWith(prefix)) {
+                    suggestions = new java.util.ArrayList<>(suggestions);
+                    if (!suggestions.contains("*")) {
+                        suggestions.add(0, "*");
+                    }
+                }
+                return suggestions;
+            }
+            if (args.length == 5 && args[1].equalsIgnoreCase("audit") && args[2].equalsIgnoreCase("log")) {
+                String prefix = args[4].toLowerCase(Locale.ROOT);
+                return "1".startsWith(prefix) ? List.of("1") : List.of();
             }
             if (args.length == 5 && args[1].equalsIgnoreCase("player")) {
                 if (args[3].equalsIgnoreCase("export")) {
@@ -166,6 +188,7 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                 || sender.hasPermission("nexus.admin.player.import")
                 || sender.hasPermission("nexus.admin.reload")
                 || sender.hasPermission("nexus.admin.dump")
-                || sender.hasPermission("nexus.admin.budget");
+                || sender.hasPermission("nexus.admin.budget")
+                || sender.hasPermission("nexus.admin.audit.view");
     }
 }

--- a/src/main/java/com/heneria/nexus/db/repository/AuditLogRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/AuditLogRepository.java
@@ -1,0 +1,21 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.audit.AuditLogRecord;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository responsible for persisting audit log entries.
+ */
+public interface AuditLogRepository {
+
+    CompletableFuture<Void> saveAll(Collection<AuditLogRecord> entries);
+
+    CompletableFuture<List<AuditLogRecord>> findRecent(Optional<UUID> subjectUuid,
+                                                        Optional<String> subjectName,
+                                                        int limit,
+                                                        int offset);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/AuditLogRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/AuditLogRepositoryImpl.java
@@ -1,0 +1,157 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.audit.AuditActionType;
+import com.heneria.nexus.audit.AuditLogRecord;
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * MariaDB backed implementation of {@link AuditLogRepository}.
+ */
+public final class AuditLogRepositoryImpl implements AuditLogRepository {
+
+    private static final String INSERT_SQL =
+            "INSERT INTO nexus_audit_logs (timestamp, actor_uuid, actor_name, action_type, target_uuid, target_name, details) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String BASE_SELECT_SQL =
+            "SELECT log_id, timestamp, actor_uuid, actor_name, action_type, target_uuid, target_name, details " +
+                    "FROM nexus_audit_logs";
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public AuditLogRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletableFuture<Void> saveAll(Collection<AuditLogRecord> entries) {
+        Objects.requireNonNull(entries, "entries");
+        if (entries.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_SQL)) {
+                for (AuditLogRecord entry : entries) {
+                    statement.setTimestamp(1, Timestamp.from(entry.timestamp()));
+                    setUuid(statement, 2, entry.actorUuid());
+                    setString(statement, 3, entry.actorName());
+                    statement.setString(4, entry.actionType().databaseValue());
+                    setUuid(statement, 5, entry.targetUuid());
+                    setString(statement, 6, entry.targetName());
+                    setString(statement, 7, entry.details());
+                    statement.addBatch();
+                }
+                statement.executeBatch();
+            }
+            return null;
+        }, ioExecutor);
+    }
+
+    @Override
+    public CompletableFuture<List<AuditLogRecord>> findRecent(Optional<UUID> subjectUuid,
+                                                               Optional<String> subjectName,
+                                                               int limit,
+                                                               int offset) {
+        Objects.requireNonNull(subjectUuid, "subjectUuid");
+        Objects.requireNonNull(subjectName, "subjectName");
+        if (limit <= 0) {
+            throw new IllegalArgumentException("limit must be positive");
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be >= 0");
+        }
+        return dbProvider.execute(connection -> {
+            StringBuilder sql = new StringBuilder(BASE_SELECT_SQL);
+            List<Object> parameters = new ArrayList<>();
+            boolean whereAdded = false;
+            if (subjectUuid.isPresent()) {
+                sql.append(whereAdded ? " AND" : " WHERE");
+                sql.append(" (actor_uuid = ? OR target_uuid = ?)");
+                String uuid = subjectUuid.get().toString();
+                parameters.add(uuid);
+                parameters.add(uuid);
+                whereAdded = true;
+            }
+            if (subjectName.isPresent()) {
+                sql.append(whereAdded ? " AND" : " WHERE");
+                sql.append(" (actor_name = ? OR target_name = ?)");
+                String name = subjectName.get();
+                parameters.add(name);
+                parameters.add(name);
+                whereAdded = true;
+            }
+            sql.append(" ORDER BY log_id DESC LIMIT ? OFFSET ?");
+            parameters.add(limit);
+            parameters.add(offset);
+            try (PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+                for (int i = 0; i < parameters.size(); i++) {
+                    Object parameter = parameters.get(i);
+                    if (parameter instanceof String string) {
+                        statement.setString(i + 1, string);
+                    } else if (parameter instanceof Integer integer) {
+                        statement.setInt(i + 1, integer);
+                    } else {
+                        statement.setObject(i + 1, parameter);
+                    }
+                }
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    List<AuditLogRecord> records = new ArrayList<>();
+                    while (resultSet.next()) {
+                        records.add(mapRow(resultSet));
+                    }
+                    return records;
+                }
+            }
+        }, ioExecutor);
+    }
+
+    private AuditLogRecord mapRow(ResultSet resultSet) throws SQLException {
+        long id = resultSet.getLong("log_id");
+        Timestamp timestamp = resultSet.getTimestamp("timestamp");
+        Instant instant = timestamp != null ? timestamp.toInstant() : Instant.EPOCH;
+        String actorUuid = resultSet.getString("actor_uuid");
+        String targetUuid = resultSet.getString("target_uuid");
+        return new AuditLogRecord(
+                id,
+                instant,
+                actorUuid != null ? UUID.fromString(actorUuid) : null,
+                resultSet.getString("actor_name"),
+                AuditActionType.fromDatabaseValue(resultSet.getString("action_type")),
+                targetUuid != null ? UUID.fromString(targetUuid) : null,
+                resultSet.getString("target_name"),
+                resultSet.getString("details"));
+    }
+
+    private void setUuid(PreparedStatement statement, int index, UUID uuid) throws SQLException {
+        if (uuid == null) {
+            statement.setNull(index, Types.CHAR);
+            return;
+        }
+        statement.setString(index, uuid.toString());
+    }
+
+    private void setString(PreparedStatement statement, int index, String value) throws SQLException {
+        if (value == null) {
+            statement.setNull(index, Types.VARCHAR);
+            return;
+        }
+        statement.setString(index, value);
+    }
+}

--- a/src/main/resources/db/migration/V5__Add_Audit_Log_Table.sql
+++ b/src/main/resources/db/migration/V5__Add_Audit_Log_Table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS nexus_audit_logs (
+    log_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    actor_uuid CHAR(36) NULL,
+    actor_name VARCHAR(16) NULL,
+    action_type VARCHAR(64) NOT NULL,
+    target_uuid CHAR(36) NULL,
+    target_name VARCHAR(16) NULL,
+    details TEXT NULL,
+    INDEX idx_audit_actor_uuid (actor_uuid),
+    INDEX idx_audit_action_type (action_type),
+    INDEX idx_audit_timestamp (timestamp)
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/src/main/resources/lang/messages_fr.yml
+++ b/src/main/resources/lang/messages_fr.yml
@@ -14,6 +14,7 @@ help:
     dump: "<gray>/nexus dump</gray> <dark_gray>-</dark_gray> <yellow>Affiche l'état courant (threads, DB, scheduler).</yellow>"
     budget: "<gray>/nexus budget [arène]</gray> <dark_gray>-</dark_gray> <yellow>Inspecte les budgets en cours.</yellow>"
     player: "<gray>/nexus admin player <joueur> <export|import></gray> <dark_gray>-</dark_gray> <yellow>Export/import des données joueurs.</yellow>"
+    audit: "<gray>/nexus admin audit log <joueur|*></gray> <dark_gray>-</dark_gray> <yellow>Consulte les actions sensibles enregistrées.</yellow>"
     holo: "<gray>/nexus holo <create|remove|move|list|reload></gray> <dark_gray>-</dark_gray> <yellow>Gère les hologrammes.</yellow>"
 
 errors:
@@ -49,6 +50,15 @@ admin:
       none: "<red>Aucun import en attente. Préparez d'abord un fichier.</red>"
       mismatch: "<red>Ce fichier ne correspond pas à la demande d'import en attente.</red>"
       expired: "<red>La demande d'import a expiré. Recommencez la validation.</red>"
+  audit:
+    usage: "<gray>Usage :</gray> <yellow>/nexus admin audit log <joueur|*> [page]</yellow>"
+    unavailable: "<red>Le journal d'audit est indisponible actuellement.</red>"
+    invalid_page: "<red>Page invalide : <page>.</red>"
+    header: "<gold>Logs d'audit (<scope>) — page <page></gold>"
+    empty: "<gray>Aucune entrée ne correspond à ce filtre.</gray>"
+    entry: "<gray>[<id>]</gray> <white><timestamp></white> <aqua><type></aqua> <yellow><actor></yellow> <dark_gray>→</dark_gray> <green><target></green> <gray>-</gray> <white><details></white>"
+    more: "<gray>Page suivante :</gray> <yellow><command></yellow>"
+    error: "<red>Impossible de récupérer les logs : <reason>.</red>"
 
 titles:
   round_start:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -31,6 +31,9 @@ permissions:
   nexus.admin.player.import:
     description: Importer les données d'un joueur.
     default: op
+  nexus.admin.audit.view:
+    description: Consulter les logs d'audit Nexus.
+    default: op
   nexus.admin.*:
     description: Accès complet aux commandes d'administration Nexus.
     default: op
@@ -40,6 +43,7 @@ permissions:
       nexus.admin.budget: true
       nexus.admin.player.export: true
       nexus.admin.player.import: true
+      nexus.admin.audit.view: true
   nexus.holo.manage:
     description: Gérer les hologrammes Nexus via /nexus holo.
     default: op


### PR DESCRIPTION
## Summary
- add a dedicated nexus_audit_logs table with repository and write-behind audit service
- log sensitive admin commands, shop purchases, and arena reset events through the new audit pipeline
- expose an /nexus admin audit log command with permissions, localisation, and audit help text

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads blocked by 403 from papermc repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f9b7015c83249175ea8e02987892