### PR TITLE
feat: add map blueprint loading and validation

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -67,6 +67,7 @@ import com.heneria.nexus.api.ArenaService;
 import com.heneria.nexus.api.EconomyService;
 import com.heneria.nexus.api.FirstWinBonusService;
 import com.heneria.nexus.api.MapService;
+import com.heneria.nexus.api.MapValidatorService;
 import com.heneria.nexus.api.ProfileService;
 import com.heneria.nexus.api.RewardService;
 import com.heneria.nexus.api.QueueService;
@@ -77,6 +78,7 @@ import com.heneria.nexus.service.core.ArenaServiceImpl;
 import com.heneria.nexus.service.core.EconomyServiceImpl;
 import com.heneria.nexus.service.core.FirstWinBonusServiceImpl;
 import com.heneria.nexus.service.core.MapServiceImpl;
+import com.heneria.nexus.service.core.MapValidatorServiceImpl;
 import com.heneria.nexus.service.core.PersistenceService;
 import com.heneria.nexus.service.core.PersistenceServiceImpl;
 import com.heneria.nexus.service.core.ProfileServiceImpl;
@@ -1430,6 +1432,7 @@ public final class NexusPlugin extends JavaPlugin {
 
     private void registerServices() {
         serviceRegistry.registerService(RingScheduler.class, RingScheduler.class);
+        serviceRegistry.registerService(MapValidatorService.class, MapValidatorServiceImpl.class);
         serviceRegistry.registerService(MapService.class, MapServiceImpl.class);
         serviceRegistry.registerService(ProfileRepository.class, ProfileRepositoryImpl.class);
         serviceRegistry.registerService(PlayerClassRepository.class, PlayerClassRepositoryImpl.class);

--- a/src/main/java/com/heneria/nexus/api/MapDefinition.java
+++ b/src/main/java/com/heneria/nexus/api/MapDefinition.java
@@ -1,5 +1,6 @@
 package com.heneria.nexus.api;
 
+import com.heneria.nexus.api.map.MapBlueprint;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
@@ -11,8 +12,13 @@ import java.util.Objects;
  * @param displayName human readable map name
  * @param folder root folder containing the map resources
  * @param metadata additional metadata stored alongside the map
+ * @param blueprint structured configuration extracted from {@code map.yml}
  */
-public record MapDefinition(String id, String displayName, Path folder, Map<String, Object> metadata) {
+public record MapDefinition(String id,
+                            String displayName,
+                            Path folder,
+                            Map<String, Object> metadata,
+                            MapBlueprint blueprint) {
 
     /**
      * Validates constructor arguments.
@@ -22,5 +28,6 @@ public record MapDefinition(String id, String displayName, Path folder, Map<Stri
         Objects.requireNonNull(displayName, "displayName");
         Objects.requireNonNull(folder, "folder");
         Objects.requireNonNull(metadata, "metadata");
+        Objects.requireNonNull(blueprint, "blueprint");
     }
 }

--- a/src/main/java/com/heneria/nexus/api/MapValidatorService.java
+++ b/src/main/java/com/heneria/nexus/api/MapValidatorService.java
@@ -1,0 +1,19 @@
+package com.heneria.nexus.api;
+
+import com.heneria.nexus.api.map.MapBlueprint;
+
+/**
+ * Service responsible for validating loaded maps.
+ */
+public interface MapValidatorService {
+
+    /**
+     * Validates the provided map definition and returns a report describing
+     * potential issues.
+     *
+     * @param definition high level definition of the map
+     * @param blueprint  structured configuration extracted from {@code map.yml}
+     * @return validation report describing warnings and blocking errors
+     */
+    ValidationReport validate(MapDefinition definition, MapBlueprint blueprint);
+}

--- a/src/main/java/com/heneria/nexus/api/map/MapBlueprint.java
+++ b/src/main/java/com/heneria/nexus/api/map/MapBlueprint.java
@@ -1,0 +1,128 @@
+package com.heneria.nexus.api.map;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Structured representation of the {@code map.yml} file associated with a map.
+ */
+public record MapBlueprint(boolean configurationPresent,
+                           MapAsset asset,
+                           MapRules rules,
+                           List<MapTeam> teams,
+                           List<MapRegion> regions,
+                           List<MapInteractive> interactives,
+                           Map<String, Object> extras) {
+
+    /**
+     * Creates an empty blueprint signalling that {@code map.yml} is missing.
+     *
+     * @return blueprint without configuration content
+     */
+    public static MapBlueprint missingConfiguration() {
+        return new MapBlueprint(false, null, null, List.of(), List.of(), List.of(), Map.of());
+    }
+
+    /**
+     * Validates constructor arguments.
+     */
+    public MapBlueprint {
+        Objects.requireNonNull(teams, "teams");
+        Objects.requireNonNull(regions, "regions");
+        Objects.requireNonNull(interactives, "interactives");
+        Objects.requireNonNull(extras, "extras");
+    }
+
+    /**
+     * Description of the schematic/world asset used by the map.
+     */
+    public record MapAsset(String file, Map<String, Object> properties) {
+
+        public MapAsset {
+            Objects.requireNonNull(properties, "properties");
+            properties = Map.copyOf(properties);
+        }
+
+        public MapAsset(String file) {
+            this(file, Map.of());
+        }
+    }
+
+    /**
+     * Global gameplay rules of the map.
+     */
+    public record MapRules(Integer minPlayers, Integer maxPlayers, Map<String, Object> properties) {
+
+        public MapRules {
+            Objects.requireNonNull(properties, "properties");
+            properties = Map.copyOf(properties);
+        }
+    }
+
+    /**
+     * Configuration of a team participating on the map.
+     */
+    public record MapTeam(String id,
+                          String displayName,
+                          MapVector spawn,
+                          MapNexus nexus,
+                          Map<String, Object> properties) {
+
+        public MapTeam {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(properties, "properties");
+            properties = Map.copyOf(properties);
+        }
+    }
+
+    /**
+     * Configuration of the nexus associated with a team.
+     */
+    public record MapNexus(MapVector position, Integer hitPoints, Map<String, Object> properties) {
+
+        public MapNexus {
+            Objects.requireNonNull(properties, "properties");
+            properties = Map.copyOf(properties);
+        }
+    }
+
+    /**
+     * Utility record used for coordinates in the blueprint.
+     */
+    public record MapVector(Double x, Double y, Double z, Float yaw, Float pitch) {
+
+        /**
+         * Indicates whether the vector provides valid XYZ coordinates.
+         *
+         * @return {@code true} when x, y and z are all provided
+         */
+        public boolean hasCoordinates() {
+            return x != null && y != null && z != null;
+        }
+    }
+
+    /**
+     * Declaration of a named region.
+     */
+    public record MapRegion(String id, Map<String, Object> properties) {
+
+        public MapRegion {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(properties, "properties");
+            properties = Map.copyOf(properties);
+        }
+    }
+
+    /**
+     * Definition of an interactive object defined in {@code map.yml}.
+     */
+    public record MapInteractive(String id, Map<String, Object> properties) {
+
+        public MapInteractive {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(properties, "properties");
+            properties = Map.copyOf(properties);
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/MapServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/MapServiceImpl.java
@@ -1,29 +1,42 @@
 package com.heneria.nexus.service.core;
 
-import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.api.MapDefinition;
 import com.heneria.nexus.api.MapLoadException;
 import com.heneria.nexus.api.MapQuery;
 import com.heneria.nexus.api.MapService;
+import com.heneria.nexus.api.MapValidatorService;
 import com.heneria.nexus.api.ValidationReport;
+import com.heneria.nexus.api.map.MapBlueprint;
+import com.heneria.nexus.api.map.MapBlueprint.MapAsset;
+import com.heneria.nexus.api.map.MapBlueprint.MapInteractive;
+import com.heneria.nexus.api.map.MapBlueprint.MapNexus;
+import com.heneria.nexus.api.map.MapBlueprint.MapRegion;
+import com.heneria.nexus.api.map.MapBlueprint.MapRules;
+import com.heneria.nexus.api.map.MapBlueprint.MapTeam;
+import com.heneria.nexus.api.map.MapBlueprint.MapVector;
+import com.heneria.nexus.concurrent.ExecutorManager;
 import com.heneria.nexus.util.NexusLogger;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -32,16 +45,23 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public final class MapServiceImpl implements MapService {
 
+    private static final Set<String> KNOWN_BLUEPRINT_KEYS = Set.of("asset", "rules", "teams", "regions", "interactives");
+
     private final JavaPlugin plugin;
     private final NexusLogger logger;
     private final ExecutorManager executorManager;
+    private final MapValidatorService validatorService;
     private final AtomicReference<Map<String, MapDefinition>> catalog = new AtomicReference<>(Map.of());
     private final AtomicReference<ValidationReport> lastValidation = new AtomicReference<>();
 
-    public MapServiceImpl(JavaPlugin plugin, NexusLogger logger, ExecutorManager executorManager) {
+    public MapServiceImpl(JavaPlugin plugin,
+                          NexusLogger logger,
+                          ExecutorManager executorManager,
+                          MapValidatorService validatorService) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.logger = Objects.requireNonNull(logger, "logger");
         this.executorManager = Objects.requireNonNull(executorManager, "executorManager");
+        this.validatorService = Objects.requireNonNull(validatorService, "validatorService");
     }
 
     @Override
@@ -59,29 +79,66 @@ public final class MapServiceImpl implements MapService {
     public void loadCatalog() throws MapLoadException {
         Path dataFolder = plugin.getDataFolder().toPath();
         Path mapsFile = dataFolder.resolve("maps.yml");
-        FileConfiguration configuration = YamlConfiguration.loadConfiguration(mapsFile.toFile());
+        YamlConfiguration configuration = loadYaml(mapsFile);
         ConfigurationSection root = configuration.getConfigurationSection("maps");
-        Map<String, MapDefinition> newCatalog = new ConcurrentHashMap<>();
+        Map<String, MapDefinition> validCatalog = new ConcurrentHashMap<>();
+        int totalEntries = 0;
         if (root != null) {
             for (String key : root.getKeys(false)) {
+                totalEntries++;
                 ConfigurationSection section = root.getConfigurationSection(key);
                 if (section == null) {
+                    logger.warn("[maps.yml] Entrée '%s' ignorée : section invalide".formatted(key));
                     continue;
                 }
+                String identifier = key.toLowerCase(Locale.ROOT);
                 String displayName = section.getString("display", key);
                 Path mapFolder = dataFolder.resolve("maps").resolve(key);
-                Map<String, Object> metadata = new HashMap<>();
-                section.getValues(false).forEach(metadata::put);
-                newCatalog.put(key.toLowerCase(Locale.ROOT), new MapDefinition(key, displayName, mapFolder, Map.copyOf(metadata)));
+                Map<String, Object> metadata = extractMetadata(section);
+                if (!Files.exists(mapFolder)) {
+                    ValidationReport report = ValidationReport.failure(List.of(),
+                            List.of("[maps.yml] Carte '%s': le dossier %s est introuvable".formatted(key, mapFolder)));
+                    logReport(key, displayName, report);
+                    continue;
+                }
+                MapBlueprint blueprint;
+                try {
+                    blueprint = loadBlueprint(key, mapFolder);
+                } catch (IOException exception) {
+                    ValidationReport report = ValidationReport.failure(List.of(),
+                            List.of("[maps.yml] Carte '%s': lecture de map.yml impossible (%s)".formatted(key, exception.getMessage())));
+                    logger.error("Lecture de map.yml impossible pour la carte '" + key + "'", exception);
+                    logReport(key, displayName, report);
+                    continue;
+                }
+                MapDefinition definition = new MapDefinition(key, displayName, mapFolder, metadata, blueprint);
+                ValidationReport report = validatorService.validate(definition, blueprint);
+                logReport(key, displayName, report);
+                if (report.valid()) {
+                    validCatalog.put(identifier, definition);
+                }
             }
         }
-        catalog.set(Collections.unmodifiableMap(newCatalog));
-        logger.info("Catalogue des maps chargé (%d entrées)".formatted(newCatalog.size()));
+        catalog.set(Collections.unmodifiableMap(validCatalog));
+        logger.info("Catalogue des maps chargé : %d valide(s) / %d entrée(s)".formatted(validCatalog.size(), totalEntries));
     }
 
     @Override
     public void reload() throws MapLoadException {
-        loadCatalog();
+        try {
+            executorManager.runCompute(() -> {
+                try {
+                    loadCatalog();
+                } catch (MapLoadException exception) {
+                    throw new CompletionException(exception);
+                }
+            }).join();
+        } catch (CompletionException exception) {
+            if (exception.getCause() instanceof MapLoadException loadException) {
+                throw loadException;
+            }
+            throw exception;
+        }
     }
 
     @Override
@@ -116,36 +173,267 @@ public final class MapServiceImpl implements MapService {
 
     @Override
     public ValidationReport validate(String mapId) {
-        MapDefinition definition = getMap(mapId).orElse(null);
-        List<String> warnings = new ArrayList<>();
-        List<String> errors = new ArrayList<>();
-        if (definition == null) {
-            errors.add("Map inconnue : " + mapId);
-            ValidationReport report = ValidationReport.failure(warnings, errors);
+        if (mapId == null || mapId.isBlank()) {
+            ValidationReport report = ValidationReport.failure(List.of(),
+                    List.of("Identifiant de carte vide"));
             lastValidation.set(report);
             return report;
         }
-        Path folder = definition.folder();
-        if (!Files.exists(folder)) {
-            errors.add("Dossier introuvable : " + folder);
-        } else {
-            Path layout = folder.resolve("map.yml");
-            if (!Files.exists(layout)) {
-                warnings.add("map.yml manquant pour " + definition.id());
-            }
-            Path schematic = folder.resolve("world.schem");
-            if (!Files.exists(schematic)) {
-                warnings.add("world.schem absent pour " + definition.id());
-            }
+        Path mapFolder = plugin.getDataFolder().toPath().resolve("maps").resolve(mapId);
+        MapBlueprint blueprint;
+        try {
+            blueprint = loadBlueprint(mapId, mapFolder);
+        } catch (IOException exception) {
+            ValidationReport report = ValidationReport.failure(List.of(),
+                    List.of("Lecture de map.yml impossible pour '%s': %s".formatted(mapId, exception.getMessage())));
+            lastValidation.set(report);
+            return report;
         }
-        ValidationReport report = errors.isEmpty()
-                ? ValidationReport.success(warnings)
-                : ValidationReport.failure(warnings, errors);
+        MapDefinition definition = getMap(mapId)
+                .orElse(new MapDefinition(mapId, mapId, mapFolder, Map.of(), blueprint));
+        ValidationReport report = validatorService.validate(definition, blueprint);
         lastValidation.set(report);
         return report;
     }
 
     public Optional<ValidationReport> lastValidation() {
         return Optional.ofNullable(lastValidation.get());
+    }
+
+    private YamlConfiguration loadYaml(Path file) throws MapLoadException {
+        YamlConfiguration configuration = new YamlConfiguration();
+        if (!Files.exists(file)) {
+            return configuration;
+        }
+        try {
+            configuration.load(file.toFile());
+        } catch (IOException | InvalidConfigurationException exception) {
+            throw new MapLoadException("Impossible de lire " + file.getFileName(), exception);
+        }
+        return configuration;
+    }
+
+    private MapBlueprint loadBlueprint(String mapId, Path mapFolder) throws IOException {
+        if (!Files.exists(mapFolder)) {
+            return MapBlueprint.missingConfiguration();
+        }
+        Path mapFile = mapFolder.resolve("map.yml");
+        if (!Files.exists(mapFile)) {
+            return MapBlueprint.missingConfiguration();
+        }
+        YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(mapFile.toFile());
+        } catch (IOException | InvalidConfigurationException exception) {
+            throw new IOException("map.yml invalide", exception);
+        }
+        return parseBlueprint(configuration);
+    }
+
+    private MapBlueprint parseBlueprint(YamlConfiguration configuration) {
+        MapAsset asset = parseAsset(configuration.getConfigurationSection("asset"));
+        MapRules rules = parseRules(configuration.getConfigurationSection("rules"));
+        List<MapTeam> teams = parseTeams(configuration.getConfigurationSection("teams"));
+        List<MapRegion> regions = parseRegions(configuration.getConfigurationSection("regions"));
+        List<MapInteractive> interactives = parseInteractives(configuration.getConfigurationSection("interactives"));
+        Map<String, Object> extras = extractExtras(configuration, KNOWN_BLUEPRINT_KEYS);
+        return new MapBlueprint(true, asset, rules, teams, regions, interactives, extras);
+    }
+
+    private MapAsset parseAsset(ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        String file = section.getString("file");
+        Map<String, Object> properties = extractMetadata(section);
+        return new MapAsset(file, properties);
+    }
+
+    private MapRules parseRules(ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        Integer minPlayers = getInteger(section, "min_players");
+        Integer maxPlayers = getInteger(section, "max_players");
+        Map<String, Object> properties = extractMetadata(section);
+        return new MapRules(minPlayers, maxPlayers, properties);
+    }
+
+    private List<MapTeam> parseTeams(ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        List<MapTeam> teams = new ArrayList<>();
+        for (String id : section.getKeys(false)) {
+            ConfigurationSection teamSection = section.getConfigurationSection(id);
+            if (teamSection == null) {
+                continue;
+            }
+            String displayName = teamSection.getString("name", id);
+            MapVector spawn = parseVector(teamSection.getConfigurationSection("spawn"));
+            MapNexus nexus = parseNexus(teamSection.getConfigurationSection("nexus"));
+            Map<String, Object> properties = extractMetadata(teamSection);
+            teams.add(new MapTeam(id, displayName, spawn, nexus, properties));
+        }
+        return List.copyOf(teams);
+    }
+
+    private MapNexus parseNexus(ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        ConfigurationSection positionSection = section.getConfigurationSection("position");
+        MapVector position = positionSection != null ? parseVector(positionSection) : parseVector(section);
+        Integer hp = getInteger(section, "hp");
+        Map<String, Object> properties = extractMetadata(section);
+        return new MapNexus(position, hp, properties);
+    }
+
+    private List<MapRegion> parseRegions(ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        List<MapRegion> regions = new ArrayList<>();
+        for (String id : section.getKeys(false)) {
+            ConfigurationSection regionSection = section.getConfigurationSection(id);
+            if (regionSection == null) {
+                continue;
+            }
+            regions.add(new MapRegion(id, extractMetadata(regionSection)));
+        }
+        return List.copyOf(regions);
+    }
+
+    private List<MapInteractive> parseInteractives(ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        List<MapInteractive> interactives = new ArrayList<>();
+        for (String id : section.getKeys(false)) {
+            ConfigurationSection interactiveSection = section.getConfigurationSection(id);
+            if (interactiveSection == null) {
+                continue;
+            }
+            interactives.add(new MapInteractive(id, extractMetadata(interactiveSection)));
+        }
+        return List.copyOf(interactives);
+    }
+
+    private MapVector parseVector(ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        Double x = getDouble(section, "x");
+        Double y = getDouble(section, "y");
+        Double z = getDouble(section, "z");
+        Float yaw = getFloat(section, "yaw");
+        Float pitch = getFloat(section, "pitch");
+        if (x == null && y == null && z == null && yaw == null && pitch == null) {
+            return null;
+        }
+        return new MapVector(x, y, z, yaw, pitch);
+    }
+
+    private Map<String, Object> extractMetadata(ConfigurationSection section) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Entry<String, Object> entry : section.getValues(false).entrySet()) {
+            result.put(entry.getKey(), convertValue(entry.getValue()));
+        }
+        return Map.copyOf(result);
+    }
+
+    private Map<String, Object> extractExtras(ConfigurationSection section, Set<String> excludedKeys) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String key : section.getKeys(false)) {
+            if (excludedKeys.contains(key)) {
+                continue;
+            }
+            result.put(key, convertValue(section.get(key)));
+        }
+        return Map.copyOf(result);
+    }
+
+    private Object convertValue(Object value) {
+        if (value instanceof ConfigurationSection configurationSection) {
+            return extractMetadata(configurationSection);
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> converted = new LinkedHashMap<>();
+            map.forEach((k, v) -> converted.put(String.valueOf(k), convertValue(v)));
+            return Map.copyOf(converted);
+        }
+        if (value instanceof List<?> list) {
+            List<Object> converted = new ArrayList<>();
+            for (Object element : list) {
+                converted.add(convertValue(element));
+            }
+            return List.copyOf(converted);
+        }
+        return value;
+    }
+
+    private Integer getInteger(ConfigurationSection section, String key) {
+        if (!section.contains(key)) {
+            return null;
+        }
+        Object value = section.get(key);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Integer.parseInt(string.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Double getDouble(ConfigurationSection section, String key) {
+        if (!section.contains(key)) {
+            return null;
+        }
+        Object value = section.get(key);
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Double.parseDouble(string.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Float getFloat(ConfigurationSection section, String key) {
+        if (!section.contains(key)) {
+            return null;
+        }
+        Object value = section.get(key);
+        if (value instanceof Number number) {
+            return number.floatValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Float.parseFloat(string.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private void logReport(String mapId, String displayName, ValidationReport report) {
+        String label = displayName == null || displayName.isBlank() ? mapId : displayName;
+        report.warnings().forEach(warning -> logger.warn("[map:%s] %s".formatted(mapId, warning)));
+        report.errors().forEach(error -> logger.error("[map:%s] %s".formatted(mapId, error)));
+        if (report.valid()) {
+            logger.info("Carte '%s' (%s) prête pour la rotation".formatted(label, mapId));
+        } else {
+            logger.error("Carte '%s' (%s) désactivée : validation échouée".formatted(label, mapId));
+        }
     }
 }

--- a/src/main/java/com/heneria/nexus/service/core/MapValidatorServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/MapValidatorServiceImpl.java
@@ -1,0 +1,146 @@
+package com.heneria.nexus.service.core;
+
+import com.heneria.nexus.api.MapDefinition;
+import com.heneria.nexus.api.MapValidatorService;
+import com.heneria.nexus.api.ValidationReport;
+import com.heneria.nexus.api.map.MapBlueprint;
+import com.heneria.nexus.api.map.MapBlueprint.MapAsset;
+import com.heneria.nexus.api.map.MapBlueprint.MapNexus;
+import com.heneria.nexus.api.map.MapBlueprint.MapRules;
+import com.heneria.nexus.api.map.MapBlueprint.MapTeam;
+import com.heneria.nexus.api.map.MapBlueprint.MapVector;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Default implementation performing structural validations on loaded maps.
+ */
+public final class MapValidatorServiceImpl implements MapValidatorService {
+
+    @Override
+    public ValidationReport validate(MapDefinition definition, MapBlueprint blueprint) {
+        Objects.requireNonNull(definition, "definition");
+        Objects.requireNonNull(blueprint, "blueprint");
+        List<String> warnings = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+
+        Path folder = definition.folder();
+        if (!Files.exists(folder)) {
+            errors.add("Le dossier de la carte est introuvable : " + folder);
+            return ValidationReport.failure(warnings, errors);
+        }
+
+        if (!blueprint.configurationPresent()) {
+            errors.add("map.yml est manquant dans " + folder);
+            return ValidationReport.failure(warnings, errors);
+        }
+
+        validateAsset(definition, blueprint.asset(), warnings, errors);
+        validateRules(blueprint.rules(), errors);
+        validateTeams(definition, blueprint.teams(), warnings, errors);
+
+        if (errors.isEmpty()) {
+            return ValidationReport.success(warnings);
+        }
+        return ValidationReport.failure(warnings, errors);
+    }
+
+    private void validateAsset(MapDefinition definition,
+                               MapAsset asset,
+                               List<String> warnings,
+                               List<String> errors) {
+        if (asset == null || asset.file() == null || asset.file().isBlank()) {
+            errors.add("[" + definition.id() + "] Section asset invalide : fichier non défini");
+            return;
+        }
+        Path assetPath = definition.folder().resolve(asset.file());
+        if (!Files.exists(assetPath)) {
+            errors.add("[" + definition.id() + "] Le fichier asset '" + asset.file()
+                    + "' est introuvable dans " + assetPath.getParent());
+        }
+    }
+
+    private void validateRules(MapRules rules, List<String> errors) {
+        if (rules == null) {
+            errors.add("Section rules manquante");
+            return;
+        }
+        Integer minPlayers = rules.minPlayers();
+        Integer maxPlayers = rules.maxPlayers();
+        if (minPlayers == null) {
+            errors.add("Le champ rules.min_players est requis");
+        }
+        if (maxPlayers == null) {
+            errors.add("Le champ rules.max_players est requis");
+        }
+        if (minPlayers != null && maxPlayers != null && minPlayers > maxPlayers) {
+            errors.add("rules.min_players ne peut pas être supérieur à rules.max_players");
+        }
+    }
+
+    private void validateTeams(MapDefinition definition,
+                               List<MapTeam> teams,
+                               List<String> warnings,
+                               List<String> errors) {
+        if (teams == null || teams.isEmpty()) {
+            errors.add("[" + definition.id() + "] Section teams manquante ou vide");
+            return;
+        }
+        Set<String> teamNames = new HashSet<>();
+        for (MapTeam team : teams) {
+            String display = team.displayName() == null || team.displayName().isBlank()
+                    ? team.id()
+                    : team.displayName();
+            String normalized = display.toLowerCase(Locale.ROOT);
+            if (!teamNames.add(normalized)) {
+                errors.add("[" + definition.id() + "] Nom d'équipe dupliqué : " + display);
+            }
+
+            validateSpawn(definition, team, errors);
+            validateNexus(definition, team, errors);
+        }
+    }
+
+    private void validateSpawn(MapDefinition definition, MapTeam team, List<String> errors) {
+        MapVector spawn = team.spawn();
+        if (spawn == null) {
+            errors.add("[" + definition.id() + "] Spawn manquant pour l'équipe " + team.id());
+            return;
+        }
+        if (!spawn.hasCoordinates() || !areValidCoordinates(spawn)) {
+            errors.add("[" + definition.id() + "] Coordonnées de spawn invalides pour l'équipe " + team.id());
+        }
+    }
+
+    private void validateNexus(MapDefinition definition, MapTeam team, List<String> errors) {
+        MapNexus nexus = team.nexus();
+        if (nexus == null) {
+            errors.add("[" + definition.id() + "] Section nexus manquante pour l'équipe " + team.id());
+            return;
+        }
+        MapVector position = nexus.position();
+        if (position == null || !position.hasCoordinates() || !areValidCoordinates(position)) {
+            errors.add("[" + definition.id() + "] Coordonnées du nexus invalides pour l'équipe " + team.id());
+        }
+        Integer hp = nexus.hitPoints();
+        if (hp == null) {
+            errors.add("[" + definition.id() + "] Le nexus de l'équipe " + team.id() + " doit définir hp");
+        } else if (hp <= 0) {
+            errors.add("[" + definition.id() + "] Le nexus de l'équipe " + team.id() + " doit avoir un hp positif");
+        }
+    }
+
+    private boolean areValidCoordinates(MapVector vector) {
+        return isFinite(vector.x()) && isFinite(vector.y()) && isFinite(vector.z());
+    }
+
+    private boolean isFinite(Double value) {
+        return value != null && Double.isFinite(value);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the map catalog loader to parse per-map blueprints from map.yml and store them on definitions
- introduce a dedicated validator service to enforce asset presence, team setup, and gameplay rules before enabling a map
- wire the validator into the plugin bootstrap and improve logging for successful and failed map validations

## Testing
- mvn -q -DskipTests compile *(fails: dependency downloads blocked by papermc repository returning 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d95aab52308324a449085131e1e840