### PR TITLE
Add database-backed rate limiting service

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -41,6 +41,8 @@ import com.heneria.nexus.db.repository.PlayerCosmeticRepository;
 import com.heneria.nexus.db.repository.PlayerCosmeticRepositoryImpl;
 import com.heneria.nexus.db.repository.ProfileRepository;
 import com.heneria.nexus.db.repository.ProfileRepositoryImpl;
+import com.heneria.nexus.db.repository.RateLimitRepository;
+import com.heneria.nexus.db.repository.RateLimitRepositoryImpl;
 import com.heneria.nexus.db.repository.RewardClaimRepository;
 import com.heneria.nexus.db.repository.RewardClaimRepositoryImpl;
 import com.heneria.nexus.hologram.HoloService;
@@ -71,6 +73,8 @@ import com.heneria.nexus.service.core.RewardServiceImpl;
 import com.heneria.nexus.service.core.ShopServiceImpl;
 import com.heneria.nexus.service.core.TimerServiceImpl;
 import com.heneria.nexus.service.core.VaultEconomyService;
+import com.heneria.nexus.service.ratelimit.RateLimiterService;
+import com.heneria.nexus.service.ratelimit.RateLimiterServiceImpl;
 import com.heneria.nexus.service.maintenance.DataPurgeService;
 import com.heneria.nexus.service.permissions.NexusContextManager;
 import com.heneria.nexus.util.DumpUtil;
@@ -444,6 +448,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.updateSingleton(CoreConfig.class, newBundle.core());
         serviceRegistry.updateSingleton(EconomyConfig.class, newBundle.economy());
         configureDatabase(newBundle.core().databaseSettings());
+        serviceRegistry.get(RateLimiterService.class).applyConfiguration(newBundle.core());
         serviceRegistry.get(DataPurgeService.class).applyConfiguration(newBundle.core());
         serviceRegistry.get(QueueService.class).applySettings(newBundle.core().queueSettings());
         serviceRegistry.get(ArenaService.class).applyArenaSettings(newBundle.core().arenaSettings());
@@ -451,6 +456,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.get(BudgetService.class).applySettings(newBundle.core().arenaSettings());
         serviceRegistry.get(ProfileService.class).applyDegradedModeSettings(newBundle.core().degradedModeSettings());
         serviceRegistry.get(EconomyService.class).applyDegradedModeSettings(newBundle.core().degradedModeSettings());
+        serviceRegistry.get(ShopService.class).applyRateLimitSettings(newBundle.core().rateLimitSettings());
         serviceRegistry.get(ShopService.class).applyCatalog(newBundle.economy().shop());
         serviceRegistry.get(HoloService.class).applySettings(newBundle.core().hologramSettings());
         serviceRegistry.get(HoloService.class).loadFromConfig();
@@ -1119,6 +1125,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerSingleton(CoreConfig.class, bundle.core());
         serviceRegistry.registerSingleton(EconomyConfig.class, bundle.economy());
         serviceRegistry.registerSingleton(ExecutorManager.class, executorManager);
+        serviceRegistry.registerSingleton(MessageFacade.class, messageFacade);
         serviceRegistry.registerSingleton(DbProvider.class, dbProvider);
         serviceRegistry.registerSingleton(DatabaseMigrator.class, databaseMigrator);
         serviceRegistry.registerSingleton(Boolean.class, placeholderApiAvailable);
@@ -1177,6 +1184,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(PlayerCosmeticRepository.class, PlayerCosmeticRepositoryImpl.class);
         serviceRegistry.registerService(EconomyRepository.class, EconomyRepositoryImpl.class);
         serviceRegistry.registerService(MatchRepository.class, MatchRepositoryImpl.class);
+        serviceRegistry.registerService(RateLimitRepository.class, RateLimitRepositoryImpl.class);
         serviceRegistry.registerService(DataPurgeService.class, DataPurgeService.class);
         serviceRegistry.registerService(RewardClaimRepository.class, RewardClaimRepositoryImpl.class);
         serviceRegistry.registerService(AuditLogRepository.class, AuditLogRepositoryImpl.class);
@@ -1185,6 +1193,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
         serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);
         serviceRegistry.registerService(TimerService.class, TimerServiceImpl.class);
