### PR TITLE
Add database resilience with retry and circuit breaker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <hikari.version>5.1.0</hikari.version>
         <caffeine.version>3.1.8</caffeine.version>
         <placeholderapi.version>2.11.5</placeholderapi.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
 
         <!--
             Keep a fixed timestamp to guarantee that identical sources always produce identical
@@ -107,6 +108,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.17.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -179,6 +190,14 @@
                                 <relocation>
                                     <pattern>com.github.benmanes.caffeine</pattern>
                                     <shadedPattern>com.heneria.nexus.lib.caffeine</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.github.resilience4j</pattern>
+                                    <shadedPattern>com.heneria.nexus.lib.resilience4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.vavr</pattern>
+                                    <shadedPattern>com.heneria.nexus.lib.vavr</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/src/main/java/com/heneria/nexus/db/ResilientDbExecutor.java
+++ b/src/main/java/com/heneria/nexus/db/ResilientDbExecutor.java
@@ -1,0 +1,190 @@
+package com.heneria.nexus.db;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.util.NexusLogger;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnStateTransitionEvent;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.decorators.Decorators;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+import java.sql.SQLTransientException;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Wraps {@link DbProvider} calls with retry and circuit breaker policies.
+ */
+public final class ResilientDbExecutor {
+
+    private static final String RETRY_NAME = "nexus-db-retry";
+    private static final String CIRCUIT_BREAKER_NAME = "nexus-db-circuit-breaker";
+
+    private final NexusLogger logger;
+    private final DbProvider dbProvider;
+    private final Executor ioExecutor;
+    private final AtomicReference<Retry> retryRef = new AtomicReference<>();
+    private final AtomicReference<CircuitBreaker> circuitBreakerRef = new AtomicReference<>();
+
+    public ResilientDbExecutor(NexusLogger logger,
+                               DbProvider dbProvider,
+                               Executor ioExecutor,
+                               CoreConfig.DatabaseSettings databaseSettings) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
+        this.ioExecutor = Objects.requireNonNull(ioExecutor, "ioExecutor");
+        configure(databaseSettings);
+    }
+
+    public synchronized void configure(CoreConfig.DatabaseSettings databaseSettings) {
+        Objects.requireNonNull(databaseSettings, "databaseSettings");
+        CoreConfig.DatabaseSettings.ResilienceSettings resilience = databaseSettings.resilience();
+        if (resilience == null) {
+            throw new IllegalArgumentException("Resilience settings must not be null");
+        }
+
+        RetryConfig retryConfig = RetryConfig.custom()
+                .maxAttempts(resilience.retry().maxAttempts())
+                .intervalFunction(createIntervalFunction(resilience.retry()))
+                .retryOnException(this::shouldRetry)
+                .build();
+        Retry retry = Retry.of(RETRY_NAME, retryConfig);
+
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+                .failureRateThreshold((float) resilience.circuitBreaker().failureRateThreshold())
+                .minimumNumberOfCalls(resilience.circuitBreaker().minimumNumberOfCalls())
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.TIME_BASED)
+                .slidingWindowSize(Math.toIntExact(Math.max(1L,
+                        resilience.circuitBreaker().slidingWindowDuration().getSeconds())))
+                .waitDurationInOpenState(resilience.circuitBreaker().waitDurationInOpenState())
+                .permittedNumberOfCallsInHalfOpenState(resilience.circuitBreaker().permittedCallsInHalfOpenState())
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .recordException(this::shouldRecordFailure)
+                .ignoreException(throwable -> unwrap(throwable) instanceof OptimisticLockException)
+                .build();
+        CircuitBreaker circuitBreaker = CircuitBreaker.of(CIRCUIT_BREAKER_NAME, circuitBreakerConfig);
+        circuitBreaker.getEventPublisher().onStateTransition(this::handleStateTransition);
+
+        retryRef.set(retry);
+        circuitBreakerRef.set(circuitBreaker);
+    }
+
+    public <T> CompletableFuture<T> execute(DbProvider.QueryTask<T> task) {
+        Objects.requireNonNull(task, "task");
+        Supplier<CompletionStage<T>> supplier = () -> dbProvider.execute(task, ioExecutor);
+        Supplier<CompletionStage<T>> decorated = Decorators.ofCompletionStage(supplier)
+                .withCircuitBreaker(circuitBreakerRef.get())
+                .withRetry(retryRef.get())
+                .decorate();
+        try {
+            return decorated.get().toCompletableFuture();
+        } catch (Throwable throwable) {
+            CompletableFuture<T> failed = new CompletableFuture<>();
+            failed.completeExceptionally(throwable);
+            return failed;
+        }
+    }
+
+    private IntervalFunction createIntervalFunction(CoreConfig.DatabaseSettings.ResilienceSettings.RetrySettings retrySettings) {
+        long initial = retrySettings.initialInterval().toMillis();
+        double multiplier = retrySettings.multiplier();
+        long max = retrySettings.maxInterval().toMillis();
+        return attempt -> {
+            double candidate = initial * Math.pow(multiplier, Math.max(0, attempt - 1));
+            long value = (long) Math.min(candidate, max);
+            return value < 0L ? max : value;
+        };
+    }
+
+    private boolean shouldRetry(Throwable throwable) {
+        Throwable unwrapped = unwrap(throwable);
+        if (unwrapped instanceof OptimisticLockException) {
+            return false;
+        }
+        if (unwrapped instanceof IllegalStateException) {
+            return false;
+        }
+        if (unwrapped instanceof SQLException sqlException) {
+            return isTransient(sqlException);
+        }
+        return false;
+    }
+
+    private boolean shouldRecordFailure(Throwable throwable) {
+        Throwable unwrapped = unwrap(throwable);
+        if (unwrapped instanceof OptimisticLockException) {
+            return false;
+        }
+        if (unwrapped instanceof SQLException sqlException) {
+            return isTransient(sqlException);
+        }
+        return false;
+    }
+
+    private boolean isTransient(SQLException exception) {
+        if (exception instanceof SQLTransientException
+                || exception instanceof SQLRecoverableException
+                || exception instanceof SQLNonTransientConnectionException
+                || exception instanceof SQLTimeoutException) {
+            return true;
+        }
+        String sqlState = exception.getSQLState();
+        return sqlState != null && sqlState.startsWith("08");
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        Throwable current = throwable;
+        while (current instanceof CompletionException || current instanceof ExecutionException) {
+            Throwable cause = current.getCause();
+            if (cause == null) {
+                break;
+            }
+            current = cause;
+        }
+        if (current instanceof RuntimeException runtimeException && runtimeException.getCause() != null) {
+            Throwable cause = runtimeException.getCause();
+            if (cause instanceof SQLException) {
+                return cause;
+            }
+        }
+        return current;
+    }
+
+    private void handleStateTransition(CircuitBreakerOnStateTransitionEvent event) {
+        CircuitBreaker.State toState = event.getStateTransition().getToState();
+        switch (toState) {
+            case OPEN -> {
+                boolean alreadyDegraded = dbProvider.isDegraded();
+                dbProvider.setDegraded(true);
+                if (alreadyDegraded) {
+                    logger.warn("La connexion à la base de données reste instable, le circuit est OUVERT.");
+                } else {
+                    logger.warn("La connexion à la base de données est instable, le circuit est maintenant OUVERT. Passage en mode dégradé.");
+                }
+            }
+            case HALF_OPEN -> logger.info("Circuit MariaDB en état SEMI-OUVERT : test de la connectivité.");
+            case CLOSED -> {
+                if (dbProvider.isDegraded()) {
+                    dbProvider.setDegraded(false);
+                    logger.info("Circuit MariaDB refermé, retour au mode normal.");
+                } else {
+                    logger.info("Circuit MariaDB refermé.");
+                }
+            }
+            default -> {
+                // No-op
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/db/repository/PlayerClassRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/PlayerClassRepositoryImpl.java
@@ -1,13 +1,11 @@
 package com.heneria.nexus.db.repository;
 
-import com.heneria.nexus.concurrent.ExecutorManager;
-import com.heneria.nexus.db.DbProvider;
+import com.heneria.nexus.db.ResilientDbExecutor;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 /**
  * Default MariaDB-backed implementation of {@link PlayerClassRepository}.
@@ -21,19 +19,17 @@ public final class PlayerClassRepositoryImpl implements PlayerClassRepository {
                     "VALUES (?, ?, ?, TRUE) " +
                     "ON DUPLICATE KEY UPDATE is_unlocked = VALUES(is_unlocked)";
 
-    private final DbProvider dbProvider;
-    private final Executor ioExecutor;
+    private final ResilientDbExecutor dbExecutor;
 
-    public PlayerClassRepositoryImpl(DbProvider dbProvider, ExecutorManager executorManager) {
-        this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
-        this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
+    public PlayerClassRepositoryImpl(ResilientDbExecutor dbExecutor) {
+        this.dbExecutor = Objects.requireNonNull(dbExecutor, "dbExecutor");
     }
 
     @Override
     public CompletableFuture<Boolean> isUnlocked(UUID playerUuid, String classId) {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(classId, "classId");
-        return dbProvider.execute(connection -> {
+        return dbExecutor.execute(connection -> {
             try (PreparedStatement statement = connection.prepareStatement(SELECT_UNLOCK_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, classId);
@@ -44,14 +40,14 @@ public final class PlayerClassRepositoryImpl implements PlayerClassRepository {
                     return resultSet.getBoolean("is_unlocked");
                 }
             }
-        }, ioExecutor);
+        });
     }
 
     @Override
     public CompletableFuture<Void> unlock(UUID playerUuid, String classId) {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(classId, "classId");
-        return dbProvider.execute(connection -> {
+        return dbExecutor.execute(connection -> {
             try (PreparedStatement statement = connection.prepareStatement(UPSERT_UNLOCK_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, classId);
@@ -59,6 +55,6 @@ public final class PlayerClassRepositoryImpl implements PlayerClassRepository {
                 statement.executeUpdate();
             }
             return null;
-        }, ioExecutor);
+        });
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #  PaperMC 1.21.x — Java 21
 # =============================================
 
-config-version: 3
+config-version: 4
 
 server:
   mode: "nexus"
@@ -45,6 +45,18 @@ database:
     maxSize: 10
     minIdle: 2
     connTimeoutMs: 3000
+  resilience:
+    retry:
+      max_attempts: 5
+      initial_interval_ms: 1000
+      max_interval_ms: 8000
+      multiplier: 2.0
+    circuit_breaker:
+      failure_rate_threshold: 50.0
+      minimum_number_of_calls: 5
+      sliding_window_seconds: 30
+      wait_duration_open_state_seconds: 60
+      permitted_calls_in_half_open_state: 1
   write_behind_interval_seconds: 60
   cache:
     profiles:


### PR DESCRIPTION
## Summary
- add Resilience4j retry and circuit breaker dependencies and shading to the build
- introduce a ResilientDbExecutor that wraps database calls with retry and circuit breaker behaviour and updates DbProvider degraded handling
- surface resilience settings in configuration/validation and wire repositories and NexusPlugin to use the new executor

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d81c59fc1c8324bdbf6818f3310fe5