### PR TITLE
Fix RedisService subscription task initialization

### DIFF
--- a/src/main/java/com/heneria/nexus/redis/RedisService.java
+++ b/src/main/java/com/heneria/nexus/redis/RedisService.java
@@ -469,8 +469,8 @@ public final class RedisService implements LifecycleAware {
             if (current != null && !current.isDone()) {
                 return;
             }
-            CompletableFuture<Void> task = executorManager.runIo(this::runLoop)
-                    .whenComplete((ignored, throwable) -> taskRef.compareAndSet(task, null));
+            CompletableFuture<Void> task = executorManager.runIo(this::runLoop);
+            task.whenComplete((ignored, throwable) -> taskRef.compareAndSet(task, null));
             taskRef.set(task);
         }
 


### PR DESCRIPTION
## Summary
- ensure RedisService subscription tasks are initialized before attaching completion handlers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5745834508324b0933e519936f9fb