+        serviceRegistry.registerService(RateLimiterService.class, RateLimiterServiceImpl.class);
         serviceRegistry.registerService(ShopService.class, ShopServiceImpl.class);
         serviceRegistry.registerService(BudgetService.class, BudgetServiceImpl.class);
         serviceRegistry.registerService(WatchdogService.class, WatchdogServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/api/PurchaseResult.java
+++ b/src/main/java/com/heneria/nexus/api/PurchaseResult.java
@@ -7,5 +7,6 @@ public enum PurchaseResult {
     SUCCESS,
     INSUFFICIENT_FUNDS,
     ALREADY_OWNED,
+    RATE_LIMITED,
     ERROR
 }

--- a/src/main/java/com/heneria/nexus/api/ShopService.java
+++ b/src/main/java/com/heneria/nexus/api/ShopService.java
@@ -34,4 +34,11 @@ public interface ShopService extends LifecycleAware {
      * @param shopSettings shop settings loaded from configuration
      */
     void applyCatalog(EconomyConfig.ShopSettings shopSettings);
+
+    /**
+     * Applies updated rate limit settings after a configuration reload.
+     *
+     * @param rateLimitSettings rate limiter configuration from the core config
+     */
+    void applyRateLimitSettings(com.heneria.nexus.config.CoreConfig.RateLimitSettings rateLimitSettings);
 }

--- a/src/main/java/com/heneria/nexus/config/ConfigMigrator.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigMigrator.java
@@ -36,6 +36,7 @@ public final class ConfigMigrator {
         Map<String, List<MigrationStep>> map = new HashMap<>();
         List<MigrationStep> configMigrations = new ArrayList<>();
         configMigrations.add(new MigrationStep(2, ConfigMigrator::migrateConfigToV2));
+        configMigrations.add(new MigrationStep(3, ConfigMigrator::migrateConfigToV3));
         map.put("config.yml", Collections.unmodifiableList(configMigrations));
         map.put("economy.yml", List.of());
         map.put("maps.yml", List.of());
@@ -226,6 +227,19 @@ public final class ConfigMigrator {
             configuration.set("threads.scheduler.main_check_interval_ticks", scheduler);
         }
         configuration.set("executors", null);
+    }
+
+    private static void migrateConfigToV3(YamlConfiguration configuration) {
+        if (configuration.contains("rate-limits")) {
+            return;
+        }
+        configuration.set("rate-limits.enabled", true);
+        configuration.set("rate-limits.cleanup.interval_minutes", 60);
+        configuration.set("rate-limits.cleanup.retention_minutes", 1440);
+        configuration.set("rate-limits.actions.purchase:class", 3);
+        configuration.set("rate-limits.actions.purchase:cosmetic", 3);
+        configuration.set("rate-limits.actions.shop:refresh", 60);
+        configuration.set("rate-limits.actions.quest:reroll_daily", 300);
     }
 
     private record MigrationStep(long targetVersion, Consumer<YamlConfiguration> action) {

--- a/src/main/java/com/heneria/nexus/db/repository/RateLimitRepository.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RateLimitRepository.java
@@ -1,0 +1,31 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.ratelimit.RateLimitResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Repository responsible for persisting rate limiter state in MariaDB.
+ */
+public interface RateLimitRepository {
+
+    /**
+     * Checks whether the rate limited action can be performed and records the new timestamp when allowed.
+     *
+     * @param playerUuid player identifier
+     * @param actionKey unique action key
+     * @param cooldown cooldown duration
+     * @return asynchronous result describing whether the action is allowed and remaining time otherwise
+     */
+    CompletableFuture<RateLimitResult> checkAndRecord(UUID playerUuid, String actionKey, Duration cooldown);
+
+    /**
+     * Deletes entries older than the provided cutoff.
+     *
+     * @param cutoff cutoff instant
+     * @return future resolving to the number of deleted rows
+     */
+    CompletableFuture<Integer> purgeOlderThan(Instant cutoff);
+}

--- a/src/main/java/com/heneria/nexus/db/repository/RateLimitRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RateLimitRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.heneria.nexus.db.repository;
+
+import com.heneria.nexus.concurrent.ExecutorManager;
+import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.ratelimit.RateLimitResult;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * MariaDB implementation of {@link RateLimitRepository} using optimistic locking.
+ */
+public final class RateLimitRepositoryImpl implements RateLimitRepository {
+
+    private static final String SELECT_FOR_UPDATE_SQL =
+            "SELECT last_executed_at FROM nexus_rate_limits WHERE player_uuid = ? AND action_key = ? FOR UPDATE";
+    private static final String UPSERT_SQL =
+            "INSERT INTO nexus_rate_limits (player_uuid, action_key, last_executed_at) VALUES (?, ?, ?) "
+                    + "ON DUPLICATE KEY UPDATE last_executed_at = VALUES(last_executed_at)";
+    private static final String DELETE_OLDER_THAN_SQL =
+            "DELETE FROM nexus_rate_limits WHERE last_executed_at < ?";
+
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+
+    public RateLimitRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    }
+
+    @Override
+    public CompletableFuture<RateLimitResult> checkAndRecord(UUID playerUuid, String actionKey, Duration cooldown) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        Objects.requireNonNull(actionKey, "actionKey");
+        Objects.requireNonNull(cooldown, "cooldown");
+        return dbProvider.execute(connection -> executeCheck(connection, playerUuid, actionKey, cooldown), ioExecutor);
+    }
+
+    private RateLimitResult executeCheck(Connection connection,
+                                         UUID playerUuid,
+                                         String actionKey,
+                                         Duration cooldown) throws SQLException {
+        boolean previousAutoCommit = true;
+        try {
+            previousAutoCommit = connection.getAutoCommit();
+        } catch (SQLException ignored) {
+            // Use default value if unsupported
+        }
+        connection.setAutoCommit(false);
+        try {
+            Instant now = Instant.now();
+            try (PreparedStatement select = connection.prepareStatement(SELECT_FOR_UPDATE_SQL)) {
+                select.setString(1, playerUuid.toString());
+                select.setString(2, actionKey);
+                try (ResultSet resultSet = select.executeQuery()) {
+                    if (resultSet.next()) {
+                        Instant lastExecution = resultSet.getTimestamp(1).toInstant();
+                        Instant nextAllowed = lastExecution.plus(cooldown);
+                        if (nextAllowed.isAfter(now)) {
+                            connection.rollback();
+                            Duration remaining = Duration.between(now, nextAllowed);
+                            if (remaining.isNegative()) {
+                                remaining = Duration.ZERO;
+                            }
+                            return RateLimitResult.blocked(remaining);
+                        }
+                    }
+                }
+            }
+            try (PreparedStatement upsert = connection.prepareStatement(UPSERT_SQL)) {
+                upsert.setString(1, playerUuid.toString());
+                upsert.setString(2, actionKey);
+                upsert.setTimestamp(3, Timestamp.from(now));
+                upsert.executeUpdate();
+            }
+            connection.commit();
+            return RateLimitResult.allowed();
+        } catch (SQLException exception) {
+            connection.rollback();
+            throw exception;
+        } finally {
+            try {
+                connection.setAutoCommit(previousAutoCommit);
+            } catch (SQLException ignored) {
+                // Ignore
+            }
+        }
+    }
+
+    @Override
+    public CompletableFuture<Integer> purgeOlderThan(Instant cutoff) {
+        Objects.requireNonNull(cutoff, "cutoff");
+        return dbProvider.execute(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(DELETE_OLDER_THAN_SQL)) {
+                statement.setTimestamp(1, Timestamp.from(cutoff));
+                return statement.executeUpdate();
+            }
+        }, ioExecutor);
+    }
+}

