### PR TITLE
feat: add rotating configuration backups and admin restore commands

### DIFF
--- a/src/main/java/com/heneria/nexus/command/NexusCommand.java
+++ b/src/main/java/com/heneria/nexus/command/NexusCommand.java
@@ -17,9 +17,11 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
 
     private static final List<String> SUB_COMMANDS = List.of("help", "reload", "dump", "budget", "holo", "admin");
     private static final List<String> HOLO_SUB = List.of("create", "remove", "move", "list", "reload");
-    private static final List<String> ADMIN_SUB = List.of("player", "audit");
+    private static final List<String> ADMIN_SUB = List.of("player", "audit", "config");
     private static final List<String> ADMIN_PLAYER_ACTIONS = List.of("export", "import");
     private static final List<String> ADMIN_AUDIT_ACTIONS = List.of("log");
+    private static final List<String> ADMIN_CONFIG_ACTIONS = List.of("backups", "restore");
+    private static final List<String> ADMIN_CONFIG_BACKUPS = List.of("list");
 
     private final NexusPlugin plugin;
 
@@ -106,6 +108,15 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                         .filter(action -> action.startsWith(prefix))
                         .toList();
             }
+            if (args.length == 3 && args[1].equalsIgnoreCase("config")) {
+                if (!sender.hasPermission("nexus.admin.config.manage_backups")) {
+                    return Collections.emptyList();
+                }
+                String prefix = args[2].toLowerCase(Locale.ROOT);
+                return ADMIN_CONFIG_ACTIONS.stream()
+                        .filter(action -> action.startsWith(prefix))
+                        .toList();
+            }
             if (args.length == 4 && args[1].equalsIgnoreCase("player")) {
                 String prefix = args[3].toLowerCase(Locale.ROOT);
                 return ADMIN_PLAYER_ACTIONS.stream()
@@ -122,6 +133,22 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                     }
                 }
                 return suggestions;
+            }
+            if (args.length == 4 && args[1].equalsIgnoreCase("config") && args[2].equalsIgnoreCase("backups")) {
+                if (!sender.hasPermission("nexus.admin.config.manage_backups")) {
+                    return Collections.emptyList();
+                }
+                String prefix = args[3].toLowerCase(Locale.ROOT);
+                return ADMIN_CONFIG_BACKUPS.stream()
+                        .filter(action -> action.startsWith(prefix))
+                        .toList();
+            }
+            if (args.length == 4 && args[1].equalsIgnoreCase("config") && args[2].equalsIgnoreCase("restore")) {
+                if (!sender.hasPermission("nexus.admin.config.manage_backups")) {
+                    return Collections.emptyList();
+                }
+                String prefix = args[3].toLowerCase(Locale.ROOT);
+                return "confirm".startsWith(prefix) ? List.of("confirm") : List.of();
             }
             if (args.length == 5 && args[1].equalsIgnoreCase("audit") && args[2].equalsIgnoreCase("log")) {
                 String prefix = args[4].toLowerCase(Locale.ROOT);
@@ -189,6 +216,7 @@ public final class NexusCommand implements CommandExecutor, TabCompleter {
                 || sender.hasPermission("nexus.admin.reload")
                 || sender.hasPermission("nexus.admin.dump")
                 || sender.hasPermission("nexus.admin.budget")
-                || sender.hasPermission("nexus.admin.audit.view");
+                || sender.hasPermission("nexus.admin.audit.view")
+                || sender.hasPermission("nexus.admin.config.manage_backups");
     }
 }

