### PR TITLE
feat: add region management system

### DIFF
--- a/src/main/java/com/heneria/nexus/NexusPlugin.java
+++ b/src/main/java/com/heneria/nexus/NexusPlugin.java
@@ -61,6 +61,9 @@ import com.heneria.nexus.listener.FirstWinBonusListener;
 import com.heneria.nexus.listener.PlayerRespawnListener;
 import com.heneria.nexus.listener.NexusDamageListener;
 import com.heneria.nexus.listener.SpawnProtectionListener;
+import com.heneria.nexus.listener.region.RegionBuildListener;
+import com.heneria.nexus.listener.region.RegionCombatListener;
+import com.heneria.nexus.listener.region.RegionMovementListener;
 import com.heneria.nexus.scheduler.GamePhase;
 import com.heneria.nexus.scheduler.RingScheduler;
 import com.heneria.nexus.scheduler.RingScheduler.TaskProfile;
@@ -78,6 +81,7 @@ import com.heneria.nexus.api.RewardService;
 import com.heneria.nexus.api.QueueService;
 import com.heneria.nexus.api.TeleportService;
 import com.heneria.nexus.api.ShopService;
+import com.heneria.nexus.api.region.RegionService;
 import com.heneria.nexus.api.service.TimerService;
 import com.heneria.nexus.service.core.AntiSpawnKillServiceImpl;
 import com.heneria.nexus.service.core.ArenaServiceImpl;
@@ -92,6 +96,7 @@ import com.heneria.nexus.service.core.ProfileServiceImpl;
 import com.heneria.nexus.service.core.QueueServiceImpl;
 import com.heneria.nexus.service.core.RewardServiceImpl;
 import com.heneria.nexus.service.core.ShopServiceImpl;
+import com.heneria.nexus.service.core.region.RegionServiceImpl;
 import com.heneria.nexus.service.core.TimerServiceImpl;
 import com.heneria.nexus.service.core.TeleportServiceImpl;
 import com.heneria.nexus.service.core.nexus.NexusManager;
@@ -387,10 +392,14 @@ public final class NexusPlugin extends JavaPlugin {
         PluginManager manager = getServer().getPluginManager();
         AntiSpawnKillService spawnKillService = serviceRegistry.get(AntiSpawnKillService.class);
         ArenaService arenaService = serviceRegistry.get(ArenaService.class);
+        RegionService regionService = serviceRegistry.get(RegionService.class);
         manager.registerEvents(new HologramVisibilityListener(serviceRegistry.get(HoloService.class)), this);
         manager.registerEvents(new FirstWinBonusListener(logger, serviceRegistry.get(FirstWinBonusService.class)), this);
         manager.registerEvents(new PlayerRespawnListener(logger, arenaService, spawnKillService, executorManager), this);
         manager.registerEvents(new SpawnProtectionListener(spawnKillService), this);
+        manager.registerEvents(new RegionBuildListener(regionService), this);
+        manager.registerEvents(new RegionCombatListener(regionService), this);
+        manager.registerEvents(new RegionMovementListener(regionService), this);
         manager.registerEvents(new NexusDamageListener(serviceRegistry.get(NexusManager.class)), this);
     }
 
