### PR TITLE
Handle IO errors and fix rate limit compilation

### DIFF
--- a/src/main/java/com/heneria/nexus/ratelimit/RateLimitResult.java
+++ b/src/main/java/com/heneria/nexus/ratelimit/RateLimitResult.java
@@ -21,10 +21,6 @@ public record RateLimitResult(boolean allowed, Optional<Duration> timeRemaining)
         });
     }
 
-    public static RateLimitResult allowed() {
-        return new RateLimitResult(true, Optional.empty());
-    }
-
     public static RateLimitResult blocked(Duration timeRemaining) {
         Objects.requireNonNull(timeRemaining, "timeRemaining");
         if (timeRemaining.isNegative()) {


### PR DESCRIPTION
## Summary
- guard PlayerDataImporter.prepareImport against IO failures when reading import files
- remove the conflicting accessor override from RateLimitResult to restore record compilation

## Testing
- `mvn -q -DskipTests compile` *(fails: requires external repositories that return 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d85382fdec83248afb27451d1eb07f