--- a/src/main/java/com/heneria/nexus/config/BackupService.java
+++ b/src/main/java/com/heneria/nexus/config/BackupService.java
@@ -1,0 +1,84 @@
+package com.heneria.nexus.config;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Service responsible for managing configuration file backups.
+ */
+public interface BackupService extends AutoCloseable {
+
+    /**
+     * Creates a new backup for the given file if backups are enabled.
+     *
+     * @param originalFile absolute path to the file to back up
+     * @return future holding metadata for the created backup or empty if backups are disabled
+     */
+    CompletableFuture<Optional<BackupMetadata>> createBackup(Path originalFile);
+
+    /**
+     * Lists the available backups. When {@code baseFile} is provided only backups for
+     * that file are returned.
+     *
+     * @param baseFile optional relative path within the data folder (using forward slashes)
+     * @return future with ordered metadata, newest first
+     */
+    CompletableFuture<List<BackupMetadata>> listBackups(@Nullable String baseFile);
+
+    /**
+     * Retrieves metadata for the given backup file name.
+     *
+     * @param backupFileName file present inside the backups directory
+     * @return future containing the metadata if it exists
+     */
+    CompletableFuture<Optional<BackupMetadata>> getBackup(String backupFileName);
+
+    /**
+     * Restores the configuration file from the provided backup.
+     *
+     * <p>The current version of the file will be backed up before being overwritten.</p>
+     *
+     * @param backupFileName name of the backup file inside the backups directory
+     * @return future describing the operation
+     */
+    CompletableFuture<RestoreResult> restoreBackup(String backupFileName);
+
+    /**
+     * Updates the retention policy controlling how many backups are kept per file.
+     *
+     * @param maxBackupsPerFile non-negative value, {@code 0} disables backups entirely
+     */
+    void updateRetentionLimit(int maxBackupsPerFile);
+
+    /**
+     * Returns the path to the backups directory.
+     */
+    Path backupsDirectory();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void close();
+
+    /**
+     * Immutable description of a backup file.
+     */
+    record BackupMetadata(String baseFileName,
+                          String backupFileName,
+                          Path path,
+                          Instant createdAt,
+                          long sizeBytes) {
+    }
+
+    /**
+     * Information returned after a successful restoration.
+     */
+    record RestoreResult(BackupMetadata restoredBackup,
+                         Optional<BackupMetadata> preRestoreBackup) {
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/BackupServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/config/BackupServiceImpl.java
@@ -1,0 +1,329 @@
+package com.heneria.nexus.config;
+
+import com.heneria.nexus.config.BackupService.BackupMetadata;
+import com.heneria.nexus.config.BackupService.RestoreResult;
+import com.heneria.nexus.util.NamedThreadFactory;
+import com.heneria.nexus.util.NexusLogger;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Default implementation of {@link BackupService} using the local filesystem.
+ */
+public final class BackupServiceImpl implements BackupService {
+
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS")
+            .withZone(ZoneOffset.UTC);
+    private static final ZoneId TIMESTAMP_ZONE = ZoneOffset.UTC;
+    private static final int TIMESTAMP_LENGTH = 18;
+    private static final Pattern BACKUP_SUFFIX = Pattern.compile(".+\\.bak");
+
+    private final Path dataDirectory;
+    private final Path backupsDirectory;
+    private final NexusLogger logger;
+    private final ExecutorService executor;
+    private final AtomicInteger retentionLimit = new AtomicInteger(10);
+    private final Map<String, Object> fileLocks = new ConcurrentHashMap<>();
+
+    public BackupServiceImpl(Path dataDirectory, NexusLogger logger) {
+        this.dataDirectory = Objects.requireNonNull(dataDirectory, "dataDirectory").normalize();
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.backupsDirectory = this.dataDirectory.resolve("backups");
+        this.executor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors() / 2),
+                new NamedThreadFactory("Nexus-Backup", true, logger));
+    }
+
+    @Override
+    public CompletableFuture<Optional<BackupMetadata>> createBackup(Path originalFile) {
+        Objects.requireNonNull(originalFile, "originalFile");
+        return CompletableFuture.supplyAsync(() -> {
+            if (retentionLimit.get() == 0) {
+                return Optional.empty();
+            }
+            Path normalised = originalFile.normalize();
+            if (!normalised.startsWith(dataDirectory)) {
+                throw new CompletionException(new IOException("Le fichier à sauvegarder doit se trouver dans le dossier de données"));
+            }
+            if (Files.notExists(normalised) || !Files.isRegularFile(normalised)) {
+                return Optional.empty();
+            }
+            ensureDirectory();
+            String relative = relativePath(normalised);
+            Object lock = fileLocks.computeIfAbsent(relative, key -> new Object());
+            synchronized (lock) {
+                try {
+                    return Optional.ofNullable(createBackupLocked(relative, normalised));
+                } catch (IOException exception) {
+                    throw new CompletionException(exception);
+                }
+            }
+        }, executor);
+    }
+
+    @Override
+    public CompletableFuture<List<BackupMetadata>> listBackups(@Nullable String baseFile) {
+        return CompletableFuture.supplyAsync(() -> {
+            ensureDirectory();
+            if (Files.notExists(backupsDirectory)) {
+                return List.of();
+            }
+            try (Stream<Path> stream = Files.list(backupsDirectory)) {
+                return stream
+                        .filter(Files::isRegularFile)
+                        .filter(path -> BACKUP_SUFFIX.matcher(path.getFileName().toString()).matches())
+                        .map(this::metadataFromFile)
+                        .flatMap(Optional::stream)
+                        .filter(metadata -> baseFile == null
+                                || metadata.baseFileName().equals(normaliseRelative(baseFile)))
+                        .sorted(Comparator.comparing(BackupMetadata::createdAt).reversed())
+                        .collect(Collectors.toList());
+            } catch (IOException exception) {
+                throw new CompletionException(exception);
+            }
+        }, executor);
+    }
+
+    @Override
+    public CompletableFuture<Optional<BackupMetadata>> getBackup(String backupFileName) {
+        Objects.requireNonNull(backupFileName, "backupFileName");
+        return CompletableFuture.supplyAsync(() -> {
+            ensureDirectory();
+            Path candidate = resolveBackupPath(backupFileName);
+            if (Files.notExists(candidate) || !Files.isRegularFile(candidate)) {
+                return Optional.empty();
+            }
+            return metadataFromFile(candidate);
+        }, executor);
+    }
+
+    @Override
+    public CompletableFuture<RestoreResult> restoreBackup(String backupFileName) {
+        Objects.requireNonNull(backupFileName, "backupFileName");
+        return CompletableFuture.supplyAsync(() -> {
+            ensureDirectory();
+            Path backupPath = resolveBackupPath(backupFileName);
+            if (Files.notExists(backupPath) || !Files.isRegularFile(backupPath)) {
+                throw new CompletionException(new IOException("Sauvegarde introuvable: " + backupFileName));
+            }
+            BackupMetadata metadata = metadataFromFile(backupPath)
+                    .orElseThrow(() -> new CompletionException(new IOException("Sauvegarde invalide: " + backupFileName)));
+            String relative = metadata.baseFileName();
+            Path destination = resolveRelative(relative);
+            Object lock = fileLocks.computeIfAbsent(relative, key -> new Object());
+            synchronized (lock) {
+                try {
+                    Optional<BackupMetadata> preRestore = Optional.empty();
+                    if (Files.exists(destination) && Files.isRegularFile(destination) && retentionLimit.get() != 0) {
+                        preRestore = Optional.ofNullable(createBackupLocked(relative, destination));
+                    }
+                    Path parent = destination.getParent();
+                    if (parent != null) {
+                        Files.createDirectories(parent);
+                    }
+                    Files.copy(backupPath, destination, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+                    logger.info("Configuration restaurée depuis la sauvegarde '" + backupFileName + "'");
+                    return new RestoreResult(metadata, preRestore);
+                } catch (IOException exception) {
+                    throw new CompletionException(exception);
+                }
+            }
+        }, executor);
+    }
+
+    @Override
+    public void updateRetentionLimit(int maxBackupsPerFile) {
+        if (maxBackupsPerFile < 0) {
+            throw new IllegalArgumentException("maxBackupsPerFile doit être >= 0");
+        }
+        retentionLimit.set(maxBackupsPerFile);
+    }
+
+    @Override
+    public Path backupsDirectory() {
+        return backupsDirectory;
+    }
+
+    @Override
+    public void close() {
+        executor.shutdownNow();
+    }
+
+    private @Nullable BackupMetadata createBackupLocked(String relative, Path originalFile) throws IOException {
+        if (retentionLimit.get() == 0) {
+            return null;
+        }
+        String encodedRelative = encodeRelative(relative);
+        String timestamp = TIMESTAMP_FORMATTER.format(LocalDateTime.now(TIMESTAMP_ZONE));
+        Path backupPath = backupsDirectory.resolve(encodedRelative + "." + timestamp + ".bak");
+        int counter = 1;
+        while (Files.exists(backupPath)) {
+            backupPath = backupsDirectory.resolve(encodedRelative + "." + timestamp + "-" + counter + ".bak");
+            counter++;
+        }
+        Path parent = backupPath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Files.copy(originalFile, backupPath, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+        performRotationLocked(relative);
+        BasicFileAttributes attrs = Files.readAttributes(backupPath, BasicFileAttributes.class);
+        Instant createdAt = parseTimestamp(backupPath.getFileName().toString())
+                .orElseGet(() -> attrs.creationTime().toInstant());
+        return new BackupMetadata(relative, backupPath.getFileName().toString(), backupPath, createdAt, attrs.size());
+    }
+
+    private void performRotationLocked(String relative) throws IOException {
+        int limit = retentionLimit.get();
+        if (limit <= 0) {
+            return;
+        }
+        String encoded = encodeRelative(relative);
+        try (Stream<Path> stream = Files.list(backupsDirectory)) {
+            List<Path> backups = stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> {
+                        String name = path.getFileName().toString();
+                        return name.startsWith(encoded + ".") && name.endsWith(".bak");
+                    })
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()).reversed())
+                    .collect(Collectors.toList());
+            if (backups.size() <= limit) {
+                return;
+            }
+            for (int i = limit; i < backups.size(); i++) {
+                Path toDelete = backups.get(i);
+                try {
+                    Files.deleteIfExists(toDelete);
+                } catch (IOException exception) {
+                    logger.warn("Impossible de supprimer l'ancienne sauvegarde " + toDelete.getFileName(), exception);
+                }
+            }
+        }
+    }
+
+    private Optional<BackupMetadata> metadataFromFile(Path path) {
+        String fileName = path.getFileName().toString();
+        if (!fileName.endsWith(".bak")) {
+            return Optional.empty();
+        }
+        String withoutSuffix = fileName.substring(0, fileName.length() - 4);
+        int lastDot = withoutSuffix.lastIndexOf('.');
+        if (lastDot < 0) {
+            return Optional.empty();
+        }
+        String encodedRelative = withoutSuffix.substring(0, lastDot);
+        String decodedRelative = decodeRelative(encodedRelative);
+        Instant createdAt = parseTimestamp(fileName)
+                .orElseGet(() -> {
+                    try {
+                        return Files.readAttributes(path, BasicFileAttributes.class).creationTime().toInstant();
+                    } catch (IOException exception) {
+                        logger.warn("Impossible de lire les métadonnées de la sauvegarde " + fileName, exception);
+                        return Instant.now();
+                    }
+                });
+        long size;
+        try {
+            size = Files.size(path);
+        } catch (IOException exception) {
+            logger.warn("Impossible de déterminer la taille de la sauvegarde " + fileName, exception);
+            size = 0L;
+        }
+        return Optional.of(new BackupMetadata(decodedRelative, fileName, path, createdAt, size));
+    }
+
+    private Optional<Instant> parseTimestamp(String fileName) {
+        String withoutSuffix = fileName.endsWith(".bak")
+                ? fileName.substring(0, fileName.length() - 4)
+                : fileName;
+        int lastDot = withoutSuffix.lastIndexOf('.');
+        if (lastDot < 0) {
+            return Optional.empty();
+        }
+        String timestampPart = withoutSuffix.substring(lastDot + 1);
+        if (timestampPart.length() < TIMESTAMP_LENGTH) {
+            return Optional.empty();
+        }
+        String token = timestampPart.substring(0, TIMESTAMP_LENGTH);
+        try {
+            LocalDateTime dateTime = LocalDateTime.parse(token, TIMESTAMP_FORMATTER);
+            return Optional.of(dateTime.atZone(TIMESTAMP_ZONE).toInstant());
+        } catch (Exception exception) {
+            return Optional.empty();
+        }
+    }
+
+    private void ensureDirectory() {
+        try {
+            Files.createDirectories(backupsDirectory);
+        } catch (IOException exception) {
+            throw new CompletionException(exception);
+        }
+    }
+
+    private Path resolveBackupPath(String backupFileName) {
+        Path resolved = backupsDirectory.resolve(backupFileName).normalize();
+        if (!resolved.startsWith(backupsDirectory)) {
+            throw new CompletionException(new IOException("Accès à une sauvegarde en dehors du dossier autorisé"));
+        }
+        return resolved;
+    }
+
+    private Path resolveRelative(String relative) {
+        Path resolved = dataDirectory.resolve(relative.replace('/', java.io.File.separatorChar)).normalize();
+        if (!resolved.startsWith(dataDirectory)) {
+            throw new CompletionException(new IOException("Chemin de sauvegarde en dehors du dossier de données"));
+        }
+        return resolved;
+    }
+
+    private String relativePath(Path path) {
+        Path relative = dataDirectory.relativize(path);
+        return relative.toString().replace(java.io.File.separatorChar, '/');
+    }
+
+    private String encodeRelative(String relative) {
+        return URLEncoder.encode(relative, StandardCharsets.UTF_8);
+    }
+
+    private String decodeRelative(String encoded) {
+        return URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+    }
+
+    private String normaliseRelative(String input) {
+        String normalised = input.replace('\\', '/');
+        while (normalised.startsWith("./")) {
+            normalised = normalised.substring(2);
+        }
+        while (normalised.startsWith("/")) {
+            normalised = normalised.substring(1);
+        }
+        return normalised;
+    }
+}

