### PR TITLE
Fix compilation errors in rate limiting implementation

### DIFF
--- a/src/main/java/com/heneria/nexus/db/repository/RateLimitRepositoryImpl.java
+++ b/src/main/java/com/heneria/nexus/db/repository/RateLimitRepositoryImpl.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -66,7 +67,7 @@ public final class RateLimitRepositoryImpl implements RateLimitRepository {
                             if (remaining.isNegative()) {
                                 remaining = Duration.ZERO;
                             }
-                            return RateLimitResult.blocked(remaining);
+                            return new RateLimitResult(false, Optional.of(remaining));
                         }
                     }
                 }
@@ -78,7 +79,7 @@ public final class RateLimitRepositoryImpl implements RateLimitRepository {
                 upsert.executeUpdate();
             }
             connection.commit();
-            return RateLimitResult.allowed();
+            return new RateLimitResult(true, Optional.empty());
         } catch (SQLException exception) {
             connection.rollback();
             throw exception;

--- a/src/main/java/com/heneria/nexus/ratelimit/RateLimitResult.java
+++ b/src/main/java/com/heneria/nexus/ratelimit/RateLimitResult.java
@@ -21,15 +21,6 @@ public record RateLimitResult(boolean allowed, Optional<Duration> timeRemaining)
         });
     }
 
-    @Override
-    public boolean allowed() {
-        return allowed;
-    }
-
-    public boolean isAllowed() {
-        return allowed;
-    }
-
     public static RateLimitResult allowed() {
         return new RateLimitResult(true, Optional.empty());
     }

--- a/src/main/java/com/heneria/nexus/service/core/ShopServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/ShopServiceImpl.java
@@ -246,7 +246,7 @@ public final class ShopServiceImpl implements ShopService {
         }
         return rateLimiterService.check(player.getUniqueId(), actionKey, cooldown)
                 .thenApply(result -> {
-                    if (result.isAllowed()) {
+                    if (result.allowed()) {
                         return true;
                     }
                     Duration remaining = result.timeRemaining().orElse(cooldown);

--- a/src/main/java/com/heneria/nexus/service/ratelimit/RateLimiterServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/ratelimit/RateLimiterServiceImpl.java
@@ -7,6 +7,7 @@ import com.heneria.nexus.util.NexusLogger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -63,13 +64,13 @@ public final class RateLimiterServiceImpl implements RateLimiterService {
         Objects.requireNonNull(cooldown, "cooldown");
         ServiceConfiguration configuration = configurationRef.get();
         if (!configuration.enabled() || !configuration.databaseEnabled() || cooldown.isZero() || cooldown.isNegative()) {
-            return CompletableFuture.completedFuture(RateLimitResult.allowed());
+            return CompletableFuture.completedFuture(new RateLimitResult(true, Optional.empty()));
         }
         return repository.checkAndRecord(playerUuid, actionKey, cooldown)
                 .exceptionally(throwable -> {
                     Throwable cause = unwrap(throwable);
                     logger.warn("Vérification de rate limit en échec pour " + actionKey, cause);
-                    return RateLimitResult.allowed();
+                    return new RateLimitResult(true, Optional.empty());
                 });
     }
 


### PR DESCRIPTION
## Summary
- remove the redundant accessor implementation from `RateLimitResult`
- return concrete `RateLimitResult` instances from the repository and service layers
- update the shop service to read the record's generated accessor when checking limits

## Testing
- mvn -q -DskipTests compile *(fails: dependency downloads blocked by HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d84e132bd0832492e25c35056c4224