@@ -1486,6 +1495,7 @@ public final class NexusPlugin extends JavaPlugin {
         serviceRegistry.registerService(AntiSpawnKillService.class, AntiSpawnKillServiceImpl.class);
         serviceRegistry.registerService(HoloService.class, HoloServiceImpl.class);
         serviceRegistry.registerService(NexusManager.class, NexusManager.class);
+        serviceRegistry.registerService(RegionService.class, RegionServiceImpl.class);
         serviceRegistry.registerService(ArenaService.class, ArenaServiceImpl.class);
         serviceRegistry.registerService(RewardService.class, RewardServiceImpl.class);
         serviceRegistry.registerService(FirstWinBonusService.class, FirstWinBonusServiceImpl.class);

--- a/src/main/java/com/heneria/nexus/api/MapDefinition.java
+++ b/src/main/java/com/heneria/nexus/api/MapDefinition.java
@@ -1,6 +1,9 @@
 package com.heneria.nexus.api;
 
 import com.heneria.nexus.api.map.MapBlueprint;
+import com.heneria.nexus.api.region.Region;
+import com.heneria.nexus.api.region.RegionFlag;
+import java.util.List;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
@@ -18,7 +21,9 @@ public record MapDefinition(String id,
                             String displayName,
                             Path folder,
                             Map<String, Object> metadata,
-                            MapBlueprint blueprint) {
+                            MapBlueprint blueprint,
+                            List<Region> regions,
+                            Map<RegionFlag, Object> regionDefaults) {
 
     /**
      * Validates constructor arguments.
@@ -29,5 +34,7 @@ public record MapDefinition(String id,
         Objects.requireNonNull(folder, "folder");
         Objects.requireNonNull(metadata, "metadata");
         Objects.requireNonNull(blueprint, "blueprint");
+        Objects.requireNonNull(regions, "regions");
+        Objects.requireNonNull(regionDefaults, "regionDefaults");
     }
 }

--- a/src/main/java/com/heneria/nexus/api/region/Region.java
+++ b/src/main/java/com/heneria/nexus/api/region/Region.java
@@ -1,0 +1,92 @@
+package com.heneria.nexus.api.region;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import org.bukkit.util.BoundingBox;
+
+/**
+ * Immutable representation of a named cuboid region defined in a map.
+ */
+public record Region(String id,
+                     BoundingBox bounds,
+                     Map<RegionFlag, Object> flags) {
+
+    public Region {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(bounds, "bounds");
+        Objects.requireNonNull(flags, "flags");
+    }
+
+    /**
+     * Returns an immutable copy of the flags associated with this region.
+     *
+     * @return immutable map of region flags
+     */
+    @Override
+    public Map<RegionFlag, Object> flags() {
+        return Map.copyOf(flags);
+    }
+
+    /**
+     * Computes the volume of the region.
+     *
+     * @return cuboid volume in blocks
+     */
+    public double volume() {
+        double width = Math.abs(bounds.getMaxX() - bounds.getMinX());
+        double height = Math.abs(bounds.getMaxY() - bounds.getMinY());
+        double depth = Math.abs(bounds.getMaxZ() - bounds.getMinZ());
+        return width * height * depth;
+    }
+
+    /**
+     * Resolves the flag associated with the supplied identifier.
+     *
+     * @param flag flag identifier
+     * @return optional value when present
+     */
+    public Object flagValue(RegionFlag flag) {
+        Objects.requireNonNull(flag, "flag");
+        return flags.get(flag);
+    }
+
+    /**
+     * Creates a new {@link Builder} instance.
+     *
+     * @param id unique region identifier
+     * @return a builder seeded with the provided id
+     */
+    public static Builder builder(String id) {
+        return new Builder(id);
+    }
+
+    /**
+     * Builder used to simplify region creation when parsing map definitions.
+     */
+    public static final class Builder {
+
+        private final String id;
+        private BoundingBox bounds;
+        private final EnumMap<RegionFlag, Object> flags = new EnumMap<>(RegionFlag.class);
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id, "id");
+        }
+
+        public Builder bounds(BoundingBox bounds) {
+            this.bounds = Objects.requireNonNull(bounds, "bounds");
+            return this;
+        }
+
+        public Builder flag(RegionFlag flag, Object value) {
+            flags.put(Objects.requireNonNull(flag, "flag"), value);
+            return this;
+        }
+
+        public Region build() {
+            Objects.requireNonNull(bounds, "bounds");
+            return new Region(id, bounds, Map.copyOf(flags));
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/api/region/RegionFlag.java
+++ b/src/main/java/com/heneria/nexus/api/region/RegionFlag.java
@@ -1,0 +1,68 @@
+package com.heneria.nexus.api.region;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Enumeration of the supported region flags.
+ */
+public enum RegionFlag {
+
+    PVP_ENABLED("pvp.enabled", Set.of("pvp", "pvp_enabled", "pvp.enabled")),
+    BUILD_ALLOWED("build.allowed", Set.of("build", "build_allowed", "build.allowed")),
+    KNOCKBACK_REDUCTION("knockback.reduction", Set.of("knockback", "knockback_reduction", "knockback.reduction")),
+    FALL_DAMAGE("fall_damage", Set.of("fall_damage", "fall.damage", "falldamage")),
+    EFFECTS_APPLY("effects.apply", Set.of("effects", "effects_apply", "effects.apply"));
+
+    private final String key;
+    private final Set<String> aliases;
+
+    RegionFlag(String key, Set<String> aliases) {
+        this.key = Objects.requireNonNull(key, "key");
+        this.aliases = normalizeAliases(aliases, key);
+    }
+
+    private Set<String> normalizeAliases(Set<String> aliases, String key) {
+        Set<String> normalized = aliases.stream()
+                .map(RegionFlag::normalize)
+                .collect(Collectors.toSet());
+        normalized.add(normalize(key));
+        return normalized;
+    }
+
+    /**
+     * Returns the canonical configuration key of the flag.
+     *
+     * @return canonical key using dot notation
+     */
+    public String key() {
+        return key;
+    }
+
+    /**
+     * Resolves a flag from an arbitrary configuration key.
+     *
+     * @param key raw configuration key
+     * @return optional containing the resolved flag
+     */
+    public static Optional<RegionFlag> fromKey(String key) {
+        if (key == null || key.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = normalize(key);
+        return Arrays.stream(values())
+                .filter(flag -> flag.aliases.contains(normalized))
+                .findFirst();
+    }
+
+    private static String normalize(String key) {
+        String lower = key.toLowerCase(Locale.ROOT).replace(' ', '_');
+        lower = lower.replace('-', '_');
+        lower = lower.replace('.', '_');
+        return lower;
+    }
+}

--- a/src/main/java/com/heneria/nexus/api/region/RegionService.java
+++ b/src/main/java/com/heneria/nexus/api/region/RegionService.java
@@ -1,0 +1,62 @@
+package com.heneria.nexus.api.region;
+
+import com.heneria.nexus.api.MapDefinition;
+import com.heneria.nexus.service.LifecycleAware;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * Centralized service responsible for managing active region definitions
+ * across arenas.
+ */
+public interface RegionService extends LifecycleAware {
+
+    /**
+     * Registers the regions associated with the provided arena instance.
+     *
+     * @param arenaId unique identifier of the arena
+     * @param definition map definition used by the arena
+     */
+    void registerArena(UUID arenaId, MapDefinition definition);
+
+    /**
+     * Removes the regions associated with the provided arena instance.
+     *
+     * @param arenaId unique identifier of the arena being destroyed
+     */
+    void unregisterArena(UUID arenaId);
+
+    /**
+     * Returns the regions attached to the supplied arena.
+     *
+     * @param arenaId identifier of the arena
+     * @return immutable collection of regions
+     */
+    Collection<Region> getRegionsForArena(UUID arenaId);
+
+    /**
+     * Resolves the effective flags at the provided location.
+     *
+     * @param location target location
+     * @return immutable map of resolved flags
+     */
+    Map<RegionFlag, Object> getFlagsAt(Location location);
+
+    /**
+     * Notifies the service that a player moved, allowing cached state to be
+     * refreshed.
+     *
+     * @param player player that moved inside an arena
+     */
+    void handlePlayerMove(Player player);
+
+    /**
+     * Clears any region side effects applied to the provided player.
+     *
+     * @param player player leaving the arena context
+     */
+    void handlePlayerLeave(Player player);
+}

--- a/src/main/java/com/heneria/nexus/listener/region/RegionBuildListener.java
+++ b/src/main/java/com/heneria/nexus/listener/region/RegionBuildListener.java
@@ -1,0 +1,43 @@
+package com.heneria.nexus.listener.region;
+
+import com.heneria.nexus.api.region.RegionFlag;
+import com.heneria.nexus.api.region.RegionService;
+import java.util.Map;
+import java.util.Objects;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+/**
+ * Prevents block interactions in regions where building is disabled.
+ */
+public final class RegionBuildListener implements Listener {
+
+    private final RegionService regionService;
+
+    public RegionBuildListener(RegionService regionService) {
+        this.regionService = Objects.requireNonNull(regionService, "regionService");
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (!isBuildAllowed(event.getBlock().getLocation())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (!isBuildAllowed(event.getBlock().getLocation())) {
+            event.setCancelled(true);
+        }
+    }
+
+    private boolean isBuildAllowed(Location location) {
+        Map<RegionFlag, Object> flags = regionService.getFlagsAt(location);
+        return RegionFlagUtil.getBoolean(flags, RegionFlag.BUILD_ALLOWED, true);
+    }
+}

--- a/src/main/java/com/heneria/nexus/listener/region/RegionCombatListener.java
+++ b/src/main/java/com/heneria/nexus/listener/region/RegionCombatListener.java
@@ -1,0 +1,54 @@
+package com.heneria.nexus.listener.region;
+
+import com.heneria.nexus.api.region.RegionFlag;
+import com.heneria.nexus.api.region.RegionService;
+import java.util.Map;
+import java.util.Objects;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+/**
+ * Applies combat related region rules such as PvP or knockback modifiers.
+ */
+public final class RegionCombatListener implements Listener {
+
+    private final RegionService regionService;
+
+    public RegionCombatListener(RegionService regionService) {
+        this.regionService = Objects.requireNonNull(regionService, "regionService");
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        Location location = event.getEntity().getLocation();
+        Map<RegionFlag, Object> flags = regionService.getFlagsAt(location);
+        boolean pvpEnabled = RegionFlagUtil.getBoolean(flags, RegionFlag.PVP_ENABLED, true);
+        if (!pvpEnabled) {
+            event.setCancelled(true);
+            return;
+        }
+        double reduction = Math.max(0D, RegionFlagUtil.getDouble(flags, RegionFlag.KNOCKBACK_REDUCTION, 0D));
+        if (reduction <= 0D) {
+            return;
+        }
+        double factor = Math.max(0D, 1D - Math.min(reduction, 1D));
+        event.setDamage(event.getDamage() * factor);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onFallDamage(EntityDamageEvent event) {
+        if (event.getCause() != EntityDamageEvent.DamageCause.FALL) {
+            return;
+        }
+        Location location = event.getEntity().getLocation();
+        Map<RegionFlag, Object> flags = regionService.getFlagsAt(location);
+        boolean enabled = RegionFlagUtil.getBoolean(flags, RegionFlag.FALL_DAMAGE, true);
+        if (!enabled) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/com/heneria/nexus/listener/region/RegionFlagUtil.java
+++ b/src/main/java/com/heneria/nexus/listener/region/RegionFlagUtil.java
@@ -1,0 +1,44 @@
+package com.heneria.nexus.listener.region;
+
+import com.heneria.nexus.api.region.RegionFlag;
+import java.util.Map;
+
+final class RegionFlagUtil {
+
+    private RegionFlagUtil() {
+    }
+
+    static boolean getBoolean(Map<RegionFlag, Object> flags, RegionFlag flag, boolean defaultValue) {
+        Object value = flags.get(flag);
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        if (value instanceof Number number) {
+            return number.intValue() != 0;
+        }
+        if (value instanceof String string) {
+            if (string.equalsIgnoreCase("true") || string.equalsIgnoreCase("yes") || string.equalsIgnoreCase("on")) {
+                return true;
+            }
+            if (string.equalsIgnoreCase("false") || string.equalsIgnoreCase("no") || string.equalsIgnoreCase("off")) {
+                return false;
+            }
+        }
+        return defaultValue;
+    }
+
+    static double getDouble(Map<RegionFlag, Object> flags, RegionFlag flag, double defaultValue) {
+        Object value = flags.get(flag);
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Double.parseDouble(string.trim());
+            } catch (NumberFormatException ignored) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/src/main/java/com/heneria/nexus/listener/region/RegionMovementListener.java
+++ b/src/main/java/com/heneria/nexus/listener/region/RegionMovementListener.java
@@ -1,0 +1,55 @@
+package com.heneria.nexus.listener.region;
+
+import com.heneria.nexus.api.region.RegionService;
+import java.util.Objects;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Keeps track of players entering or leaving regions to apply side effects.
+ */
+public final class RegionMovementListener implements Listener {
+
+    private final RegionService regionService;
+
+    public RegionMovementListener(RegionService regionService) {
+        this.regionService = Objects.requireNonNull(regionService, "regionService");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (!hasMovedBlock(event)) {
+            return;
+        }
+        regionService.handlePlayerMove(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        regionService.handlePlayerLeave(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerKick(PlayerKickEvent event) {
+        regionService.handlePlayerLeave(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onWorldChange(PlayerChangedWorldEvent event) {
+        regionService.handlePlayerMove(event.getPlayer());
+    }
+
+    private boolean hasMovedBlock(PlayerMoveEvent event) {
+        if (event.getFrom().getWorld() != event.getTo().getWorld()) {
+            return true;
+        }
+        return event.getFrom().getBlockX() != event.getTo().getBlockX()
+                || event.getFrom().getBlockY() != event.getTo().getBlockY()
+                || event.getFrom().getBlockZ() != event.getTo().getBlockZ();
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/region/RegionFactory.java
+++ b/src/main/java/com/heneria/nexus/service/core/region/RegionFactory.java
@@ -1,0 +1,230 @@
+package com.heneria.nexus.service.core.region;
+
+import com.heneria.nexus.api.region.Region;
+import com.heneria.nexus.api.region.RegionFlag;
+import com.heneria.nexus.api.map.MapBlueprint.MapRegion;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.bukkit.util.BoundingBox;
+
+/**
+ * Utility responsible for converting blueprint declarations into runtime region
+ * models.
+ */
+public final class RegionFactory {
+
+    private RegionFactory() {
+    }
+
+    public static List<Region> fromBlueprint(String mapId,
+                                             List<MapRegion> blueprint,
+                                             NexusLogger logger) {
+        if (blueprint == null || blueprint.isEmpty()) {
+            return List.of();
+        }
+        List<Region> regions = new ArrayList<>();
+        for (MapRegion candidate : blueprint) {
+            if (candidate == null) {
+                continue;
+            }
+            try {
+                Optional<Region> region = buildRegion(candidate);
+                region.ifPresent(regions::add);
+            } catch (IllegalArgumentException exception) {
+                if (logger != null) {
+                    logger.warn("[map:%s] Région '%s' ignorée: %s".formatted(mapId, candidate.id(), exception.getMessage()));
+                }
+            }
+        }
+        return List.copyOf(regions);
+    }
+
+    public static Map<RegionFlag, Object> extractFlagDefaults(Map<String, Object> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        EnumMap<RegionFlag, Object> flags = new EnumMap<>(RegionFlag.class);
+        collectFlags("", source, flags);
+        return Map.copyOf(flags);
+    }
+
+    private static Optional<Region> buildRegion(MapRegion candidate) {
+        Map<String, Object> properties = candidate.properties();
+        BoundingBox bounds = resolveBounds(properties)
+                .orElseThrow(() -> new IllegalArgumentException("limites manquantes ou invalides"));
+        EnumMap<RegionFlag, Object> flags = new EnumMap<>(RegionFlag.class);
+        Object flagSection = properties.get("flags");
+        if (flagSection instanceof Map<?, ?> map) {
+            collectFlags("", map, flags);
+        }
+        properties.forEach((key, value) -> RegionFlag.fromKey(key).ifPresent(flag -> flags.put(flag, value)));
+        Region.Builder builder = Region.builder(candidate.id()).bounds(bounds);
+        flags.forEach(builder::flag);
+        return Optional.of(builder.build());
+    }
+
+    private static Optional<BoundingBox> resolveBounds(Map<String, Object> properties) {
+        Object first = firstPresent(properties, "min", "pos1", "corner1", "from", "a", "start");
+        Object second = firstPresent(properties, "max", "pos2", "corner2", "to", "b", "end");
+        if (first == null || second == null) {
+            Object bounds = properties.get("bounds");
+            if (bounds instanceof List<?> list && list.size() >= 2) {
+                first = list.get(0);
+                second = list.get(1);
+            }
+        }
+        Optional<Vector3> min = parseVector(first);
+        Optional<Vector3> max = parseVector(second);
+        if (min.isEmpty() || max.isEmpty()) {
+            return Optional.empty();
+        }
+        Vector3 a = min.get();
+        Vector3 b = max.get();
+        double minX = Math.min(a.x(), b.x());
+        double minY = Math.min(a.y(), b.y());
+        double minZ = Math.min(a.z(), b.z());
+        double maxX = Math.max(a.x(), b.x());
+        double maxY = Math.max(a.y(), b.y());
+        double maxZ = Math.max(a.z(), b.z());
+        if (Double.isNaN(minX) || Double.isNaN(minY) || Double.isNaN(minZ)
+                || Double.isNaN(maxX) || Double.isNaN(maxY) || Double.isNaN(maxZ)) {
+            return Optional.empty();
+        }
+        return Optional.of(new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ));
+    }
+
+    private static Object firstPresent(Map<String, Object> properties, String... keys) {
+        for (String key : keys) {
+            Object value = properties.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static Optional<Vector3> parseVector(Object value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (value instanceof Vector3 vector) {
+            return Optional.of(vector);
+        }
+        if (value instanceof Map<?, ?> map) {
+            return parseVectorFromMap(map);
+        }
+        if (value instanceof List<?> list) {
+            return parseVectorFromList(list);
+        }
+        if (value instanceof String string) {
+            return parseVectorFromString(string);
+        }
+        if (value instanceof Number number) {
+            double coordinate = number.doubleValue();
+            return Optional.of(new Vector3(coordinate, coordinate, coordinate));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Vector3> parseVectorFromMap(Map<?, ?> map) {
+        Object xValue = map.get("x");
+        Object yValue = map.get("y");
+        Object zValue = map.get("z");
+        if (xValue == null && yValue == null && zValue == null) {
+            Object nested = map.get("pos");
+            if (nested != null) {
+                return parseVector(nested);
+            }
+            if (map.size() >= 3) {
+                Object[] values = map.values().toArray();
+                return parseVectorFromArray(values);
+            }
+            return Optional.empty();
+        }
+        Double x = parseCoordinate(xValue);
+        Double y = parseCoordinate(yValue);
+        Double z = parseCoordinate(zValue);
+        if (x == null || y == null || z == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Vector3(x, y, z));
+    }
+
+    private static Optional<Vector3> parseVectorFromList(List<?> list) {
+        if (list.size() < 3) {
+            return Optional.empty();
+        }
+        return parseVectorFromArray(list.toArray());
+    }
+
+    private static Optional<Vector3> parseVectorFromArray(Object[] values) {
+        Double x = parseCoordinate(values[0]);
+        Double y = parseCoordinate(values[1]);
+        Double z = parseCoordinate(values[2]);
+        if (x == null || y == null || z == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Vector3(x, y, z));
+    }
+
+    private static Optional<Vector3> parseVectorFromString(String value) {
+        String[] parts = value.split(",");
+        if (parts.length < 3) {
+            return Optional.empty();
+        }
+        Double x = parseCoordinate(parts[0]);
+        Double y = parseCoordinate(parts[1]);
+        Double z = parseCoordinate(parts[2]);
+        if (x == null || y == null || z == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Vector3(x, y, z));
+    }
+
+    private static Double parseCoordinate(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Double.parseDouble(string.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static void collectFlags(String prefix, Object value, EnumMap<RegionFlag, Object> result) {
+        if (value instanceof Map<?, ?> map) {
+            map.forEach((key, entry) -> {
+                String path = join(prefix, String.valueOf(key));
+                collectFlags(path, entry, result);
+            });
+            return;
+        }
+        if (value instanceof List<?> list) {
+            for (Object element : list) {
+                collectFlags(prefix, element, result);
+            }
+            return;
+        }
+        RegionFlag.fromKey(prefix).ifPresent(flag -> result.put(flag, value));
+    }
+
+    private static String join(String prefix, String key) {
+        String normalizedKey = key == null ? "" : key.toLowerCase(Locale.ROOT);
+        if (prefix == null || prefix.isEmpty()) {
+            return normalizedKey;
+        }
+        return prefix + "." + normalizedKey;
+    }
+
+    private record Vector3(double x, double y, double z) {
+    }
+}

--- a/src/main/java/com/heneria/nexus/service/core/region/RegionServiceImpl.java
+++ b/src/main/java/com/heneria/nexus/service/core/region/RegionServiceImpl.java
@@ -1,0 +1,356 @@
+package com.heneria.nexus.service.core.region;
+
+import com.heneria.nexus.api.MapDefinition;
+import com.heneria.nexus.api.region.Region;
+import com.heneria.nexus.api.region.RegionFlag;
+import com.heneria.nexus.api.region.RegionService;
+import com.heneria.nexus.scheduler.GamePhase;
+import com.heneria.nexus.scheduler.RingScheduler;
+import com.heneria.nexus.util.NexusLogger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.BoundingBox;
+
+/**
+ * Default in-memory implementation of {@link RegionService}.
+ */
+public final class RegionServiceImpl implements RegionService {
+
+    private static final String EFFECT_TASK_ID = "regions-effects";
+    private static final EnumSet<GamePhase> EFFECT_PHASES = EnumSet.allOf(GamePhase.class);
+    private static final long EFFECT_TASK_INTERVAL = 20L;
+    private static final Map<RegionFlag, Object> BASE_DEFAULTS = Map.of(
+            RegionFlag.PVP_ENABLED, Boolean.TRUE,
+            RegionFlag.BUILD_ALLOWED, Boolean.TRUE,
+            RegionFlag.FALL_DAMAGE, Boolean.TRUE
+    );
+
+    private final NexusLogger logger;
+    private final RingScheduler ringScheduler;
+    private final ConcurrentMap<UUID, ArenaRegionState> arenas = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, UUID> worldToArena = new ConcurrentHashMap<>();
+    private final ConcurrentMap<UUID, EnumMap<PotionEffectType, PotionEffect>> playerEffects = new ConcurrentHashMap<>();
+    private final ConcurrentMap<UUID, UUID> playerArena = new ConcurrentHashMap<>();
+
+    public RegionServiceImpl(NexusLogger logger, RingScheduler ringScheduler) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.ringScheduler = Objects.requireNonNull(ringScheduler, "ringScheduler");
+    }
+
+    @Override
+    public void registerArena(UUID arenaId, MapDefinition definition) {
+        Objects.requireNonNull(arenaId, "arenaId");
+        Objects.requireNonNull(definition, "definition");
+        List<Region> regions = definition.regions();
+        Map<RegionFlag, Object> defaults = mergeDefaults(definition.regionDefaults());
+        ArenaRegionState state = new ArenaRegionState(arenaId, definition.id(), defaults, sortRegions(regions));
+        arenas.put(arenaId, state);
+        worldToArena.put(definition.id().toLowerCase(Locale.ROOT), arenaId);
+        worldToArena.put(arenaId.toString().toLowerCase(Locale.ROOT), arenaId);
+        logger.debug(() -> "Régions enregistrées pour l'arène " + arenaId + " -> " + regions.size() + " zone(s)");
+    }
+
+    @Override
+    public void unregisterArena(UUID arenaId) {
+        Objects.requireNonNull(arenaId, "arenaId");
+        ArenaRegionState state = arenas.remove(arenaId);
+        if (state == null) {
+            return;
+        }
+        state.worldAliases().forEach(worldToArena::remove);
+        List<UUID> affectedPlayers = playerArena.entrySet().stream()
+                .filter(entry -> arenaId.equals(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .toList();
+        affectedPlayers.forEach(this::clearPlayerEffects);
+        logger.debug(() -> "Régions déchargées pour l'arène " + arenaId);
+    }
+
+    @Override
+    public Collection<Region> getRegionsForArena(UUID arenaId) {
+        ArenaRegionState state = arenas.get(arenaId);
+        if (state == null) {
+            return List.of();
+        }
+        return state.regions();
+    }
+
+    @Override
+    public Map<RegionFlag, Object> getFlagsAt(Location location) {
+        if (location == null || location.getWorld() == null) {
+            return Map.of();
+        }
+        UUID arenaId = worldToArena.get(location.getWorld().getName().toLowerCase(Locale.ROOT));
+        if (arenaId == null) {
+            return Map.of();
+        }
+        ArenaRegionState state = arenas.get(arenaId);
+        if (state == null) {
+            return Map.of();
+        }
+        Map<RegionFlag, Object> resolved = new EnumMap<>(state.defaults());
+        List<Region> stack = resolveRegions(state.regions(), location);
+        for (Region region : stack) {
+            region.flags().forEach(resolved::put);
+        }
+        return Map.copyOf(resolved);
+    }
+
+    @Override
+    public void handlePlayerMove(Player player) {
+        Objects.requireNonNull(player, "player");
+        updatePlayerState(player, false);
+    }
+
+    @Override
+    public void handlePlayerLeave(Player player) {
+        Objects.requireNonNull(player, "player");
+        clearPlayerEffects(player.getUniqueId());
+        playerArena.remove(player.getUniqueId());
+    }
+
+    @Override
+    public java.util.concurrent.CompletableFuture<Void> start() {
+        ringScheduler.registerTask(EFFECT_TASK_ID, EFFECT_TASK_INTERVAL, EFFECT_PHASES, this::refreshPlayerStates);
+        return RegionService.super.start();
+    }
+
+    @Override
+    public java.util.concurrent.CompletableFuture<Void> stop() {
+        ringScheduler.unregisterTask(EFFECT_TASK_ID);
+        arenas.clear();
+        worldToArena.clear();
+        playerArena.keySet().forEach(this::clearPlayerEffects);
+        playerArena.clear();
+        playerEffects.clear();
+        return RegionService.super.stop();
+    }
+
+    private Map<RegionFlag, Object> mergeDefaults(Map<RegionFlag, Object> mapDefaults) {
+        EnumMap<RegionFlag, Object> merged = new EnumMap<>(RegionFlag.class);
+        merged.putAll(BASE_DEFAULTS);
+        if (mapDefaults != null) {
+            merged.putAll(mapDefaults);
+        }
+        return Map.copyOf(merged);
+    }
+
+    private List<Region> sortRegions(Collection<Region> regions) {
+        if (regions == null || regions.isEmpty()) {
+            return List.of();
+        }
+        return regions.stream()
+                .sorted((a, b) -> {
+                    int volumeComparison = Double.compare(a.volume(), b.volume());
+                    if (volumeComparison != 0) {
+                        return volumeComparison;
+                    }
+                    return a.id().compareToIgnoreCase(b.id());
+                })
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private List<Region> resolveRegions(List<Region> regions, Location location) {
+        if (regions == null || regions.isEmpty()) {
+            return List.of();
+        }
+        return regions.stream()
+                .filter(region -> contains(region.bounds(), location))
+                .toList();
+    }
+
+    private boolean contains(BoundingBox bounds, Location location) {
+        return bounds.contains(location.getX(), location.getY(), location.getZ());
+    }
+
+    private void updatePlayerState(Player player, boolean force) {
+        Location location = player.getLocation();
+        if (location.getWorld() == null) {
+            clearPlayerEffects(player.getUniqueId());
+            playerArena.remove(player.getUniqueId());
+            return;
+        }
+        String worldName = location.getWorld().getName().toLowerCase(Locale.ROOT);
+        UUID arenaId = worldToArena.get(worldName);
+        if (arenaId == null) {
+            clearPlayerEffects(player.getUniqueId());
+            playerArena.remove(player.getUniqueId());
+            return;
+        }
+        Map<RegionFlag, Object> flags = getFlagsAt(location);
+        playerArena.put(player.getUniqueId(), arenaId);
+        applyEffects(player, flags, force);
+    }
+
+    private void refreshPlayerStates() {
+        for (UUID playerId : List.copyOf(playerArena.keySet())) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player == null) {
+                clearPlayerEffects(playerId);
+                playerArena.remove(playerId);
+                continue;
+            }
+            updatePlayerState(player, true);
+        }
+    }
+
+    private void applyEffects(Player player, Map<RegionFlag, Object> flags, boolean force) {
+        Object raw = flags.get(RegionFlag.EFFECTS_APPLY);
+        Collection<PotionEffect> desired = resolveEffects(raw);
+        UUID playerId = player.getUniqueId();
+        EnumMap<PotionEffectType, PotionEffect> active = playerEffects.computeIfAbsent(playerId,
+                ignored -> new EnumMap<>(PotionEffectType.class));
+        if (desired.isEmpty()) {
+            if (!active.isEmpty()) {
+                active.keySet().forEach(player::removePotionEffect);
+                active.clear();
+            }
+            return;
+        }
+        Map<PotionEffectType, PotionEffect> desiredMap = desired.stream()
+                .collect(Collectors.toMap(PotionEffect::getType, effect -> effect, (first, second) -> second));
+        boolean changed = force;
+        for (PotionEffect effect : desired) {
+            PotionEffect current = active.get(effect.getType());
+            if (!effect.equals(current) || force) {
+                player.addPotionEffect(effect, true);
+                active.put(effect.getType(), effect);
+                changed = true;
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        List<PotionEffectType> toRemove = active.keySet().stream()
+                .filter(type -> !desiredMap.containsKey(type))
+                .toList();
+        toRemove.forEach(type -> {
+            player.removePotionEffect(type);
+            active.remove(type);
+        });
+    }
+
+    private Collection<PotionEffect> resolveEffects(Object raw) {
+        if (raw == null) {
+            return List.of();
+        }
+        if (raw instanceof Collection<?> collection) {
+            List<PotionEffect> effects = new ArrayList<>();
+            for (Object element : collection) {
+                effects.addAll(resolveEffects(element));
+            }
+            return effects;
+        }
+        if (raw instanceof Map<?, ?> map) {
+            List<PotionEffect> effects = new ArrayList<>();
+            map.forEach((key, value) -> {
+                PotionEffectType type = PotionEffectType.getByName(String.valueOf(key).toUpperCase(Locale.ROOT));
+                if (type == null) {
+                    return;
+                }
+                PotionEffect effect = buildEffect(type, value);
+                if (effect != null) {
+                    effects.add(effect);
+                }
+            });
+            return effects;
+        }
+        if (raw instanceof String string) {
+            PotionEffectType type = PotionEffectType.getByName(string.toUpperCase(Locale.ROOT));
+            if (type == null) {
+                return List.of();
+            }
+            PotionEffect effect = new PotionEffect(type, 100, 0, false, true, true);
+            return List.of(effect);
+        }
+        if (raw instanceof PotionEffect effect) {
+            return List.of(effect);
+        }
+        return List.of();
+    }
+
+    private PotionEffect buildEffect(PotionEffectType type, Object value) {
+        if (value instanceof Number number) {
+            int amplifier = Math.max(0, number.intValue());
+            return new PotionEffect(type, 100, amplifier, false, true, true);
+        }
+        if (value instanceof Map<?, ?> map) {
+            int amplifier = getInt(map.get("amplifier"), 0);
+            int duration = getInt(map.get("duration"), 100);
+            boolean ambient = getBoolean(map.get("ambient"), false);
+            boolean particles = getBoolean(map.get("particles"), true);
+            boolean icon = getBoolean(map.get("icon"), true);
+            return new PotionEffect(type, Math.max(1, duration), Math.max(0, amplifier), ambient, particles, icon);
+        }
+        if (value instanceof String string) {
+            try {
+                int amplifier = Integer.parseInt(string.trim());
+                return new PotionEffect(type, 100, Math.max(0, amplifier), false, true, true);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private int getInt(Object value, int fallback) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Integer.parseInt(string.trim());
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        return fallback;
+    }
+
+    private boolean getBoolean(Object value, boolean fallback) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        if (value instanceof String string) {
+            return Boolean.parseBoolean(string.trim());
+        }
+        return fallback;
+    }
+
+    private void clearPlayerEffects(UUID playerId) {
+        EnumMap<PotionEffectType, PotionEffect> effects = playerEffects.remove(playerId);
+        if (effects == null || effects.isEmpty()) {
+            return;
+        }
+        Player player = Bukkit.getPlayer(playerId);
+        if (player == null) {
+            return;
+        }
+        effects.keySet().forEach(player::removePotionEffect);
+    }
+
+    private record ArenaRegionState(UUID arenaId,
+                                    String mapId,
+                                    Map<RegionFlag, Object> defaults,
+                                    List<Region> regions) {
+
+        Collection<String> worldAliases() {
+            return List.of(arenaId.toString().toLowerCase(Locale.ROOT), mapId.toLowerCase(Locale.ROOT));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce region data models and a dedicated service to manage region flags across arenas
- parse map.yml region definitions and expose map-level defaults when building map definitions
- enforce region rules for combat, building, movement, and potion effects through new listeners

## Testing
- `mvn -q -DskipTests package` *(fails: dependency repository returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e4093949208324beb1eccfd4633539