--- a/src/main/java/com/heneria/nexus/config/ConfigManager.java
+++ b/src/main/java/com/heneria/nexus/config/ConfigManager.java
@@ -50,13 +50,13 @@ public final class ConfigManager implements AutoCloseable {
     private final ConfigHotSwap hotSwap = new ConfigHotSwap();
     private final ConfigMigrator migrator;
 
-    public ConfigManager(JavaPlugin plugin, NexusLogger logger) {
+    public ConfigManager(JavaPlugin plugin, NexusLogger logger, BackupService backupService) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.dataDirectory = plugin.getDataFolder().toPath();
         this.ioExecutor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors() / 2),
                 new NamedThreadFactory("Nexus-Config", true, logger));
-        this.migrator = new ConfigMigrator(logger);
+        this.migrator = new ConfigMigrator(logger, Objects.requireNonNull(backupService, "backupService"));
     }
 
     public ReloadReport initialLoad() {

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -22,6 +22,7 @@ public final class CoreConfig {
     private final DatabaseSettings databaseSettings;
     private final RateLimitSettings rateLimitSettings;
     private final ServiceSettings serviceSettings;
+    private final BackupSettings backupSettings;
     private final TimeoutSettings timeoutSettings;
     private final DegradedModeSettings degradedModeSettings;
     private final QueueSettings queueSettings;
@@ -37,6 +38,7 @@ public final class CoreConfig {
                       DatabaseSettings databaseSettings,
                       RateLimitSettings rateLimitSettings,
                       ServiceSettings serviceSettings,
+                      BackupSettings backupSettings,
                       TimeoutSettings timeoutSettings,
                       DegradedModeSettings degradedModeSettings,
                       QueueSettings queueSettings,
@@ -51,6 +53,7 @@ public final class CoreConfig {
         this.databaseSettings = Objects.requireNonNull(databaseSettings, "databaseSettings");
         this.rateLimitSettings = Objects.requireNonNull(rateLimitSettings, "rateLimitSettings");
         this.serviceSettings = Objects.requireNonNull(serviceSettings, "serviceSettings");
+        this.backupSettings = Objects.requireNonNull(backupSettings, "backupSettings");
         this.timeoutSettings = Objects.requireNonNull(timeoutSettings, "timeoutSettings");
         this.degradedModeSettings = Objects.requireNonNull(degradedModeSettings, "degradedModeSettings");
         this.queueSettings = Objects.requireNonNull(queueSettings, "queueSettings");
@@ -91,6 +94,10 @@ public final class CoreConfig {
         return serviceSettings;
     }
 
+    public BackupSettings backupSettings() {
+        return backupSettings;
+    }
+
     public TimeoutSettings timeoutSettings() {
         return timeoutSettings;
     }
@@ -113,6 +120,14 @@ public final class CoreConfig {
 
     public UiSettings uiSettings() {
         return uiSettings;
+    }
+
+    public record BackupSettings(int maxBackupsPerFile) {
+        public BackupSettings {
+            if (maxBackupsPerFile < 0) {
+                throw new IllegalArgumentException("maxBackupsPerFile must be >= 0");
+            }
+        }
     }
 
     public record ArenaSettings(int hudHz, int scoreboardHz, int particlesSoftCap, int particlesHardCap,

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,11 @@ server:
   language: "fr"
   timezone: "Europe/Paris"
 
+config:
+  backups:
+    # Nombre maximum de sauvegardes à conserver par fichier. Mettre à 0 pour désactiver.
+    max_backups_per_file: 10
+
 perf:
   hud_hz: 5
   scoreboard_hz: 3

--- a/src/main/resources/lang/messages_fr.yml
+++ b/src/main/resources/lang/messages_fr.yml
@@ -16,6 +16,7 @@ help:
     player: "<gray>/nexus admin player <joueur> <export|import></gray> <dark_gray>-</dark_gray> <yellow>Export/import des données joueurs.</yellow>"
     audit: "<gray>/nexus admin audit log <joueur|*></gray> <dark_gray>-</dark_gray> <yellow>Consulte les actions sensibles enregistrées.</yellow>"
     holo: "<gray>/nexus holo <create|remove|move|list|reload></gray> <dark_gray>-</dark_gray> <yellow>Gère les hologrammes.</yellow>"
+    config: "<gray>/nexus admin config <backups|restore></gray> <dark_gray>-</dark_gray> <yellow>Gère les sauvegardes des configurations.</yellow>"
 
 errors:
   no_permission: "<red>Vous n'avez pas la permission requise.</red>"
@@ -62,6 +63,25 @@ admin:
     entry: "<gray>[<id>]</gray> <white><timestamp></white> <aqua><type></aqua> <yellow><actor></yellow> <dark_gray>→</dark_gray> <green><target></green> <gray>-</gray> <white><details></white>"
     more: "<gray>Page suivante :</gray> <yellow><command></yellow>"
     error: "<red>Impossible de récupérer les logs : <reason>.</red>"
+  config:
+    usage: "<gray>Usage :</gray> <yellow>/nexus admin config <backups|restore> ...</yellow>"
+    backups:
+      usage: "<gray>Usage :</gray> <yellow>/nexus admin config backups list [fichier]</yellow>"
+      header: "<gold>Sauvegardes disponibles (<count>) — filtre : <scope></gold>"
+      entry: "<gray>-</gray> <white><backup></white> <dark_gray>(</dark_gray><yellow><file></yellow><dark_gray>)</dark_gray> <gray>créée le</gray> <aqua><created_at></aqua> <gray>(<size>)</gray>"
+      empty: "<gray>Aucune sauvegarde trouvée.</gray>"
+      empty_filtered: "<gray>Aucune sauvegarde trouvée pour <file>.</gray>"
+      error: "<red>Impossible de lister les sauvegardes : <reason>.</red>"
+    restore:
+      usage: "<gray>Usage :</gray> <yellow>/nexus admin config restore <fichier.bak|confirm></yellow>"
+      missing: "<red>Sauvegarde introuvable : <backup>.</red>"
+      pending: "<yellow>Confirmez la restauration de <backup> (<file>) avec</yellow> <gray>/nexus admin config restore confirm</gray> <yellow>d'ici <seconds> seconde(s).</yellow>"
+      none: "<red>Aucune restauration en attente.</red>"
+      expired: "<red>La demande de restauration a expiré. Relancez la commande.</red>"
+      success: "<green>Sauvegarde <backup> restaurée vers <file>.</green>"
+      safety_backup: "<gray>Une sauvegarde de l'état actuel a été créée : <yellow><backup></yellow>.</gray>"
+      reload_hint: "<yellow>Exécutez</yellow> <gray>/nexus reload</gray> <yellow>pour appliquer les changements.</yellow>"
+      error: "<red>Impossible de restaurer la configuration : <reason>.</red>"
 
 titles:
   round_start:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -34,6 +34,9 @@ permissions:
   nexus.admin.audit.view:
     description: Consulter les logs d'audit Nexus.
     default: op
+  nexus.admin.config.manage_backups:
+    description: Gérer les sauvegardes de configuration Nexus.
+    default: op
   nexus.admin.*:
     description: Accès complet aux commandes d'administration Nexus.
     default: op
@@ -44,6 +47,7 @@ permissions:
       nexus.admin.player.export: true
       nexus.admin.player.import: true
       nexus.admin.audit.view: true
+      nexus.admin.config.manage_backups: true
   nexus.holo.manage:
     description: Gérer les hologrammes Nexus via /nexus holo.
     default: op


### PR DESCRIPTION
## Summary
- add an asynchronous backup service with retention-aware rotation and restore workflows
- integrate backup creation into config loading, validation, and migration paths
- expose admin commands, messaging, and permissions to list and restore configuration backups
- document retention settings in the default configuration file

## Testing
- `mvn -q -DskipTests compile` *(fails: dependency download blocked by repo.papermc.io 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d810cef5988324be3815072494c0d4