--- a/src/main/java/com/heneria/nexus/ratelimit/RateLimitResult.java
+++ b/src/main/java/com/heneria/nexus/ratelimit/RateLimitResult.java
@@ -1,0 +1,35 @@
+package com.heneria.nexus.ratelimit;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Result of a rate limit check.
+ */
+public record RateLimitResult(boolean allowed, Optional<Duration> timeRemaining) {
+
+    public RateLimitResult {
+        Objects.requireNonNull(timeRemaining, "timeRemaining");
+        if (allowed && timeRemaining.isPresent()) {
+            throw new IllegalArgumentException("Allowed result cannot have remaining time");
+        }
+        timeRemaining.ifPresent(duration -> {
+            if (duration.isNegative()) {
+                throw new IllegalArgumentException("timeRemaining must be >= 0");
+            }
+        });
+    }
+
+    public static RateLimitResult allowed() {
+        return new RateLimitResult(true, Optional.empty());
+    }
+
+    public static RateLimitResult blocked(Duration timeRemaining) {
+        Objects.requireNonNull(timeRemaining, "timeRemaining");
+        if (timeRemaining.isNegative()) {
+            throw new IllegalArgumentException("timeRemaining must be >= 0");
+        }
+        return new RateLimitResult(false, Optional.of(timeRemaining));
+    }
+}

