### PR TITLE
Add SQL query monitoring and tracing support

### DIFF
--- a/src/main/java/com/heneria/nexus/admin/PlayerDataImporter.java
+++ b/src/main/java/com/heneria/nexus/admin/PlayerDataImporter.java
@@ -208,7 +208,8 @@ public final class PlayerDataImporter {
     }
 
     private CompletableFuture<Void> persistSnapshot(PlayerDataSnapshot snapshot) {
-        return dbProvider.execute(connection -> persistTransactional(connection, snapshot), executorManager.io());
+        return dbProvider.execute("PlayerDataImporter::persistSnapshot",
+                connection -> persistTransactional(connection, snapshot), executorManager.io());
     }
 
     private Void persistTransactional(Connection connection, PlayerDataSnapshot snapshot) throws SQLException {

--- a/src/main/java/com/heneria/nexus/analytics/AnalyticsRepository.java
+++ b/src/main/java/com/heneria/nexus/analytics/AnalyticsRepository.java
@@ -61,7 +61,8 @@ public final class AnalyticsRepository {
         if (events.isEmpty()) {
             return CompletableFuture.completedFuture(0);
         }
-        return dbProvider.execute(connection -> persistBatch(connection, events), executorManager.io());
+        return dbProvider.execute("AnalyticsRepository::saveBatch",
+                connection -> persistBatch(connection, events), executorManager.io());
     }
 
     private int persistBatch(Connection connection, List<AnalyticsEvent> events) throws SQLException {

--- a/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsAggregatorService.java
+++ b/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsAggregatorService.java
@@ -158,7 +158,8 @@ public final class DailyStatsAggregatorService implements LifecycleAware {
     }
 
     private CompletableFuture<Void> performAggregation(LocalDate targetDate) {
-        return dbProvider.execute(connection -> computeSnapshot(connection, targetDate), ioExecutor)
+        return dbProvider.execute("DailyStatsAggregatorService::computeSnapshot",
+                connection -> computeSnapshot(connection, targetDate), ioExecutor)
                 .thenCompose(repository::saveOrUpdate)
                 .whenComplete((ignored, throwable) -> {
                     if (throwable != null) {

--- a/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsRepository.java
+++ b/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsRepository.java
@@ -36,7 +36,8 @@ public final class DailyStatsRepository {
 
     public CompletableFuture<Void> saveOrUpdate(DailyStatsSnapshot snapshot) {
         Objects.requireNonNull(snapshot, "snapshot");
-        return dbProvider.execute(connection -> persist(connection, snapshot), ioExecutor);
+        return dbProvider.execute("DailyStatsRepository::saveOrUpdate",
+                connection -> persist(connection, snapshot), ioExecutor);
     }
 
     private Void persist(Connection connection, DailyStatsSnapshot snapshot) throws SQLException {

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -174,8 +174,8 @@ public final class CoreConfig {
 
     public record DatabaseSettings(boolean enabled, String jdbcUrl, String username, String password,
                                    PoolSettings poolSettings, Duration writeBehindInterval,
-                                   CacheSettings cacheSettings, DataRetentionSettings retentionPolicy,
-                                   ResilienceSettings resilience) {
+                                   CacheSettings cacheSettings, MonitoringSettings monitoring,
+                                   DataRetentionSettings retentionPolicy, ResilienceSettings resilience) {
         public DatabaseSettings {
             Objects.requireNonNull(jdbcUrl, "jdbcUrl");
             Objects.requireNonNull(username, "username");
@@ -183,6 +183,7 @@ public final class CoreConfig {
             Objects.requireNonNull(poolSettings, "poolSettings");
             Objects.requireNonNull(writeBehindInterval, "writeBehindInterval");
             Objects.requireNonNull(cacheSettings, "cacheSettings");
+            Objects.requireNonNull(monitoring, "monitoring");
             Objects.requireNonNull(retentionPolicy, "retentionPolicy");
             Objects.requireNonNull(resilience, "resilience");
             if (writeBehindInterval.isZero() || writeBehindInterval.isNegative()) {
@@ -193,6 +194,14 @@ public final class CoreConfig {
         public record CacheSettings(ProfileCacheSettings profiles) {
             public CacheSettings {
                 Objects.requireNonNull(profiles, "profiles");
+            }
+        }
+
+        public record MonitoringSettings(boolean enableSqlTracing, long slowQueryThresholdMs) {
+            public MonitoringSettings {
+                if (slowQueryThresholdMs < 0L) {
+                    throw new IllegalArgumentException("slowQueryThresholdMs must be >= 0");
+                }
             }
         }
 

--- a/src/main/java/com/heneria/nexus/db/ResilientDbExecutor.java
+++ b/src/main/java/com/heneria/nexus/db/ResilientDbExecutor.java
@@ -80,9 +80,10 @@ public final class ResilientDbExecutor {
         circuitBreakerRef.set(circuitBreaker);
     }
 
-    public <T> CompletableFuture<T> execute(DbProvider.QueryTask<T> task) {
+    public <T> CompletableFuture<T> execute(String queryIdentifier, DbProvider.QueryTask<T> task) {
+        Objects.requireNonNull(queryIdentifier, "queryIdentifier");
         Objects.requireNonNull(task, "task");
-        Supplier<CompletionStage<T>> supplier = () -> dbProvider.execute(task, ioExecutor);
+        Supplier<CompletionStage<T>> supplier = () -> dbProvider.execute(queryIdentifier, task, ioExecutor);
         Supplier<CompletionStage<T>> decorated = Decorators.ofCompletionStage(supplier)
                 .withCircuitBreaker(circuitBreakerRef.get())
                 .withRetry(retryRef.get())

--- a/src/main/java/com/heneria/nexus/db/repository/AuditLogRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/AuditLogRepositoryImpl.java
@@ -42,7 +42,7 @@ public final class AuditLogRepositoryImpl implements AuditLogRepository {
         if (entries.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("AuditLogRepository::saveAll", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(INSERT_SQL)) {
                 for (AuditLogRecord entry : entries) {
                     statement.setTimestamp(1, Timestamp.from(entry.timestamp()));
@@ -73,7 +73,7 @@ public final class AuditLogRepositoryImpl implements AuditLogRepository {
         if (offset < 0) {
             throw new IllegalArgumentException("offset must be >= 0");
         }
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("AuditLogRepository::findRecent", connection -> {
             StringBuilder sql = new StringBuilder(BASE_SELECT_SQL);
             List<Object> parameters = new ArrayList<>();
             boolean whereAdded = false;

--- a/src/main/java/com/heneria/nexus/db/repository/EconomyRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/EconomyRepositoryImpl.java
@@ -37,7 +37,7 @@ public final class EconomyRepositoryImpl implements EconomyRepository {
     @Override
     public CompletableFuture<Long> getBalance(UUID playerUuid) {
         Objects.requireNonNull(playerUuid, "playerUuid");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("EconomyRepository::getBalance", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(SELECT_BALANCE_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 try (ResultSet resultSet = statement.executeQuery()) {
@@ -56,7 +56,7 @@ public final class EconomyRepositoryImpl implements EconomyRepository {
         if (balance < 0L) {
             throw new IllegalArgumentException("balance must be >= 0");
         }
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("EconomyRepository::setBalance", connection -> {
             try (PreparedStatement update = connection.prepareStatement(UPDATE_BALANCE_SQL)) {
                 update.setLong(1, balance);
                 update.setString(2, playerUuid.toString());
@@ -76,7 +76,7 @@ public final class EconomyRepositoryImpl implements EconomyRepository {
     @Override
     public CompletableFuture<Long> addToBalance(UUID playerUuid, long amount) {
         Objects.requireNonNull(playerUuid, "playerUuid");
-        return dbExecutor.execute(connection -> adjustBalance(connection, playerUuid, amount));
+        return dbExecutor.execute("EconomyRepository::addToBalance", connection -> adjustBalance(connection, playerUuid, amount));
     }
 
     @Override
@@ -86,7 +86,7 @@ public final class EconomyRepositoryImpl implements EconomyRepository {
         if (amount < 0L) {
             throw new IllegalArgumentException("amount must be >= 0");
         }
-        return dbExecutor.execute(connection -> transferInternal(connection, from, to, amount));
+        return dbExecutor.execute("EconomyRepository::transfer", connection -> transferInternal(connection, from, to, amount));
     }
 
     @Override
@@ -95,7 +95,7 @@ public final class EconomyRepositoryImpl implements EconomyRepository {
         if (balances.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("EconomyRepository::saveAll", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(UPSERT_BALANCE_SQL)) {
                 for (Map.Entry<UUID, Long> entry : balances.entrySet()) {
                     statement.setString(1, entry.getKey().toString());

--- a/src/main/java/com/heneria/nexus/db/repository/MatchRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/MatchRepositoryImpl.java
@@ -39,13 +39,13 @@ public final class MatchRepositoryImpl implements MatchRepository {
     @Override
     public CompletableFuture<Void> save(MatchSnapshot snapshot) {
         Objects.requireNonNull(snapshot, "snapshot");
-        return dbExecutor.execute(connection -> persistSnapshot(connection, snapshot));
+        return dbExecutor.execute("MatchRepository::save", connection -> persistSnapshot(connection, snapshot));
     }
 
     @Override
     public CompletableFuture<Integer> purgeOldMatches(Instant olderThan) {
         Objects.requireNonNull(olderThan, "olderThan");
-        return dbExecutor.execute(connection -> purgeMatches(connection, olderThan));
+        return dbExecutor.execute("MatchRepository::purgeOldMatches", connection -> purgeMatches(connection, olderThan));
     }
 
     private Void persistSnapshot(Connection connection, MatchSnapshot snapshot) throws SQLException {

--- a/src/main/java/com/heneria/nexus/db/repository/PlayerClassRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/PlayerClassRepositoryImpl.java
@@ -29,7 +29,7 @@ public final class PlayerClassRepositoryImpl implements PlayerClassRepository {
     public CompletableFuture<Boolean> isUnlocked(UUID playerUuid, String classId) {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(classId, "classId");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("PlayerClassRepository::isUnlocked", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(SELECT_UNLOCK_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, classId);
@@ -47,7 +47,7 @@ public final class PlayerClassRepositoryImpl implements PlayerClassRepository {
     public CompletableFuture<Void> unlock(UUID playerUuid, String classId) {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(classId, "classId");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("PlayerClassRepository::unlock", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(UPSERT_UNLOCK_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, classId);

--- a/src/main/java/com/heneria/nexus/db/repository/PlayerCosmeticRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/PlayerCosmeticRepositoryImpl.java
@@ -29,7 +29,7 @@ public final class PlayerCosmeticRepositoryImpl implements PlayerCosmeticReposit
     public CompletableFuture<Boolean> isUnlocked(UUID playerUuid, String cosmeticId) {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(cosmeticId, "cosmeticId");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("PlayerCosmeticRepository::isUnlocked", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(SELECT_UNLOCK_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, cosmeticId);
@@ -45,7 +45,7 @@ public final class PlayerCosmeticRepositoryImpl implements PlayerCosmeticReposit
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(cosmeticId, "cosmeticId");
         Objects.requireNonNull(cosmeticType, "cosmeticType");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("PlayerCosmeticRepository::unlock", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(UPSERT_UNLOCK_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, cosmeticId);

--- a/src/main/java/com/heneria/nexus/db/repository/ProfileRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/ProfileRepositoryImpl.java
@@ -48,7 +48,7 @@ public final class ProfileRepositoryImpl implements ProfileRepository {
     @Override
     public CompletableFuture<Optional<PlayerProfile>> findByUuid(UUID playerUuid) {
         Objects.requireNonNull(playerUuid, "playerUuid");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("ProfileRepository::findByUuid", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(SELECT_PROFILE_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 try (ResultSet resultSet = statement.executeQuery()) {
@@ -82,7 +82,7 @@ public final class ProfileRepositoryImpl implements ProfileRepository {
         if (profile.getVersion() == profile.getPersistedVersion()) {
             return CompletableFuture.completedFuture(null);
         }
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("ProfileRepository::createOrUpdate", connection -> {
             try {
                 if (profile.getPersistedVersion() == 0) {
                     try (PreparedStatement statement = connection.prepareStatement(INSERT_PROFILE_SQL)) {
@@ -114,7 +114,7 @@ public final class ProfileRepositoryImpl implements ProfileRepository {
         if (profiles.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("ProfileRepository::saveAll", connection -> {
             try (PreparedStatement insertStatement = connection.prepareStatement(INSERT_PROFILE_SQL);
                  PreparedStatement updateStatement = connection.prepareStatement(UPDATE_PROFILE_SQL)) {
                 for (PlayerProfile profile : profiles) {

--- a/src/main/java/com/heneria/nexus/db/repository/RateLimitRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RateLimitRepositoryImpl.java
@@ -37,7 +37,7 @@ public final class RateLimitRepositoryImpl implements RateLimitRepository {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(actionKey, "actionKey");
         Objects.requireNonNull(cooldown, "cooldown");
-        return dbExecutor.execute(connection -> executeCheck(connection, playerUuid, actionKey, cooldown));
+        return dbExecutor.execute("RateLimitRepository::checkAndRecord", connection -> executeCheck(connection, playerUuid, actionKey, cooldown));
     }
 
     private RateLimitResult executeCheck(Connection connection,
@@ -94,7 +94,7 @@ public final class RateLimitRepositoryImpl implements RateLimitRepository {
     @Override
     public CompletableFuture<Integer> purgeOlderThan(Instant cutoff) {
         Objects.requireNonNull(cutoff, "cutoff");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("RateLimitRepository::purgeOlderThan", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(DELETE_OLDER_THAN_SQL)) {
                 statement.setTimestamp(1, Timestamp.from(cutoff));
                 return statement.executeUpdate();

--- a/src/main/java/com/heneria/nexus/db/repository/RewardClaimRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RewardClaimRepositoryImpl.java
@@ -27,7 +27,7 @@ public final class RewardClaimRepositoryImpl implements RewardClaimRepository {
     public CompletableFuture<Boolean> tryClaim(UUID playerUuid, String rewardKey) {
         Objects.requireNonNull(playerUuid, "playerUuid");
         Objects.requireNonNull(rewardKey, "rewardKey");
-        return dbExecutor.execute(connection -> {
+        return dbExecutor.execute("RewardClaimRepository::tryClaim", connection -> {
             try (PreparedStatement statement = connection.prepareStatement(INSERT_CLAIM_SQL)) {
                 statement.setString(1, playerUuid.toString());
                 statement.setString(2, rewardKey);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,6 +41,14 @@ database:
   jdbc: "jdbc:mariadb://127.0.0.1:3306/nexus"
   user: "nexus"
   password: "change_me"
+  monitoring:
+    # Si activé, toutes les requêtes SQL seront loggées au niveau DEBUG.
+    # À n'utiliser que pour le débogage !
+    enable_sql_tracing: false
+    # Seuil en millisecondes pour les requêtes lentes.
+    # Si une requête dépasse ce temps, un avertissement sera loggé.
+    # Mettre à 0 pour désactiver.
+    slow_query_threshold_ms: 500
   pool:
     maxSize: 10
     minIdle: 2


### PR DESCRIPTION
## Summary
- add configurable SQL monitoring options to the database section of the configuration and core settings model
- instrument DbProvider to measure query latency, emit tracing logs, and warn about slow statements
- propagate descriptive query identifiers through repositories and the resilient executor so all database calls participate in monitoring

## Testing
- `mvn -q -DskipTests compile` *(fails: remote dependencies from papermc repo return HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d826d0c348832492c861d3b936def7