### PR TITLE
Implement timezone-aware first win bonus and daily analytics fixes

### DIFF
--- a/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsAggregatorService.java
+++ b/src/main/java/com/heneria/nexus/analytics/daily/DailyStatsAggregatorService.java
@@ -31,8 +31,6 @@ import org.bukkit.scheduler.BukkitTask;
  */
 public final class DailyStatsAggregatorService implements LifecycleAware {
 
-    private static final ZoneId DEFAULT_ZONE = ZoneId.systemDefault();
-
     private static final String MATCHES_COUNT_SQL = """
             SELECT COUNT(*)
             FROM nexus_matches
@@ -84,8 +82,9 @@ public final class DailyStatsAggregatorService implements LifecycleAware {
         this.dbProvider = Objects.requireNonNull(dbProvider, "dbProvider");
         this.repository = Objects.requireNonNull(repository, "repository");
         this.ioExecutor = Objects.requireNonNull(executorManager, "executorManager").io();
-        this.zoneId = DEFAULT_ZONE;
-        this.enabled = Objects.requireNonNull(coreConfig, "coreConfig").databaseSettings().enabled();
+        CoreConfig config = Objects.requireNonNull(coreConfig, "coreConfig");
+        this.zoneId = Objects.requireNonNull(config.timezone(), "timezone");
+        this.enabled = config.databaseSettings().enabled();
     }
 
     @Override

--- a/src/main/java/com/heneria/nexus/api/FirstWinBonusService.java
+++ b/src/main/java/com/heneria/nexus/api/FirstWinBonusService.java
@@ -1,0 +1,41 @@
+package com.heneria.nexus.api;
+
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.config.EconomyConfig;
+import com.heneria.nexus.service.LifecycleAware;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Distributes the daily first win bonus while enforcing uniqueness per player.
+ */
+public interface FirstWinBonusService extends LifecycleAware {
+
+    /**
+     * Attempts to grant the first win bonus for the current day.
+     *
+     * @param playerId unique identifier of the rewarded player
+     * @return stage resolving to {@code true} when the bonus has been granted, {@code false} otherwise
+     */
+    default CompletionStage<Boolean> grantFirstWinBonus(UUID playerId) {
+        return grantFirstWinBonus(playerId, Instant.now());
+    }
+
+    /**
+     * Attempts to grant the first win bonus for the day containing the provided instant.
+     *
+     * @param playerId unique identifier of the rewarded player
+     * @param referenceInstant instant used to determine the applicable day
+     * @return stage resolving to {@code true} when the bonus has been granted, {@code false} otherwise
+     */
+    CompletionStage<Boolean> grantFirstWinBonus(UUID playerId, Instant referenceInstant);
+
+    /**
+     * Applies the latest configuration controlling the bonus amount and timezone.
+     *
+     * @param coreConfig core configuration providing the active timezone
+     * @param economyConfig economy configuration providing the bonus amount
+     */
+    void applySettings(CoreConfig coreConfig, EconomyConfig economyConfig);
+}

--- a/src/main/java/com/heneria/nexus/listener/FirstWinBonusListener.java
+++ b/src/main/java/com/heneria/nexus/listener/FirstWinBonusListener.java
@@ -1,0 +1,65 @@
+package com.heneria.nexus.listener;
+
+import com.heneria.nexus.api.FirstWinBonusService;
+import com.heneria.nexus.api.events.NexusArenaEndEvent;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.scoreboard.Team;
+
+/**
+ * Listens to arena completion events to grant the daily first win bonus.
+ */
+public final class FirstWinBonusListener implements Listener {
+
+    private final NexusLogger logger;
+    private final FirstWinBonusService firstWinBonusService;
+
+    public FirstWinBonusListener(NexusLogger logger, FirstWinBonusService firstWinBonusService) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.firstWinBonusService = Objects.requireNonNull(firstWinBonusService, "firstWinBonusService");
+    }
+
+    @EventHandler
+    public void onArenaEnd(NexusArenaEndEvent event) {
+        Team winner = event.getWinner();
+        if (winner == null) {
+            return;
+        }
+        Set<String> entries = winner.getEntries();
+        if (entries.isEmpty()) {
+            return;
+        }
+        entries.stream()
+                .filter(entry -> entry != null && !entry.isBlank())
+                .map(this::resolvePlayerId)
+                .filter(Objects::nonNull)
+                .forEach(this::grantBonusSafely);
+    }
+
+    private UUID resolvePlayerId(String scoreboardEntry) {
+        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(scoreboardEntry);
+        UUID uniqueId = offlinePlayer.getUniqueId();
+        if (uniqueId == null) {
+            logger.debug(() -> "Entrée de scoreboard sans identifiant: " + scoreboardEntry);
+        }
+        return uniqueId;
+    }
+
+    private void grantBonusSafely(UUID playerId) {
+        firstWinBonusService.grantFirstWinBonus(playerId).whenComplete((granted, throwable) -> {
+            if (throwable != null) {
+                logger.warn("Échec du bonus première victoire pour " + playerId, throwable);
+                return;
+            }
+            if (Boolean.TRUE.equals(granted)) {
+                logger.debug(() -> "Bonus première victoire appliqué pour " + playerId);
+            }
+        });
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/FirstWinBonusServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/FirstWinBonusServiceImpl.java
@@ -1,0 +1,90 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.api.EconomyService;
+import com.heneria.nexus.api.FirstWinBonusService;
+import com.heneria.nexus.api.RewardService;
+import com.heneria.nexus.config.CoreConfig;
+import com.heneria.nexus.config.EconomyConfig;
+import com.heneria.nexus.util.NexusLogger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Default implementation orchestrating the daily first win bonus.
+ */
+public final class FirstWinBonusServiceImpl implements FirstWinBonusService {
+
+    private static final String REWARD_KEY_PREFIX = "first_win_bonus:";
+    private static final String BONUS_REASON = "Bonus première victoire";
+
+    private final NexusLogger logger;
+    private final RewardService rewardService;
+    private final EconomyService economyService;
+    private final AtomicReference<Settings> settings = new AtomicReference<>();
+
+    public FirstWinBonusServiceImpl(NexusLogger logger,
+                                    RewardService rewardService,
+                                    EconomyService economyService,
+                                    CoreConfig coreConfig,
+                                    EconomyConfig economyConfig) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.rewardService = Objects.requireNonNull(rewardService, "rewardService");
+        this.economyService = Objects.requireNonNull(economyService, "economyService");
+        applySettings(coreConfig, economyConfig);
+    }
+
+    @Override
+    public CompletionStage<Boolean> grantFirstWinBonus(UUID playerId, Instant referenceInstant) {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(referenceInstant, "referenceInstant");
+        Settings snapshot = settings.get();
+        if (snapshot == null) {
+            return CompletableFuture.failedFuture(new IllegalStateException("Bonus settings not initialized"));
+        }
+        if (snapshot.bonusAmount() <= 0L) {
+            return CompletableFuture.completedFuture(false);
+        }
+        LocalDate day = referenceInstant.atZone(snapshot.zoneId()).toLocalDate();
+        String rewardKey = REWARD_KEY_PREFIX + day;
+        long amount = snapshot.bonusAmount();
+        return rewardService.claimReward(playerId, rewardKey, () -> creditBonus(playerId, amount, day))
+                .thenApply(claimed -> {
+                    if (claimed) {
+                        logger.debug(() -> "Bonus de première victoire accordé à " + playerId + " pour " + day);
+                    }
+                    return claimed;
+                });
+    }
+
+    @Override
+    public void applySettings(CoreConfig coreConfig, EconomyConfig economyConfig) {
+        Objects.requireNonNull(coreConfig, "coreConfig");
+        Objects.requireNonNull(economyConfig, "economyConfig");
+        ZoneId zoneId = Objects.requireNonNull(coreConfig.timezone(), "timezone");
+        EconomyConfig.CoinsSettings coins = Objects.requireNonNull(economyConfig.coins(), "coins");
+        long amount = coins.firstWinBonus();
+        settings.set(new Settings(zoneId, amount));
+        logger.debug(() -> "Configuration bonus première victoire -> zone=" + zoneId + " montant=" + amount);
+    }
+
+    private void creditBonus(UUID playerId, long amount, LocalDate day) {
+        try {
+            economyService.credit(playerId, amount, BONUS_REASON).toCompletableFuture().join();
+        } catch (RuntimeException exception) {
+            logger.error("Échec du crédit du bonus première victoire pour " + playerId + " (" + day + ")", exception);
+            throw exception;
+        }
+    }
+
+    private record Settings(ZoneId zoneId, long bonusAmount) {
+        private Settings {
+            Objects.requireNonNull(zoneId, "zoneId");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure DailyStatsAggregatorService derives its ZoneId from the core configuration
- add a FirstWinBonusService that claims per-day rewards via RewardService and credits the configured bonus
- hook the new service into arena end events, update service wiring, and use a deterministic timezone fallback for admin displays

## Testing
- mvn -q -DskipTests package *(fails: dependency download from papermc repo is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9470a99388324a2d8cb308714a6ea