--- a/src/main/java/com/heneria/nexus/ratelimit/RateLimitedActionKeys.java
+++ b/src/main/java/com/heneria/nexus/ratelimit/RateLimitedActionKeys.java
@@ -1,0 +1,15 @@
+package com.heneria.nexus.ratelimit;
+
+/**
+ * Canonical keys for rate limited actions stored in the database.
+ */
+public final class RateLimitedActionKeys {
+
+    public static final String SHOP_PURCHASE_CLASS = "purchase:class";
+    public static final String SHOP_PURCHASE_COSMETIC = "purchase:cosmetic";
+    public static final String SHOP_REFRESH = "shop:refresh";
+    public static final String QUEST_REROLL_DAILY = "quest:reroll_daily";
+
+    private RateLimitedActionKeys() {
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/ratelimit/RateLimiterService.java
+++ b/src/main/java/com/heneria/nexus/service/ratelimit/RateLimiterService.java
@@ -1,0 +1,18 @@
+package com.heneria.nexus.service.ratelimit;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.ratelimit.RateLimitResult;
+import com.heneria.nexus.service.LifecycleAware;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Exposes rate limiter checks backed by MariaDB.
+ */
+public interface RateLimiterService extends LifecycleAware {
+
+    CompletableFuture<RateLimitResult> check(UUID playerUuid, String actionKey, Duration cooldown);
+
+    void applyConfiguration(CoreConfig coreConfig);
+}

--- a/src/main/java/com/heneria/nexus/service/ratelimit/RateLimiterServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/ratelimit/RateLimiterServiceImpl.java
@@ -1,0 +1,163 @@
+package com.heneria.nexus.service.ratelimit;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.db.repository.RateLimitRepository;
+import com.heneria.nexus.ratelimit.RateLimitResult;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Default implementation orchestrating rate limit checks and background cleanup.
+ */
+public final class RateLimiterServiceImpl implements RateLimiterService {
+
+    private static final Duration MIN_RETENTION = Duration.ofMinutes(10);
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final RateLimitRepository repository;
+    private final AtomicReference<ServiceConfiguration> configurationRef;
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final Object taskLock = new Object();
+
+    private BukkitTask cleanupTask;
+
+    public RateLimiterServiceImpl(JavaPlugin plugin,
+                                  NexusLogger logger,
+                                  RateLimitRepository repository,
+                                  CoreConfig coreConfig) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.repository = Objects.requireNonNull(repository, "repository");
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        this.configurationRef = new AtomicReference<>(toConfiguration(coreConfig));
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        running.set(true);
+        scheduleCleanup();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        running.set(false);
+        cancelCleanup();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<RateLimitResult> check(UUID playerUuid, String actionKey, Duration cooldown) {
+        Objects.requireNonNull(playerUuid, "playerUuid");
+        Objects.requireNonNull(actionKey, "actionKey");
+        Objects.requireNonNull(cooldown, "cooldown");
+        ServiceConfiguration configuration = configurationRef.get();
+        if (!configuration.enabled() || !configuration.databaseEnabled() || cooldown.isZero() || cooldown.isNegative()) {
+            return CompletableFuture.completedFuture(RateLimitResult.allowed());
+        }
+        return repository.checkAndRecord(playerUuid, actionKey, cooldown)
+                .exceptionally(throwable -> {
+                    Throwable cause = unwrap(throwable);
+                    logger.warn("Vérification de rate limit en échec pour " + actionKey, cause);
+                    return RateLimitResult.allowed();
+                });
+    }
+
+    @Override
+    public void applyConfiguration(CoreConfig coreConfig) {
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        ServiceConfiguration configuration = toConfiguration(coreConfig);
+        ServiceConfiguration previous = configurationRef.getAndSet(configuration);
+        if (!running.get()) {
+            return;
+        }
+        if (!configuration.equals(previous)) {
+            scheduleCleanup();
+        }
+    }
+
+    private void scheduleCleanup() {
+        if (!running.get()) {
+            return;
+        }
+        ServiceConfiguration configuration = configurationRef.get();
+        cancelCleanup();
+        if (!configuration.enabled() || !configuration.databaseEnabled()) {
+            return;
+        }
+        long periodTicks = Math.max(1L, (configuration.cleanupInterval().toMillis() + 49L) / 50L);
+        synchronized (taskLock) {
+            cleanupTask = plugin.getServer().getScheduler()
+                    .runTaskTimerAsynchronously(plugin, this::runCleanup, periodTicks, periodTicks);
+        }
+        logger.info(() -> "Nettoyage des limiteurs de taux planifié toutes "
+                + configuration.cleanupInterval().toMinutes() + " minute(s)");
+    }
+
+    private void cancelCleanup() {
+        synchronized (taskLock) {
+            if (cleanupTask != null) {
+                cleanupTask.cancel();
+                cleanupTask = null;
+            }
+        }
+    }
+
+    private void runCleanup() {
+        if (!running.get()) {
+            return;
+        }
+        ServiceConfiguration configuration = configurationRef.get();
+        if (!configuration.enabled() || !configuration.databaseEnabled()) {
+            return;
+        }
+        Instant cutoff = Instant.now().minus(configuration.retentionDuration());
+        repository.purgeOlderThan(cutoff).whenComplete((deleted, throwable) -> {
+            if (throwable != null) {
+                logger.warn("Nettoyage des limiteurs de taux en échec", unwrap(throwable));
+                return;
+            }
+            if (deleted != null && deleted > 0) {
+                logger.debug(() -> "Nettoyage des limiteurs de taux — " + deleted + " entrées supprimées");
+            }
+        });
+    }
+
+    private ServiceConfiguration toConfiguration(CoreConfig coreConfig) {
+        CoreConfig.RateLimitSettings rateLimits = coreConfig.rateLimitSettings();
+        boolean databaseEnabled = coreConfig.databaseSettings().enabled();
+        Duration cleanupInterval = rateLimits.cleanupInterval();
+        Duration retention = rateLimits.retentionDuration();
+        Duration maxCooldown = rateLimits.maxConfiguredCooldown();
+        if (retention.compareTo(maxCooldown) < 0) {
+            retention = maxCooldown;
+        }
+        if (retention.compareTo(MIN_RETENTION) < 0) {
+            retention = MIN_RETENTION;
+        }
+        return new ServiceConfiguration(rateLimits.enabled(), databaseEnabled, cleanupInterval, retention);
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        while (throwable instanceof CompletionException && throwable.getCause() != null) {
+            throwable = throwable.getCause();
+        }
+        return throwable;
+    }
+
+    private record ServiceConfiguration(boolean enabled,
+                                        boolean databaseEnabled,
+                                        Duration cleanupInterval,
+                                        Duration retentionDuration) {
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #  PaperMC 1.21.x — Java 21
 # =============================================
 
-config-version: 2
+config-version: 3
 
 server:
   mode: "nexus"
@@ -48,6 +48,17 @@ database:
   retention_policy:
     # Durée de conservation des historiques de matchs en jours. Mettre à 0 pour désactiver la purge.
     match_history_days: 90
+
+rate-limits:
+  enabled: true
+  cleanup:
+    interval_minutes: 60
+    retention_minutes: 1440
+  actions:
+    'purchase:class': 3
+    'purchase:cosmetic': 3
+    'shop:refresh': 60
+    'quest:reroll_daily': 300
 
 services:
   expose-bukkit-services: false

--- a/src/main/resources/db/migration/V7__Add_Rate_Limits_Table.sql
+++ b/src/main/resources/db/migration/V7__Add_Rate_Limits_Table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS nexus_rate_limits (
+    player_uuid CHAR(36) NOT NULL,
+    action_key VARCHAR(128) NOT NULL,
+    last_executed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (player_uuid, action_key)
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/src/main/resources/lang/messages_fr.yml
+++ b/src/main/resources/lang/messages_fr.yml
@@ -20,6 +20,9 @@ help:
 errors:
   no_permission: "<red>Vous n'avez pas la permission requise.</red>"
 
+shop:
+  rate_limited: "<red>Veuillez patienter encore <seconds> seconde(s) avant de réessayer.</red>"
+
 admin:
   reload:
     start: "<yellow>Rechargement en cours...</yellow>"


### PR DESCRIPTION
## Summary
- add a `nexus_rate_limits` table with repository and asynchronous service that records executions and purges stale entries
- expose configurable rate limit durations in the core configuration (with migration defaults) and wire the rate limiter through the plugin bootstrap
- enforce shop purchase cooldowns via the rate limiter and notify players when they must wait

## Testing
- mvn -q -DskipTests package *(fails: repository https://repo.papermc.io/repository/maven-public/ returned 403 for Paper/PlaceholderAPI/Vault artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68d807f28ca483249a7fdf373e1b6163