### PR TITLE
Add resilience4j-all dependency to resolve Decorators usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
             <artifactId>resilience4j-circuitbreaker</artifactId>
             <version>${resilience4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-all</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
- add the resilience4j-all dependency so Decorators and other shared utilities are available during compilation

## Testing
- `mvn -q -DskipTests package` *(fails: remote repositories return HTTP 403 when resolving PaperMC and related artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68d8461563cc8324ab96edccc39e1802