### PR TITLE
Fix CompletableFuture<Void> return types in EconomyServiceImpl

### DIFF
--- a/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/EconomyServiceImpl.java
@@ -348,7 +348,7 @@ public final class EconomyServiceImpl implements EconomyService {
                     }
                     return null;
                 })
-                .thenApply(ignored -> null);
+                .thenApply(ignored -> (Void) null);
     }
 
     private CompletableFuture<Void> logTransactionBatch(Map<UUID, List<PendingLogEntry>> entries,
@@ -529,7 +529,7 @@ public final class EconomyServiceImpl implements EconomyService {
                         markDirtyForTransaction(deltas);
                         deltas.clear();
                     })
-                    .thenApply(ignored -> null)
+                    .thenApply(ignored -> (Void) null)
                     .exceptionallyCompose(EconomyServiceImpl.this::propagateEconomyFailure);
         }
 


### PR DESCRIPTION
## Summary
- ensure logEconomyChange returns a CompletableFuture<Void> by casting the terminal stage
- force the transaction commit chain to resolve to Void to match the interface signature

## Testing
- mvn -q -DskipTests compile *(fails: dependency downloads forbidden by remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d90fab85c88324a63e38352e781279