### PR TITLE
Add Velocity API dependency metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <paper.version>1.21.1-R0.1-SNAPSHOT</paper.version>
+        <velocity.version>3.3.0-SNAPSHOT</velocity.version>
         <mariadb.version>3.3.3</mariadb.version>
         <hikari.version>5.1.0</hikari.version>
         <caffeine.version>3.1.8</caffeine.version>
@@ -112,7 +113,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.2.0-SNAPSHOT</version>
+            <version>${velocity.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- define a dedicated `velocity.version` property for the Velocity proxy module
- depend on the Velocity API using the new property so proxy sources compile

## Testing
- mvn -q -e -DskipTests compile *(fails: dependency repositories return HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e414ac0ae08324b2bea0cf85ca3897