### PR TITLE
Implement Redis degraded mode failover

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -501,6 +501,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.get(ShopService.class).applyRateLimitSettings(newBundle.core().rateLimitSettings());
         serviceRegistry.get(ShopService.class).applyCatalog(newBundle.economy().shop());
         serviceRegistry.get(RedisManager.class).applySettings(newBundle.core().redisSettings());
+        serviceRegistry.get(RedisManager.class).applyDegradedModeSettings(newBundle.core().degradedModeSettings());
         serviceRegistry.get(HoloService.class).applySettings(newBundle.core().hologramSettings());
         serviceRegistry.get(HealthCheckService.class).applyConfiguration(newBundle.core());
         serviceRegistry.get(FirstWinBonusService.class).applySettings(newBundle.core(), newBundle.economy());
@@ -830,7 +831,7 @@ public final class NexusPlugin extends JavaPlugin {
         String stateKey = switch (state) {
             case CONNECTED -> "admin.redis.status.state.connected";
             case CONNECTING -> "admin.redis.status.state.connecting";
-            case FAILED -> "admin.redis.status.state.failed";
+            case DEGRADED -> "admin.redis.status.state.degraded";
             case DISABLED -> "admin.redis.status.state.disabled";
         };
         messageFacade.prefix(sender).ifPresent(sender::sendMessage);
@@ -848,7 +849,7 @@ public final class NexusPlugin extends JavaPlugin {
                 Placeholder.unparsed("waiters", Integer.toString(metrics.waiters()))));
         diagnostics.lastError().ifPresent(error ->
                 messageFacade.send(sender, "admin.redis.status.last_error", Placeholder.unparsed("error", error)));
-        if (state == RedisService.ConnectionState.FAILED) {
+        if (state == RedisService.ConnectionState.DEGRADED) {
             messageFacade.send(sender, "admin.redis.status.retry");
         }
     }

--- a/src/main/java/com/heneria/nexus/redis/RedisManager.java
+++ b/src/main/java/com/heneria/nexus/redis/RedisManager.java
@@ -27,11 +27,17 @@ public final class RedisManager {
         this.redisService = Objects.requireNonNull(redisService, "redisService");
         Objects.requireNonNull(coreConfig, "coreConfig");
         redisService.applySettings(coreConfig.redisSettings());
+        redisService.applyDegradedModeSettings(coreConfig.degradedModeSettings());
     }
 
     public void applySettings(CoreConfig.RedisSettings settings) {
         Objects.requireNonNull(settings, "settings");
         redisService.applySettings(settings);
+    }
+
+    public void applyDegradedModeSettings(CoreConfig.DegradedModeSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        redisService.applyDegradedModeSettings(settings);
     }
 
     public boolean isEnabled() {

--- a/src/main/java/com/heneria/nexus/service/core/QueueServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/QueueServiceImpl.java
@@ -324,6 +324,13 @@ public final class QueueServiceImpl implements QueueService {
             crossShardFallbackLogged.set(false);
             return false;
         }
+        RedisService.ConnectionState redisState = redisService.state();
+        if (redisState == RedisService.ConnectionState.DEGRADED) {
+            if (crossShardFallbackLogged.compareAndSet(false, true)) {
+                logger.warn("Redis en mode dégradé — file d'attente locale activée.");
+            }
+            return false;
+        }
         if (!redisService.isOperational()) {
             if (crossShardFallbackLogged.compareAndSet(false, true)) {
                 logger.warn("Redis indisponible — bascule vers la file locale pour le matchmaking.");

--- a/src/main/resources/lang/messages_fr.yml
+++ b/src/main/resources/lang/messages_fr.yml
@@ -105,8 +105,13 @@ admin:
       state:
         connected: "<green>Connecté</green>"
         connecting: "<yellow>Connexion...</yellow>"
-        failed: "<red>Échec de la connexion</red>"
+        degraded: "<yellow>Mode dégradé</yellow>"
         disabled: "<gray>Désactivé</gray>"
+
+alerts:
+  redis:
+    degraded: "<red>Redis hors ligne</red> <dark_gray>:</dark_gray> <yellow>mode dégradé activé</yellow>"
+    recovered: "<green>Redis reconnecté</green> <dark_gray>:</dark_gray> <gray>retour au mode normal</gray>"
 
 titles:
   round_start:


### PR DESCRIPTION
## Summary
- add a Redis connection state machine with a degraded mode, exponential reconnect backoff, and administrator notifications
- update the queue service and admin command to react to degraded mode and fall back to local matchmaking gracefully
- expose degraded mode configuration updates through the Redis manager and add localized alert strings

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads blocked with HTTP 403 from repo.papermc.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d95b52dad08324ab7d377f58d1f11e