### PR TITLE
feat: add Nexus health check bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <version>2.17.1</version>
         </dependency>
         <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-retry</artifactId>
             <version>${resilience4j.version}</version>

--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -82,6 +82,7 @@ import com.heneria.nexus.service.core.RewardServiceImpl;
 import com.heneria.nexus.service.core.ShopServiceImpl;
 import com.heneria.nexus.service.core.TimerServiceImpl;
 import com.heneria.nexus.service.core.TeleportServiceImpl;
+import com.heneria.nexus.service.core.HealthCheckService;
 import com.heneria.nexus.service.core.VaultEconomyService;
 import com.heneria.nexus.redis.RedisManager;
 import com.heneria.nexus.redis.RedisService;
@@ -496,6 +497,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.get(ShopService.class).applyCatalog(newBundle.economy().shop());
         serviceRegistry.get(RedisManager.class).applySettings(newBundle.core().redisSettings());
         serviceRegistry.get(HoloService.class).applySettings(newBundle.core().hologramSettings());
+        serviceRegistry.get(HealthCheckService.class).applyConfiguration(newBundle.core());
         serviceRegistry.get(HoloService.class).loadFromConfig();
         if (servicesExposed && !newBundle.core().serviceSettings().exposeBukkitServices()) {
             getServer().getServicesManager().unregisterAll(this);
@@ -1438,6 +1440,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(PersistenceService.class, PersistenceServiceImpl.class);
         serviceRegistry.registerService(ProfileService.class, ProfileServiceImpl.class);
         serviceRegistry.registerService(TeleportService.class, TeleportServiceImpl.class);
+        serviceRegistry.registerService(HealthCheckService.class, HealthCheckService.class);
         serviceRegistry.registerService(QueueService.class, QueueServiceImpl.class);
         serviceRegistry.registerService(TimerService.class, TimerServiceImpl.class);
         serviceRegistry.registerService(RateLimiterService.class, RateLimiterServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/config/CoreConfig.java
+++ b/src/main/java/com/heneria/nexus/config/CoreConfig.java
@@ -15,6 +15,7 @@ import net.kyori.adventure.bossbar.BossBar;
 public final class CoreConfig {
 
     private final String serverMode;
+    private final String serverId;
     private final Locale language;
     private final ZoneId timezone;
     private final ArenaSettings arenaSettings;
@@ -30,8 +31,10 @@ public final class CoreConfig {
     private final HologramSettings hologramSettings;
     private final AnalyticsSettings analyticsSettings;
     private final UiSettings uiSettings;
+    private final HealthCheckSettings healthCheckSettings;
 
     public CoreConfig(String serverMode,
+                      String serverId,
                       Locale language,
                       ZoneId timezone,
                       ArenaSettings arenaSettings,
@@ -46,8 +49,10 @@ public final class CoreConfig {
                       QueueSettings queueSettings,
                       HologramSettings hologramSettings,
                       AnalyticsSettings analyticsSettings,
-                      UiSettings uiSettings) {
+                      UiSettings uiSettings,
+                      HealthCheckSettings healthCheckSettings) {
         this.serverMode = Objects.requireNonNull(serverMode, "serverMode");
+        this.serverId = Objects.requireNonNull(serverId, "serverId");
         this.language = Objects.requireNonNull(language, "language");
         this.timezone = Objects.requireNonNull(timezone, "timezone");
         this.arenaSettings = Objects.requireNonNull(arenaSettings, "arenaSettings");
@@ -63,10 +68,15 @@ public final class CoreConfig {
         this.hologramSettings = Objects.requireNonNull(hologramSettings, "hologramSettings");
         this.analyticsSettings = Objects.requireNonNull(analyticsSettings, "analyticsSettings");
         this.uiSettings = Objects.requireNonNull(uiSettings, "uiSettings");
+        this.healthCheckSettings = Objects.requireNonNull(healthCheckSettings, "healthCheckSettings");
     }
 
     public String serverMode() {
         return serverMode;
+    }
+
+    public String serverId() {
+        return serverId;
     }
 
     public Locale language() {
@@ -127,6 +137,10 @@ public final class CoreConfig {
 
     public UiSettings uiSettings() {
         return uiSettings;
+    }
+
+    public HealthCheckSettings healthCheckSettings() {
+        return healthCheckSettings;
     }
 
     public record BackupSettings(int maxBackupsPerFile) {
@@ -417,6 +431,14 @@ public final class CoreConfig {
         public UiSettings {
             Objects.requireNonNull(titleProfiles, "titleProfiles");
             Objects.requireNonNull(bossBarDefaults, "bossBarDefaults");
+        }
+    }
+
+    public record HealthCheckSettings(boolean enabled, long intervalSeconds) {
+        public HealthCheckSettings {
+            if (intervalSeconds <= 0L) {
+                throw new IllegalArgumentException("intervalSeconds must be > 0");
+            }
         }
     }
 

--- a/src/main/java/com/heneria/nexus/service/core/HealthCheckService.java
+++ b/src/main/java/com/heneria/nexus/service/core/HealthCheckService.java
@@ -1,0 +1,255 @@
+package com.heneria.nexus.service.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heneria.nexus.api.ArenaHandle;
+import com.heneria.nexus.api.ArenaPhase;
+import com.heneria.nexus.api.ArenaService;
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.scheduler.GamePhase;
+import com.heneria.nexus.scheduler.RingScheduler;
+import com.heneria.nexus.service.LifecycleAware;
+import com.heneria.nexus.util.NexusLogger;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Periodically publishes lightweight health information to the Velocity proxy
+ * using plugin messages.
+ */
+public final class HealthCheckService implements LifecycleAware {
+
+    public static final String CHANNEL = "nexus:health";
+    private static final String TASK_ID = "health-check";
+    private static final double DEFAULT_TPS = 20D;
+
+    private final JavaPlugin plugin;
+    private final NexusLogger logger;
+    private final RingScheduler scheduler;
+    private final Optional<ArenaService> arenaService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final AtomicReference<Configuration> configurationRef;
+    private final AtomicReference<Throwable> lastError = new AtomicReference<>();
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final AtomicBoolean channelRegistered = new AtomicBoolean();
+
+    public HealthCheckService(JavaPlugin plugin,
+                              NexusLogger logger,
+                              RingScheduler scheduler,
+                              Optional<ArenaService> arenaService,
+                              CoreConfig coreConfig) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+        this.arenaService = Objects.requireNonNull(arenaService, "arenaService");
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        this.configurationRef = new AtomicReference<>(toConfiguration(coreConfig));
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        running.set(true);
+        registerChannel();
+        reschedule(configurationRef.get());
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        running.set(false);
+        scheduler.unregisterTask(TASK_ID);
+        unregisterChannel();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public boolean isHealthy() {
+        if (!configurationRef.get().enabled()) {
+            return LifecycleAware.super.isHealthy();
+        }
+        return channelRegistered.get() && lastError.get() == null && LifecycleAware.super.isHealthy();
+    }
+
+    @Override
+    public Optional<Throwable> lastError() {
+        return Optional.ofNullable(lastError.get());
+    }
+
+    /**
+     * Applies a freshly reloaded configuration.
+     */
+    public void applyConfiguration(CoreConfig coreConfig) {
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        Configuration newConfiguration = toConfiguration(coreConfig);
+        configurationRef.set(newConfiguration);
+        if (!running.get()) {
+            return;
+        }
+        reschedule(newConfiguration);
+    }
+
+    private void registerChannel() {
+        try {
+            plugin.getServer().getMessenger().registerOutgoingPluginChannel(plugin, CHANNEL);
+            channelRegistered.set(true);
+        } catch (Throwable throwable) {
+            channelRegistered.set(false);
+            lastError.set(throwable);
+            logger.warn("Impossible d'enregistrer le canal de health check", throwable);
+        }
+    }
+
+    private void unregisterChannel() {
+        try {
+            plugin.getServer().getMessenger().unregisterOutgoingPluginChannel(plugin, CHANNEL);
+        } catch (Throwable throwable) {
+            logger.warn("Erreur lors de la désinscription du canal de health check", throwable);
+        } finally {
+            channelRegistered.set(false);
+        }
+    }
+
+    private void reschedule(Configuration configuration) {
+        scheduler.unregisterTask(TASK_ID);
+        if (!configuration.enabled()) {
+            logger.debug(() -> "HealthCheck désactivé — aucun ping ne sera envoyé");
+            return;
+        }
+        scheduler.registerTask(TASK_ID, configuration.intervalTicks(), EnumSet.allOf(GamePhase.class), this::publishSnapshot);
+    }
+
+    private void publishSnapshot() {
+        Configuration configuration = configurationRef.get();
+        if (!configuration.enabled() || !plugin.isEnabled()) {
+            return;
+        }
+        if (!channelRegistered.get()) {
+            registerChannel();
+            if (!channelRegistered.get()) {
+                return;
+            }
+        }
+        ServerSnapshot snapshot = new ServerSnapshot(
+                configuration.serverId(),
+                plugin.getServer().getOnlinePlayers().size(),
+                plugin.getServer().getMaxPlayers(),
+                resolveAvailability().name(),
+                roundTps(queryCurrentTps()));
+        byte[] payload;
+        try {
+            payload = encode(snapshot);
+        } catch (IOException exception) {
+            lastError.set(exception);
+            logger.warn("Impossible de sérialiser le health check", exception);
+            return;
+        }
+        try {
+            plugin.getServer().sendPluginMessage(plugin, CHANNEL, payload);
+            lastError.set(null);
+        } catch (Throwable throwable) {
+            lastError.set(throwable);
+            logger.warn("Impossible d'envoyer le PluginMessage de health check", throwable);
+        }
+    }
+
+    private byte[] encode(ServerSnapshot snapshot) throws IOException {
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw exception;
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream(json.length() + 4);
+        try (DataOutputStream data = new DataOutputStream(output)) {
+            data.writeUTF(json);
+        }
+        return output.toByteArray();
+    }
+
+    private ServerAvailability resolveAvailability() {
+        return arenaService.map(this::resolveFromArenas).orElse(ServerAvailability.UNKNOWN);
+    }
+
+    private ServerAvailability resolveFromArenas(ArenaService service) {
+        Collection<ArenaHandle> arenas = service.instances();
+        if (arenas.isEmpty()) {
+            return ServerAvailability.LOBBY;
+        }
+        boolean hasStarting = false;
+        boolean hasPlaying = false;
+        boolean hasEnding = false;
+        for (ArenaHandle handle : arenas) {
+            ArenaPhase phase = handle.phase();
+            if (phase == null) {
+                continue;
+            }
+            switch (phase) {
+                case STARTING -> hasStarting = true;
+                case PLAYING, SCORED -> hasPlaying = true;
+                case RESET, END -> hasEnding = true;
+                default -> {
+                    // noop
+                }
+            }
+        }
+        if (hasPlaying) {
+            return ServerAvailability.IN_GAME;
+        }
+        if (hasEnding) {
+            return ServerAvailability.ENDING;
+        }
+        if (hasStarting) {
+            return ServerAvailability.STARTING;
+        }
+        return ServerAvailability.LOBBY;
+    }
+
+    private double queryCurrentTps() {
+        try {
+            double[] tpsValues = plugin.getServer().getTPS();
+            if (tpsValues.length == 0) {
+                return DEFAULT_TPS;
+            }
+            double value = tpsValues[0];
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                return DEFAULT_TPS;
+            }
+            return value;
+        } catch (NoSuchMethodError | UnsupportedOperationException ignored) {
+            return DEFAULT_TPS;
+        }
+    }
+
+    private double roundTps(double tps) {
+        return Math.round(tps * 100D) / 100D;
+    }
+
+    private Configuration toConfiguration(CoreConfig coreConfig) {
+        CoreConfig.HealthCheckSettings settings = coreConfig.healthCheckSettings();
+        long intervalTicks = Math.max(1L, settings.intervalSeconds() * 20L);
+        return new Configuration(settings.enabled(), coreConfig.serverId(), intervalTicks);
+    }
+
+    private record Configuration(boolean enabled, String serverId, long intervalTicks) {
+    }
+
+    private record ServerSnapshot(String serverId, int playerCount, int maxPlayers, String status, double tps) {
+    }
+
+    private enum ServerAvailability {
+        LOBBY,
+        STARTING,
+        IN_GAME,
+        ENDING,
+        UNKNOWN
+    }
+}

--- a/src/main/java/com/heneria/nexusproxy/velocity/NexusProxyPlugin.java
+++ b/src/main/java/com/heneria/nexusproxy/velocity/NexusProxyPlugin.java
@@ -1,0 +1,153 @@
+package com.heneria.nexusproxy.velocity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heneria.nexusproxy.velocity.command.NexusProxyCommand;
+import com.heneria.nexusproxy.velocity.health.ServerAvailability;
+import com.heneria.nexusproxy.velocity.health.ServerStatusRegistry;
+import com.heneria.nexusproxy.velocity.health.ServerStatusSnapshot;
+import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.command.CommandMeta;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.event.player.PluginMessageEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.scheduler.ScheduledTask;
+import com.velocitypowered.api.util.Identifier;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+
+@Plugin(id = "nexusproxy", name = "Nexus Proxy", version = "0.1.0-SNAPSHOT", authors = {"Heneria"})
+public final class NexusProxyPlugin {
+
+    private static final Identifier HEALTH_CHANNEL = Identifier.from("nexus", "health");
+    private static final Duration STATUS_TIMEOUT = Duration.ofSeconds(15);
+
+    private final ProxyServer proxyServer;
+    private final Logger logger;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ServerStatusRegistry statusRegistry = new ServerStatusRegistry();
+
+    private ScheduledTask cleanupTask;
+
+    @Inject
+    public NexusProxyPlugin(ProxyServer proxyServer, Logger logger) {
+        this.proxyServer = Objects.requireNonNull(proxyServer, "proxyServer");
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    @Subscribe
+    public void onProxyInitialize(ProxyInitializeEvent event) {
+        proxyServer.getChannelRegistrar().register(HEALTH_CHANNEL);
+        registerCommands();
+        cleanupTask = proxyServer.getScheduler().buildTask(this, () ->
+                        statusRegistry.markExpired(STATUS_TIMEOUT, Instant.now()))
+                .delay(STATUS_TIMEOUT)
+                .repeat(STATUS_TIMEOUT.dividedBy(3))
+                .schedule();
+        logger.info("Canal nexus:health enregistré");
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        proxyServer.getChannelRegistrar().unregister(HEALTH_CHANNEL);
+        if (cleanupTask != null) {
+            cleanupTask.cancel();
+            cleanupTask = null;
+        }
+        logger.info("NexusProxy arrêté proprement");
+    }
+
+    @Subscribe
+    public void onPluginMessage(PluginMessageEvent event) {
+        if (!event.getIdentifier().equals(HEALTH_CHANNEL)) {
+            return;
+        }
+        event.setResult(PluginMessageEvent.ForwardResult.handled());
+        if (!(event.getSource() instanceof ServerConnection connection)) {
+            logger.warn("PluginMessage nexus:health ignoré (source inconnue)");
+            return;
+        }
+        try {
+            HealthPayload payload = decode(event.getData());
+            if (payload == null || payload.serverId() == null || payload.serverId().isBlank()) {
+                logger.warn("PluginMessage nexus:health sans server_id depuis {}", connection.getServerInfo().getName());
+                return;
+            }
+            String serverId = payload.serverId().trim();
+            String connectionName = connection.getServerInfo().getName();
+            if (!connectionName.equalsIgnoreCase(serverId)) {
+                logger.warn("Incohérence server_id={} depuis {}", serverId, connectionName);
+            }
+            Instant now = Instant.now();
+            ServerAvailability availability = parseAvailability(payload.status());
+            ServerStatusSnapshot snapshot = new ServerStatusSnapshot(
+                    serverId,
+                    Math.max(0, payload.playerCount()),
+                    Math.max(0, payload.maxPlayers()),
+                    availability,
+                    Math.max(0D, payload.tps()),
+                    now);
+            statusRegistry.update(snapshot);
+        } catch (IOException exception) {
+            logger.warn("PluginMessage nexus:health invalide reçu depuis {}", connectionName(event), exception);
+        }
+    }
+
+    public ServerStatusRegistry statusRegistry() {
+        return statusRegistry;
+    }
+
+    private HealthPayload decode(byte[] data) throws IOException {
+        try (DataInputStream input = new DataInputStream(new ByteArrayInputStream(data))) {
+            String json = input.readUTF();
+            return objectMapper.readValue(json, HealthPayload.class);
+        }
+    }
+
+    private void registerCommands() {
+        CommandManager manager = proxyServer.getCommandManager();
+        CommandMeta meta = manager.metaBuilder("nexusproxy")
+                .plugin(this)
+                .aliases("nxproxy")
+                .build();
+        manager.register(meta, new NexusProxyCommand(statusRegistry));
+    }
+
+    private ServerAvailability parseAvailability(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return ServerAvailability.UNKNOWN;
+        }
+        String normalized = raw.trim().toUpperCase(Locale.ROOT);
+        try {
+            return ServerAvailability.valueOf(normalized);
+        } catch (IllegalArgumentException exception) {
+            logger.warn("Statut d'arène inconnu reçu: {}", raw);
+            return ServerAvailability.UNKNOWN;
+        }
+    }
+
+    private String connectionName(PluginMessageEvent event) {
+        if (event.getSource() instanceof ServerConnection connection) {
+            return connection.getServerInfo().getName();
+        }
+        return "<source inconnue>";
+    }
+
+    private record HealthPayload(@JsonProperty("server_id") String serverId,
+                                 @JsonProperty("player_count") int playerCount,
+                                 @JsonProperty("max_players") int maxPlayers,
+                                 @JsonProperty("status") String status,
+                                 @JsonProperty("tps") double tps) {
+    }
+}

--- a/src/main/java/com/heneria/nexusproxy/velocity/command/NexusProxyCommand.java
+++ b/src/main/java/com/heneria/nexusproxy/velocity/command/NexusProxyCommand.java
@@ -1,0 +1,65 @@
+package com.heneria.nexusproxy.velocity.command;
+
+import com.heneria.nexusproxy.velocity.health.ServerAvailability;
+import com.heneria.nexusproxy.velocity.health.ServerStatusRegistry;
+import com.heneria.nexusproxy.velocity.health.ServerStatusSnapshot;
+import com.velocitypowered.api.command.SimpleCommand;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Objects;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Simple administrative command displaying the health of Nexus servers.
+ */
+public final class NexusProxyCommand implements SimpleCommand {
+
+    private final ServerStatusRegistry registry;
+
+    public NexusProxyCommand(ServerStatusRegistry registry) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        String[] arguments = invocation.arguments();
+        if (arguments.length == 0 || "status".equalsIgnoreCase(arguments[0])) {
+            sendStatus(invocation.source());
+            return;
+        }
+        invocation.source().sendMessage(Component.text("Usage: /nexusproxy status", NamedTextColor.RED));
+    }
+
+    private void sendStatus(com.velocitypowered.api.command.CommandSource source) {
+        Collection<ServerStatusSnapshot> statuses = registry.snapshot();
+        source.sendMessage(Component.text("=== Serveurs Nexus ===", NamedTextColor.GOLD));
+        if (statuses.isEmpty()) {
+            source.sendMessage(Component.text("Aucun ping reçu. Tous les serveurs sont considérés disponibles.",
+                    NamedTextColor.GRAY));
+            return;
+        }
+        for (ServerStatusSnapshot snapshot : statuses) {
+            NamedTextColor color = colorFor(snapshot.availability());
+            Component line = Component.text(snapshot.serverId() + ": ", NamedTextColor.WHITE)
+                    .append(Component.text(snapshot.availability().name(), color))
+                    .append(Component.text(" — ", NamedTextColor.DARK_GRAY))
+                    .append(Component.text(snapshot.playerCount() + "/" + snapshot.maxPlayers() + " joueurs",
+                            NamedTextColor.GRAY))
+                    .append(Component.text(" — ", NamedTextColor.DARK_GRAY))
+                    .append(Component.text(String.format(Locale.ROOT, "TPS %.2f", snapshot.tps()), NamedTextColor.AQUA));
+            source.sendMessage(line);
+        }
+    }
+
+    private NamedTextColor colorFor(ServerAvailability availability) {
+        return switch (availability) {
+            case LOBBY -> NamedTextColor.GREEN;
+            case STARTING -> NamedTextColor.YELLOW;
+            case IN_GAME -> NamedTextColor.RED;
+            case ENDING -> NamedTextColor.GOLD;
+            case OFFLINE -> NamedTextColor.DARK_RED;
+            case UNKNOWN -> NamedTextColor.GRAY;
+        };
+    }
+}

--- a/src/main/java/com/heneria/nexusproxy/velocity/health/ServerAvailability.java
+++ b/src/main/java/com/heneria/nexusproxy/velocity/health/ServerAvailability.java
@@ -1,0 +1,24 @@
+package com.heneria.nexusproxy.velocity.health;
+
+/**
+ * Enumerates the different availability states reported by Nexus servers.
+ */
+public enum ServerAvailability {
+    LOBBY,
+    STARTING,
+    IN_GAME,
+    ENDING,
+    UNKNOWN,
+    OFFLINE;
+
+    /**
+     * Returns {@code true} when the server can accept additional players.
+     */
+    public boolean isJoinable(int playerCount, int maxPlayers) {
+        return switch (this) {
+            case LOBBY, STARTING -> playerCount < maxPlayers;
+            case UNKNOWN -> true;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/com/heneria/nexusproxy/velocity/health/ServerStatusRegistry.java
+++ b/src/main/java/com/heneria/nexusproxy/velocity/health/ServerStatusRegistry.java
@@ -1,0 +1,76 @@
+package com.heneria.nexusproxy.velocity.health;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe registry storing health information for every Nexus backend.
+ */
+public final class ServerStatusRegistry {
+
+    private final ConcurrentHashMap<String, ServerStatusSnapshot> statuses = new ConcurrentHashMap<>();
+
+    public void update(ServerStatusSnapshot snapshot) {
+        statuses.put(snapshot.serverId(), snapshot);
+    }
+
+    public Optional<ServerStatusSnapshot> get(String serverId) {
+        if (serverId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(statuses.get(serverId));
+    }
+
+    public Collection<ServerStatusSnapshot> snapshot() {
+        List<ServerStatusSnapshot> copy = new ArrayList<>(statuses.values());
+        copy.sort(Comparator.comparing(ServerStatusSnapshot::serverId));
+        return List.copyOf(copy);
+    }
+
+    public boolean isAcceptingPlayers(String serverId) {
+        return get(serverId).map(ServerStatusSnapshot::canAcceptPlayers).orElse(true);
+    }
+
+    public Optional<String> firstAvailable(Collection<String> candidateIds) {
+        if (candidateIds == null || candidateIds.isEmpty()) {
+            return Optional.empty();
+        }
+        for (String candidate : candidateIds) {
+            if (isAcceptingPlayers(candidate)) {
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public void markExpired(Duration timeout, Instant now) {
+        if (timeout.isZero() || timeout.isNegative()) {
+            return;
+        }
+        for (Map.Entry<String, ServerStatusSnapshot> entry : statuses.entrySet()) {
+            ServerStatusSnapshot snapshot = entry.getValue();
+            if (snapshot == null) {
+                continue;
+            }
+            Duration age = Duration.between(snapshot.lastUpdate(), now);
+            if (age.compareTo(timeout) > 0) {
+                statuses.compute(entry.getKey(), (key, existing) -> {
+                    if (existing == null) {
+                        return null;
+                    }
+                    if (Duration.between(existing.lastUpdate(), now).compareTo(timeout) > 0) {
+                        return existing.markOffline(now);
+                    }
+                    return existing;
+                });
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexusproxy/velocity/health/ServerStatusSnapshot.java
+++ b/src/main/java/com/heneria/nexusproxy/velocity/health/ServerStatusSnapshot.java
@@ -1,0 +1,38 @@
+package com.heneria.nexusproxy.velocity.health;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Immutable snapshot describing the health of a Nexus backend server.
+ */
+public record ServerStatusSnapshot(String serverId,
+                                   int playerCount,
+                                   int maxPlayers,
+                                   ServerAvailability availability,
+                                   double tps,
+                                   Instant lastUpdate) {
+
+    public ServerStatusSnapshot {
+        Objects.requireNonNull(serverId, "serverId");
+        Objects.requireNonNull(availability, "availability");
+        Objects.requireNonNull(lastUpdate, "lastUpdate");
+        if (maxPlayers < 0) {
+            throw new IllegalArgumentException("maxPlayers must be >= 0");
+        }
+        if (playerCount < 0) {
+            throw new IllegalArgumentException("playerCount must be >= 0");
+        }
+    }
+
+    public boolean canAcceptPlayers() {
+        return availability.isJoinable(playerCount, maxPlayers);
+    }
+
+    public ServerStatusSnapshot markOffline(Instant now) {
+        if (availability == ServerAvailability.OFFLINE) {
+            return this;
+        }
+        return new ServerStatusSnapshot(serverId, 0, maxPlayers, ServerAvailability.OFFLINE, 0D, now);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,9 +3,10 @@
 #  PaperMC 1.21.x — Java 21
 # =============================================
 
-config-version: 4
+config-version: 5
 
 server:
+  id: "nexus-1"
   mode: "nexus"
   language: "fr"
   timezone: "Europe/Paris"
@@ -111,6 +112,10 @@ queue:
   vip_weight: 1
   target_server: "nexus-1"
   hub_group: "hub"
+
+healthcheck:
+  enabled: true
+  interval_seconds: 5
 
 analytics:
   outbox:

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "nexusproxy",
+  "name": "Nexus Proxy",
+  "version": "${project.version}",
+  "main": "com.heneria.nexusproxy.velocity.NexusProxyPlugin",
+  "authors": ["Heneria"],
+  "dependencies": []
+}


### PR DESCRIPTION
## Summary
- add configurable server identifier and health check settings to the Nexus core config
- introduce a RingScheduler-driven HealthCheckService that publishes nexus:health plugin messages
- implement a Velocity-side plugin to track server status, expose a /nexusproxy status command, and handle timeouts

## Testing
- `mvn -q -DskipTests package` *(fails: Maven cannot download Paper/Velocity artifacts from papermc-repo due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9346f36d48324ae3345722548e3e3