### PR TITLE
Fix log economy future return type

### DIFF
--- a/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
@@ -348,7 +348,7 @@ public final class EconomyServiceImpl implements EconomyService {
                     }
                     return null;
                 })
-                .toCompletableFuture();
+                .thenApply(ignored -> null);
     }
 
     private CompletableFuture<Void> logTransactionBatch(Map<UUID, List<PendingLogEntry>> entries,


### PR DESCRIPTION
## Summary
- ensure the economy log future chain maps to Void so it matches the declared return type

## Testing
- mvn -q -pl . -am test *(fails: dependency download blocked by 403 from papermc repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d8642419b88324b17e33376a6d139b