### PR TITLE
Fix CompletableFuture return types in economy logging

### DIFF
--- a/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
@@ -332,11 +332,11 @@ public final class EconomyServiceImpl implements EconomyService {
         }
     }
 
-    private CompletableFuture<Object> logEconomyChange(UUID accountId,
-                                                       long amount,
-                                                       long balanceAfter,
-                                                       TransactionType type,
-                                                       String reason) {
+    private CompletableFuture<Void> logEconomyChange(UUID accountId,
+                                                     long amount,
+                                                     long balanceAfter,
+                                                     TransactionType type,
+                                                     String reason) {
         if (!shouldLogTransactions()) {
             return CompletableFuture.completedFuture(null);
         }


### PR DESCRIPTION
## Summary
- ensure economy log writes return `CompletableFuture<Void>` so callers receive the correct type
- keep transaction commit chaining aligned with `CompletionStage<Void>` expectations

## Testing
- mvn clean package *(fails: forbidden from downloading remote dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d90ae9030c8324be98ed202395fbc5