### PR TITLE
Implement arena lifecycle state machine

### DIFF
--- a/src/main/java/com/heneria/nexus/scheduler/GamePhase.java
+++ b/src/main/java/com/heneria/nexus/scheduler/GamePhase.java
@@ -7,6 +7,7 @@ public enum GamePhase {
     LOBBY,
     STARTING,
     PLAYING,
+    SCORED,
     RESET,
     END
 }


### PR DESCRIPTION
## Summary
- integrate the ring scheduler into the arena lifecycle and execute per-phase actions such as teleports, countdowns, PvP toggles, and freeze/unfreeze handling
- persist match completion metadata at scoring time, clean up players asynchronously, and complete resets by transitioning to END when the watchdog task succeeds
- extend the game phase enum with the SCORED phase so scheduled tasks stay in sync with arena transitions

## Testing
- mvn -q -DskipTests package *(fails: dependency downloads forbidden in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28f824a48324aff6f4e2ab734f5f